### PR TITLE
Fix linkage in SHARED mode for one test-unit.

### DIFF
--- a/src/openMVG/sfm/CMakeLists.txt
+++ b/src/openMVG/sfm/CMakeLists.txt
@@ -27,7 +27,7 @@ UNIT_TEST(openMVG sfm_data_io
 UNIT_TEST(openMVG sfm_data_BA
   "openMVG_multiview_test_data;openMVG_features;openMVG_multiview;openMVG_sfm;openMVG_system;stlplus;${openMVG_lInftyComputerVision}")
 UNIT_TEST(openMVG sfm_data_utils
-  "openMVG_features;openMVG_multiview;openMVG_sfm;stlplus;${openMVG_lInftyComputerVision}")
+  "openMVG_features;openMVG_multiview;;openMVG_system;openMVG_sfm;stlplus;${openMVG_lInftyComputerVision}")
 
 ADD_SUBDIRECTORY(pipelines)
 

--- a/src/openMVG/sfm/CMakeLists.txt
+++ b/src/openMVG/sfm/CMakeLists.txt
@@ -27,7 +27,7 @@ UNIT_TEST(openMVG sfm_data_io
 UNIT_TEST(openMVG sfm_data_BA
   "openMVG_multiview_test_data;openMVG_features;openMVG_multiview;openMVG_sfm;openMVG_system;stlplus;${openMVG_lInftyComputerVision}")
 UNIT_TEST(openMVG sfm_data_utils
-  "openMVG_features;openMVG_multiview;;openMVG_system;openMVG_sfm;stlplus;${openMVG_lInftyComputerVision}")
+  "openMVG_features;openMVG_multiview;openMVG_system;openMVG_sfm;stlplus;${openMVG_lInftyComputerVision}")
 
 ADD_SUBDIRECTORY(pipelines)
 


### PR DESCRIPTION

 One last SHARED mode related issue. I hope last one. Patch is very simple, it should not hurt any things.

* It fixes this error (only one):

[ 62%] Linking CXX executable ../../Linux-x86_64-RelWithDebInfo/openMVG_test_sfm_data_utils
cd /home/cbalint/rpmbuild/BUILD/openMVG/build/openMVG/sfm && /usr/bin/cmake -E cmake_link_script CMakeFiles/openMVG_test_sfm_data_utils.dir/link.txt --verbose=1
/usr/bin/c++   -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches  -m64 -mtune=generic  -march=native --std=c++11 -fopenmp -O2 -g -DNDEBUG   -Wl,-z,relro  CMakeFiles/openMVG_test_sfm_data_utils.dir/sfm_data_utils_test.cpp.o  -o ../../Linux-x86_64-RelWithDebInfo/openMVG_test_sfm_data_utils -rdynamic ../../Linux-x86_64-RelWithDebInfo/libopenMVG_features.so.0.8 ../../Linux-x86_64-RelWithDebInfo/libopenMVG_sfm.so.0.8 ../../Linux-x86_64-RelWithDebInfo/libstlplus.a ../../Linux-x86_64-RelWithDebInfo/libCppUnitLite.a -lgomp ../../Linux-x86_64-RelWithDebInfo/libopenMVG_multiview.so.0.8 -lemon ../../Linux-x86_64-RelWithDebInfo/libopenMVG_numeric.so.0.8 /usr/lib64/libceres.so.1.10.0 -lglog 
../../Linux-x86_64-RelWithDebInfo/libopenMVG_sfm.so.0.8: undefined reference to `openMVG::system::Timer::elapsed() const'
../../Linux-x86_64-RelWithDebInfo/libopenMVG_sfm.so.0.8: undefined reference to `openMVG::system::Timer::Timer()'



