### PR TITLE
Fixes for MinGW compilation, detecting some corner cases

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,9 @@ ENDIF(NOT CMAKE_BUILD_TYPE AND NOT MSVC)
 
 IF (WIN32)
   ADD_DEFINITIONS(-DNOMINMAX)
-  ADD_DEFINITIONS(/bigobj)
+  IF (MSVC)
+    ADD_DEFINITIONS(/bigobj)
+  ENDIF (MSVC)
 ENDIF (WIN32)
 
 # ==============================================================================

--- a/src/openMVG/matching_image_collection/GeometricFilter.hpp
+++ b/src/openMVG/matching_image_collection/GeometricFilter.hpp
@@ -89,7 +89,7 @@ class ImageCollectionGeometricFilter
   #pragma omp critical
 #endif
           {
-            map_GeometricMatches[std::make_pair(iIndex,jIndex)] = vec_filteredMatches;
+            map_GeometricMatches.insert(std::make_pair(std::make_pair(iIndex, jIndex), std::move(vec_filteredMatches)));
           }
         }
       }

--- a/src/openMVG/matching_image_collection/Matcher_Regions_AllInMemory.cpp
+++ b/src/openMVG/matching_image_collection/Matcher_Regions_AllInMemory.cpp
@@ -98,8 +98,9 @@ void Template_Matcher(
     const features::Regions *regionsI = regions_perImage.at(I).get();
     const size_t regions_countI = regionsI->RegionCount();
     const std::vector<PointFeature> pointFeaturesI = regionsI->GetRegionsPositions();
-    const typename MatcherT::ScalarT * tabI =
-      reinterpret_cast<const typename MatcherT::ScalarT *>(regionsI->DescriptorRawData());
+    const typename MatcherT::ScalarT * tabI = NULL;
+    if(regions_countI > 0)
+      tabI = reinterpret_cast<const typename MatcherT::ScalarT *>(regionsI->DescriptorRawData());
 
     MatcherT matcher10;
     ( matcher10.Build(tabI, regions_countI, regionsI->DescriptorLength()) );
@@ -112,8 +113,9 @@ void Template_Matcher(
 
       const features::Regions *regionsJ = regions_perImage.at(J).get();
       const size_t regions_countJ = regionsJ->RegionCount();
-      const typename MatcherT::ScalarT * tabJ =
-        reinterpret_cast<const typename MatcherT::ScalarT *>(regionsJ->DescriptorRawData());
+      const typename MatcherT::ScalarT * tabJ = NULL;
+      if(regions_countJ > 0)
+        tabJ = reinterpret_cast<const typename MatcherT::ScalarT *>(regionsJ->DescriptorRawData());
 
       const size_t NNN__ = 2;
       std::vector<int> vec_nIndice10;
@@ -149,7 +151,7 @@ void Template_Matcher(
         ++my_progress_bar;
         if (!vec_FilteredMatches.empty())
         {
-          map_PutativesMatches.insert( make_pair( make_pair(I,J), vec_FilteredMatches ));
+          map_PutativesMatches.insert( make_pair( make_pair(I,J), std::move(vec_FilteredMatches) ));
         }
       }
     }

--- a/src/openMVG/numeric/numeric.h
+++ b/src/openMVG/numeric/numeric.h
@@ -39,7 +39,7 @@
 #include <Eigen/QR>
 #include <Eigen/SparseCore>
 #include <Eigen/SVD>
-#include<Eigen/StdVector>
+#include <Eigen/StdVector>
 
 #include <cmath>
 #include <numeric>
@@ -335,7 +335,7 @@ namespace openMVG {
 
   inline int is_finite(const double val)
   {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return _finite(val);
 #else
     return std::isfinite(val);

--- a/src/openMVG/sfm/pipelines/global/sfm_global_engine_relative_motions.cpp
+++ b/src/openMVG/sfm/pipelines/global/sfm_global_engine_relative_motions.cpp
@@ -169,6 +169,9 @@ bool GlobalSfMReconstructionEngine_RelativeMotions::Process() {
 /// Compute from relative rotations the global rotations of the camera poses
 bool GlobalSfMReconstructionEngine_RelativeMotions::Compute_Global_Rotations()
 {
+  if(_relatives_Rt.empty())
+    return false;
+
   // Convert RelativeInfo_Map to appropriate input for solving the global rotations
   // - store the relative rotations and set a weight
   using namespace openMVG::rotation_averaging;

--- a/src/third_party/stlplus3/filesystemSimplified/portability_fixes.cpp
+++ b/src/third_party/stlplus3/filesystemSimplified/portability_fixes.cpp
@@ -16,7 +16,7 @@
 // problems with missing functions
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef MSWINDOWS
+#if defined(_MSC_VER)
 unsigned sleep(unsigned seconds)
 {
   Sleep(1000*seconds);

--- a/src/third_party/stlplus3/filesystemSimplified/portability_fixes.hpp
+++ b/src/third_party/stlplus3/filesystemSimplified/portability_fixes.hpp
@@ -93,7 +93,7 @@ namespace std
 // problems with missing functions
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef MSWINDOWS
+#if defined(_MSC_VER)
 unsigned sleep(unsigned seconds);
 #else
 #include <unistd.h>


### PR DESCRIPTION
Fixes for MinGW compilation
Detecting corner cases: Checking for empty matches
Using std::move where applicable