### PR TITLE
Fix for occasionally incorrect intial pair selection

### DIFF
--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
@@ -93,24 +93,21 @@ bool SequentialSfMReconstructionEngine::Process() {
     return false;
 
   // Initial pair choice
-  Pair initialPairIndex = _initialpair;
   if (_initialpair == Pair(0,0))
   {
-    Pair putative_initial_pair;
-    if (AutomaticInitialPairChoice(putative_initial_pair))
+    if (!AutomaticInitialPairChoice(_initialpair))
     {
-      initialPairIndex = _initialpair = putative_initial_pair;
-    }
-    else // Cannot find a valid initial pair, try to set it by hand?
-    {
+      // Cannot find a valid initial pair, try to set it by hand?
       if (!ChooseInitialPair(_initialpair))
+      {
         return false;
+      }
     }
   }
   // Else a starting pair was already initialized before
 
   // Initial pair Essential Matrix and [R|t] estimation.
-  if (!MakeInitialPair3D(initialPairIndex))
+  if (!MakeInitialPair3D(_initialpair))
     return false;
 
   // Compute robust Resection of remaining images


### PR DESCRIPTION
Hi pierre,
Here's the pull request for #452. I took the liberty of using only one type of initial pair variable to make it less confusing.