### PR TITLE
Added check for _bHtmlReport in destructor to avoid seg faults

### DIFF
--- a/src/software/SfM/SfMIncrementalEngine.cpp
+++ b/src/software/SfM/SfMIncrementalEngine.cpp
@@ -63,9 +63,12 @@ IncrementalReconstructionEngine::IncrementalReconstructionEngine(const std::stri
 
 IncrementalReconstructionEngine::~IncrementalReconstructionEngine()
 {
-  ofstream htmlFileStream( string(stlplus::folder_append_separator(_sOutDirectory) +
-    "Reconstruction_Report.html").c_str());
-  htmlFileStream << _htmlDocStream->getDoc();
+  if (_bHtmlReport)
+  {
+    ofstream htmlFileStream( string(stlplus::folder_append_separator(_sOutDirectory) +
+      "Reconstruction_Report.html").c_str());
+    htmlFileStream << _htmlDocStream->getDoc();
+  }
 }
 
 void pauseProcess()


### PR DESCRIPTION
Added check for _bHtmlReport flag in IncrementalSfMEngine destructor to avoid the segmentation fault that occurs in case the flag is set to false.