### PR TITLE
Get filename from lists.txt correctly

### DIFF
--- a/src/software/SfM/main_exportKeypoints.cpp
+++ b/src/software/SfM/main_exportKeypoints.cpp
@@ -67,7 +67,11 @@ int main(int argc, char ** argv)
     std::ifstream in(stlplus::create_filespec(sMatchesDir, "lists", "txt").c_str());
     std::string sValue;
     while(in>>sValue)
+    {
+      int n = sValue.find_first_of(';');
+      sValue = sValue.substr(0,n);
       vec_fileNames.push_back(sValue);
+    }
     in.close();
   }
   if (vec_fileNames.empty()) {

--- a/src/software/SfM/main_exportMatches.cpp
+++ b/src/software/SfM/main_exportMatches.cpp
@@ -70,7 +70,11 @@ int main(int argc, char ** argv)
     std::ifstream in(stlplus::create_filespec(sMatchesDir, "lists", "txt").c_str());
     std::string sValue;
     while(in>>sValue)
+    {
+      int n = sValue.find_first_of(';');
+      sValue = sValue.substr(0,n);
       vec_fileNames.push_back(sValue);
+    }
     in.close();
   }
   if (vec_fileNames.empty()) {

--- a/src/software/SfM/main_exportTracks.cpp
+++ b/src/software/SfM/main_exportTracks.cpp
@@ -72,7 +72,11 @@ int main(int argc, char ** argv)
     std::ifstream in(stlplus::create_filespec(sMatchesDir, "lists", "txt").c_str());
     std::string sValue;
     while(in>>sValue)
+    {
+      int n = sValue.find_first_of(';');
+      sValue = sValue.substr(0,n);
       vec_fileNames.push_back(sValue);
+    }
     in.close();
   }
   if (vec_fileNames.empty()) {


### PR DESCRIPTION
my `lists.txt` has lines that look like this:

```
001.jpg;1080;1920;4.1;0;540;0;4.1;960;0;0;1
002.jpg;1080;1920;4.1;0;540;0;4.1;960;0;0;1
...
```

so need to split on the first semi-colon to get the filename correctly. Note: `find_first_of(';')` returns the length of the string if it doesn't find a semi-colon, so this should work even if there is some other file format I'm not seeing without the extra metadata.
