### PR TITLE
Reduce point feature memory footprint

### DIFF
--- a/src/openMVG/features/feature.hpp
+++ b/src/openMVG/features/feature.hpp
@@ -55,7 +55,7 @@ typedef std::vector<PointFeature> PointFeatures;
 //with overloaded operators:
 inline std::ostream& operator<<(std::ostream& out, const PointFeature& obj)
 {
-  return out << obj._coords(0) << obj._coords(1);
+  return out << obj._coords(0) << " " << obj._coords(1);
 }
 
 inline std::istream& operator>>(std::istream& in, PointFeature& obj)
@@ -112,12 +112,14 @@ protected:
 //
 inline std::ostream& operator<<(std::ostream& out, const SIOPointFeature& obj)
 {
-  return out << obj._coords(0) << obj._coords(1) << obj._scale << obj._orientation;
+  const PointFeature *pf = static_cast<const PointFeature*>(&obj);
+  return out << *pf << " " << obj._scale << " " << obj._orientation;
 }
 
 inline std::istream& operator>>(std::istream& in, SIOPointFeature& obj)
 {
-  return in >> obj._coords(0) >> obj._coords(1) >> obj._scale >> obj._orientation;
+  PointFeature *pf = static_cast<PointFeature*>(&obj);
+  return in >> *pf >> obj._scale >> obj._orientation;
 }
 
 /// Read feats from file

--- a/src/openMVG/features/feature.hpp
+++ b/src/openMVG/features/feature.hpp
@@ -23,25 +23,22 @@ namespace features {
  * Store position of the feature point.
  */
 class PointFeature {
-public:
-  virtual inline ~PointFeature() {};
 
-  inline PointFeature(float x=0.0f, float y=0.0f)
+  friend std::ostream& operator<<(std::ostream& out, const PointFeature& obj);
+  friend std::istream& operator>>(std::istream& in, PointFeature& obj);
+
+public:
+  PointFeature(float x=0.0f, float y=0.0f)
    : _coords(x, y) {}
 
-  inline float x() const { return _coords(0); }
-  inline float y() const { return _coords(1); }
-  inline const Vec2f & coords() const { return _coords;}
+  float x() const { return _coords(0); }
+  float y() const { return _coords(1); }
+  const Vec2f & coords() const { return _coords;}
 
-  inline float& x() { return _coords(0); }
-  inline float& y() { return _coords(1); }
-  inline Vec2f& coords() { return _coords;}
+  float& x() { return _coords(0); }
+  float& y() { return _coords(1); }
+  Vec2f& coords() { return _coords;}
 
-  virtual inline std::ostream& print(std::ostream& os) const
-  { return os << _coords(0) << " " << _coords(1); }
-
-  virtual inline std::istream& read(std::istream& in)
-  { return in >> _coords(0) >> _coords(1); }
 
   template<class Archive>
   void serialize(Archive & ar)
@@ -58,12 +55,12 @@ typedef std::vector<PointFeature> PointFeatures;
 //with overloaded operators:
 inline std::ostream& operator<<(std::ostream& out, const PointFeature& obj)
 {
-  return obj.print(out); //simply call the print method.
+  return out << obj._coords(0) << obj._coords(1);
 }
 
 inline std::istream& operator>>(std::istream& in, PointFeature& obj)
 {
-  return obj.read(in); //simply call the read method.
+  return in >> obj._coords(0) >> obj._coords(1);
 }
 
 /**
@@ -71,19 +68,21 @@ inline std::istream& operator>>(std::istream& in, PointFeature& obj)
  * Add scale and orientation description to basis PointFeature.
  */
 class SIOPointFeature : public PointFeature {
-public:
-  virtual ~SIOPointFeature() {};
 
+    friend std::ostream& operator<<(std::ostream& out, const SIOPointFeature& obj);
+    friend std::istream& operator>>(std::istream& in, SIOPointFeature& obj);
+
+public:
   SIOPointFeature(float x=0.0f, float y=0.0f,
                   float scale=0.0f, float orient=0.0f)
     : PointFeature(x,y)
     , _scale(scale)
     , _orientation(orient) {}
 
-  inline float scale() const { return _scale; }
-  inline float& scale() { return _scale; }
-  inline float orientation() const { return _orientation; }
-  inline float& orientation() { return _orientation; }
+  float scale() const { return _scale; }
+  float& scale() { return _scale; }
+  float orientation() const { return _orientation; }
+  float& orientation() { return _orientation; }
 
   bool operator ==(const SIOPointFeature& b) const {
     return (_scale == b.scale()) &&
@@ -95,15 +94,6 @@ public:
     return !((*this)==b);
   };
 
-  virtual std::ostream& print(std::ostream& os) const
-  {
-    return PointFeature::print(os) << " " << _scale << " " << _orientation;
-  }
-
-  virtual std::istream& read(std::istream& in)
-  {
-    return PointFeature::read(in) >> _scale >> _orientation;
-  }
 
   template<class Archive>
   void serialize(Archive & ar)
@@ -118,6 +108,17 @@ protected:
   float _scale;        // In pixels.
   float _orientation;  // In radians.
 };
+
+//
+inline std::ostream& operator<<(std::ostream& out, const SIOPointFeature& obj)
+{
+  return out << obj._coords(0) << obj._coords(1) << obj._scale << obj._orientation;
+}
+
+inline std::istream& operator>>(std::istream& in, SIOPointFeature& obj)
+{
+  return in >> obj._coords(0) >> obj._coords(1) >> obj._scale >> obj._orientation;
+}
 
 /// Read feats from file
 template<typename FeaturesT >

--- a/src/openMVG/features/features_test.cpp
+++ b/src/openMVG/features/features_test.cpp
@@ -30,7 +30,7 @@ TEST(featureIO, ASCII) {
   }
 
   //Save them to a file
-  saveDescsToFile("tempFeats.feat", vec_feats);
+  saveFeatsToFile("tempFeats.feat", vec_feats);
 
   //Read the saved data and compare to input (to check write/read IO)
   Feats_T vec_feats_read;


### PR DESCRIPTION
Hi Pierre,

here is a simple change to reduce the size of a point feature in memory. It basically removes the memory associated with the virtual table of the PointFeature and SIOPointFeature classes. Even if it's not a lot (8 bytes per feature) I noticed a small time performance gain of approximately 1% on feature extraction and matching. I am going to test further the repercussions of this change. Let me know if this looks good for you !

Cheers,

Cyril