### PR TITLE
Fix SHARED mode, link properly flann.

### DIFF
--- a/src/openMVG/matching/CMakeLists.txt
+++ b/src/openMVG/matching/CMakeLists.txt
@@ -19,7 +19,7 @@ list(REMOVE_ITEM matching_files_cpp ${REMOVEFILESUNITTEST})
 set_source_files_properties(${matching_files_header} PROPERTIES LANGUAGE CXX)
 set_source_files_properties(${matching_files_cpp} PROPERTIES LANGUAGE CXX)
 
-UNIT_TEST(openMVG matching "")
+UNIT_TEST(openMVG matching "${FLANN_LIBRARY}")
 UNIT_TEST(openMVG matching_filters "")
 UNIT_TEST(openMVG indMatch "")
 UNIT_TEST(openMVG metric "")

--- a/src/openMVG_Samples/robust_essential_spherical/CMakeLists.txt
+++ b/src/openMVG_Samples/robust_essential_spherical/CMakeLists.txt
@@ -12,7 +12,8 @@ TARGET_LINK_LIBRARIES(openMVG_sample_robustEssential_spherical
   vlsift
   ${CERES_LIBRARIES}
   ${CLP_LIBRARIES} ${COINUTILS_LIBRARY}
-  ${OSI_LIBRARY})
+  ${OSI_LIBRARY}
+  ${FLANN_LIBRARY})
 
 SET_PROPERTY(TARGET openMVG_sample_robustEssential_spherical PROPERTY FOLDER OpenMVG/Samples)
 

--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -50,6 +50,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_ComputeMatches
   openMVG_sfm
   openMVG_matching_image_collection
   stlplus
+  ${FLANN_LIBRARY}
   )
 
 # Installation rules
@@ -223,7 +224,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_openMVG2CMPMVS
 # - Export a SfM openMVG scene to MVE(v2) format
 #
 ADD_EXECUTABLE(openMVG_main_openMVG2MVE2 main_openMVG2MVE2.cpp)
-TARGET_LINK_LIBRARIES(openMVG_main_openMVG2MVE2 ${OpenMVG_LIBRARIES})
+TARGET_LINK_LIBRARIES(openMVG_main_openMVG2MVE2 ${OpenMVG_LIBRARIES} ${FLANN_LIBRARY})
 
 # - Export a SfM openMVG scene to meshlab scene with rasters
 # -


### PR DESCRIPTION


* In fact it fixes inclusion to 'LZ4*' compression supported inside external flann (latest version, github).

../../Linux-x86_64-RelWithDebInfo/libopenMVG_matching_image_collection.so.0.8: undefined reference to LZ4_resetStreamHC' ../../Linux-x86_64-RelWithDebInfo/libopenMVG_matching_image_collection.so.0.8: undefined reference toLZ4_setStreamDecode'
../../Linux-x86_64-RelWithDebInfo/libopenMVG_matching_image_collection.so.0.8: undefined reference to LZ4_decompress_safe' ../../Linux-x86_64-RelWithDebInfo/libopenMVG_matching_image_collection.so.0.8: undefined reference toLZ4_decompress_safe_continue'
../../Linux-x86_64-RelWithDebInfo/libopenMVG_matching_image_collection.so.0.8: undefined reference to `LZ4_compress_HC_continue'
