### PR TITLE
Fix in exportKeypoints, exportMatches and exportTracks to handle lists.txt files with spaces.

### DIFF
--- a/src/software/SfM/main_exportKeypoints.cpp
+++ b/src/software/SfM/main_exportKeypoints.cpp
@@ -66,7 +66,7 @@ int main(int argc, char ** argv)
   {
     std::ifstream in(stlplus::create_filespec(sMatchesDir, "lists", "txt").c_str());
     std::string sValue;
-    while(in>>sValue)
+    while(std::getline(in, sValue))
     {
       int n = sValue.find_first_of(';');
       sValue = sValue.substr(0,n);

--- a/src/software/SfM/main_exportMatches.cpp
+++ b/src/software/SfM/main_exportMatches.cpp
@@ -69,7 +69,7 @@ int main(int argc, char ** argv)
   {
     std::ifstream in(stlplus::create_filespec(sMatchesDir, "lists", "txt").c_str());
     std::string sValue;
-    while(in>>sValue)
+    while(std::getline(in, sValue))
     {
       int n = sValue.find_first_of(';');
       sValue = sValue.substr(0,n);

--- a/src/software/SfM/main_exportTracks.cpp
+++ b/src/software/SfM/main_exportTracks.cpp
@@ -71,7 +71,7 @@ int main(int argc, char ** argv)
   {
     std::ifstream in(stlplus::create_filespec(sMatchesDir, "lists", "txt").c_str());
     std::string sValue;
-    while(in>>sValue)
+    while(std::getline(in, sValue))
     {
       int n = sValue.find_first_of(';');
       sValue = sValue.substr(0,n);


### PR DESCRIPTION
I was trying the cvlab cars dataset [1] when I got a segfault with exportMatches.
After debugging, I found that the camera name contained spaces.

Below is an extract of my lists.txt

```
tripod_seq_02_001.jpg;376;250;301.435;NIKON CORPORATION;NIKON D70
tripod_seq_02_002.jpg;376;250;301.435;NIKON CORPORATION;NIKON D70
tripod_seq_02_003.jpg;376;250;301.435;NIKON CORPORATION;NIKON D70
tripod_seq_02_004.jpg;376;250;301.435;NIKON CORPORATION;NIKON D70
```

Thus doing 

``` c++
while(in>>sValue)
```

resulted in reading 

```
tripod_seq_02_001.jpg;376;250;301.435;NIKON
CORPORATION;NIKON
D70
```

I suggest to use std::getline() to deal with this issue.

[1] http://cvlab.epfl.ch/data/pose
