### PR TITLE
[Branch Develop]: 1)Enable to undistort arbitrary image formats, 2) Enable to load Strecha or openMVG camera files for trajectory evaluation

### DIFF
--- a/src/openMVG_Samples/undisto_Brown/undistoBrown.cpp
+++ b/src/openMVG_Samples/undisto_Brown/undistoBrown.cpp
@@ -146,9 +146,9 @@ int main(int argc, char **argv)
     << distoModel.m_radial_distortion.transpose() << "\n"
     << "  Distortion focal: " << distoModel.m_f << std::endl;
 
-  std::vector<std::string> vec_fileNames = stlplus::folder_wildcard(sPath, "*.JPG", false, true);
+  std::vector<std::string> vec_fileNames = stlplus::folder_wildcard(sPath, "*.tiff", false, true);
 
-  Image<RGBColor > image, imageU;
+  Image<unsigned char > image, imageU;
   C_Progress_display my_progress_bar( vec_fileNames.size() );
   for (size_t j = 0; j < vec_fileNames.size(); ++j, ++my_progress_bar)
   {

--- a/src/software/SfM/main_evalQuality.cpp
+++ b/src/software/SfM/main_evalQuality.cpp
@@ -29,10 +29,13 @@ int main(int argc, char **argv)
     sGTDirectory,
     sComputedDirectory,
     sOutDir = "";
+    int camType; //1: openMVG cam, 2: Strechas cam
+
 
   cmd.add( make_option('i', sGTDirectory, "gt") );
   cmd.add( make_option('c', sComputedDirectory, "computed") );
   cmd.add( make_option('o', sOutDir, "outdir") );
+  cmd.add( make_option('t', camType, "camtype") );
 
   try {
     if (argc == 1) throw std::string("Invalid command line parameter.");
@@ -42,6 +45,7 @@ int main(int argc, char **argv)
       << "[-i|--gt path (where ground truth camera trajectory are saved)] \n"
       << "[-c|--computed path (openMVG SfM_Output directory)] \n"
       << "[-o|--output path (where statistics will be saved)] \n"
+      << "[-t|--camtype Type of the camera. 1: openMVG (bin), 2: Strechas 'png.camera'] \n"
       << std::endl;
 
     std::cerr << s << std::endl;
@@ -56,6 +60,24 @@ int main(int argc, char **argv)
   if (!stlplus::folder_exists(sOutDir))
     stlplus::folder_create(sOutDir);
 
+  //Setup the camera type
+  bool (*fcnReadCamPtr)(const std::string &, PinholeCamera &);
+  std::string suffix;
+  switch (camType)
+  {
+    case 1:
+      std::cout << "\nusing openMVG Camera";
+      fcnReadCamPtr=&read_openMVG_Camera;
+      suffix="bin";
+      break;
+    case 2:
+      std::cout << "\nusing Strechas Camera";
+      fcnReadCamPtr=&read_Strecha_Camera;
+      suffix="png.camera";
+      break;
+
+  }
+
   //---------------------------------------
   // Quality evaluation
   //---------------------------------------
@@ -69,7 +91,7 @@ int main(int argc, char **argv)
     std::cout << "\nTry to read data from GT";
     std::vector<std::string> vec_fileNames;
     std::string sGTPath = sGTDirectory;
-    readGt( sGTPath, vec_fileNames, map_Rt_gt, map_Cam_gt);
+    readGt(fcnReadCamPtr, sGTPath, suffix, vec_fileNames, map_Rt_gt, map_Cam_gt);
     std::cout << map_Cam_gt.size() << " gt cameras have been found" << std::endl;
   }
 


### PR DESCRIPTION
Hi Pierre,

I hope you find this pull request usefil. I implemented two very minor changes:
1)Enable to undistort arbitrary image formats with user specified file extension (jpg, tiff, etc.)
This is little bit hacky, since image use template parameters directly and I didnt find another way to distinguish them as per "if then". 

2) Enable to load Strecha or openMVG camera files for trajectory evaluation.
Used this to evaluate the BA results on Strechas dataset.

