### PR TITLE
fix clang apple

### DIFF
--- a/src/software/SfM/InterfaceMVS.h
+++ b/src/software/SfM/InterfaceMVS.h
@@ -147,7 +147,7 @@ bool Load<TYPE>(ArchiveLoad& a, TYPE& v) { \
 
 // Serialization support for basic types
 ARCHIVE_DEFINE_TYPE(uint32_t)
-ARCHIVE_DEFINE_TYPE(uint64_t)
+ARCHIVE_DEFINE_TYPE(size_t)
 ARCHIVE_DEFINE_TYPE(float)
 ARCHIVE_DEFINE_TYPE(double)
 


### PR DESCRIPTION
Fixes compilation on MacOS. All the other OSs are not affected (project binaries remain compatible). Thx!