### PR TITLE
replace deprecated finite() with isfinite()

### DIFF
--- a/src/openMVG/numeric/numeric.h
+++ b/src/openMVG/numeric/numeric.h
@@ -311,7 +311,7 @@ namespace openMVG {
 #ifdef _WIN32
     return _finite(val);
 #else
-    return finite(val);
+    return isfinite(val);
 #endif
   }
 


### PR DESCRIPTION
finite() is deprecated. Replace with isfinite() as per http://refspecs.linuxfoundation.org/LSB_3.2.0/LSB-Core-generic/LSB-Core-generic/baselib-finite.html
