### PR TITLE
Code cleanup and C++11

### DIFF
--- a/src/openMVG/cameras/Camera_IO.hpp
+++ b/src/openMVG/cameras/Camera_IO.hpp
@@ -24,15 +24,22 @@ static bool save(
   const PinholeCamera & cam)
 {
   if (stlplus::extension_part(scameraFile) != "bin")
-    return false;
+  {
+    return false;    
+  }
+  else 
+  {
+    const Mat34 & PMat = cam._P;
+    std::ofstream file( scameraFile.c_str(), std::ios::out|std::ios::binary);
+    if( ! file )
+      return false ; 
+    
+    file.write(reinterpret_cast<const char*>(PMat.data()),(std::streamsize)(3*4)*sizeof(double));
 
-  const Mat34 & PMat = cam._P;
-  std::ofstream file( scameraFile.c_str(), std::ios::out|std::ios::binary);
-  file.write((const char*)PMat.data(),(std::streamsize)(3*4)*sizeof(double));
-
-  bool bOk = (!file.fail());
-  file.close();
-  return bOk;
+    const bool bOk = (!file.fail());
+    file.close();
+    return bOk;    
+  }
 }
 
 /// Load a Pinhole camera from a file (read 12 doubles saved in binary values)
@@ -51,7 +58,7 @@ static bool load(
       return false;
     }
     val.resize(12);
-    in.read((char*)&val[0],(std::streamsize)12*sizeof(double));
+    in.read(reinterpret_cast<char*>(&val[0]),(std::streamsize)12*sizeof(double));
     if (in.fail())  {
       val.clear();
     }

--- a/src/openMVG/cameras/Camera_Intrinsics.hpp
+++ b/src/openMVG/cameras/Camera_Intrinsics.hpp
@@ -25,7 +25,7 @@ struct IntrinsicBase
   unsigned int _w, _h;
 
   IntrinsicBase(unsigned int w = 0, unsigned int h = 0):_w(w), _h(h) {}
-  virtual ~IntrinsicBase() {}
+  virtual ~IntrinsicBase() = default ;
 
   unsigned int w() const {return _w;}
   unsigned int h() const {return _h;}
@@ -119,8 +119,8 @@ struct IntrinsicBase
     stl::hash_combine(seed, _w);
     stl::hash_combine(seed, _h);
     const std::vector<double> params = this->getParams();
-    for (size_t i=0; i < params.size(); ++i)
-      stl::hash_combine(seed, params[i]);
+    for ( auto & param : params ) 
+      stl::hash_combine( seed , param );
     return seed;
   }
 };

--- a/src/openMVG/cameras/Camera_Pinhole.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole.hpp
@@ -10,6 +10,7 @@
 
 #include "openMVG/numeric/numeric.h"
 #include "openMVG/cameras/Camera_Common.hpp"
+#include "openMVG/cameras/Camera_Intrinsics.hpp"
 #include "openMVG/geometry/pose3.hpp"
 
 #include <vector>
@@ -36,47 +37,47 @@ class Pinhole_Intrinsic : public IntrinsicBase
     _Kinv = _K.inverse();
   }
 
-  virtual ~Pinhole_Intrinsic() {}
+  ~Pinhole_Intrinsic() override = default ; 
 
-  virtual EINTRINSIC getType() const { return PINHOLE_CAMERA; }
+  EINTRINSIC getType() const override { return PINHOLE_CAMERA; }
 
-  const Mat3& K() const { return _K; }
-  const Mat3& Kinv() const { return _Kinv; }
+  const Mat3& K() const  { return _K; }
+  const Mat3& Kinv() const  { return _Kinv; }
   /// Return the value of the focal in pixels
-  inline double focal() const {return _K(0,0);}
-  inline Vec2 principal_point() const {return Vec2(_K(0,2), _K(1,2));}
+  inline double focal() const  {return _K(0,0);}
+  inline Vec2 principal_point() const  {return Vec2(_K(0,2), _K(1,2));}
 
   // Get bearing vector of p point (image coord)
-  Vec3 operator () (const Vec2& p) const
+  Vec3 operator () (const Vec2& p) const override
   {
     Vec3 p3(p(0),p(1),1.0);
     return (_Kinv * p3).normalized();
   }
 
   // Transform a point from the camera plane to the image plane
-  Vec2 cam2ima(const Vec2& p) const
+  Vec2 cam2ima(const Vec2& p) const override
   {
     return focal() * p + principal_point();
   }
 
   // Transform a point from the image plane to the camera plane
-  Vec2 ima2cam(const Vec2& p) const
+  Vec2 ima2cam(const Vec2& p) const override
   {
     return ( p -  principal_point() ) / focal();
   }
 
-  virtual bool have_disto() const {  return false; }
+  bool have_disto() const override {  return false; }
 
-  virtual Vec2 add_disto(const Vec2& p) const  { return p; }
+  Vec2 add_disto(const Vec2& p) const override  { return p; }
 
-  virtual Vec2 remove_disto(const Vec2& p) const  { return p; }
+  Vec2 remove_disto(const Vec2& p) const override { return p; }
 
-  virtual double imagePlane_toCameraPlaneError(double value) const
+  double imagePlane_toCameraPlaneError(double value) const override 
   {
     return value / focal();
   }
 
-  virtual Mat34 get_projective_equivalent(const geometry::Pose3 & pose) const
+  Mat34 get_projective_equivalent(const geometry::Pose3 & pose) const override 
   {
     Mat34 P;
     P_From_KRt(K(), pose.rotation(), pose.translation(), &P);
@@ -84,14 +85,14 @@ class Pinhole_Intrinsic : public IntrinsicBase
   }
 
   // Data wrapper for non linear optimization (get data)
-  virtual std::vector<double> getParams() const
+  std::vector<double> getParams() const override
   {
     const std::vector<double> params = {_K(0,0), _K(0,2), _K(1,2)};
     return params;
   }
 
   // Data wrapper for non linear optimization (update from data)
-  virtual bool updateFromParams(const std::vector<double> & params)
+  bool updateFromParams(const std::vector<double> & params) override
   {
     if (params.size() == 3) {
       *this = Pinhole_Intrinsic(_w, _h, params[0], params[1], params[2]);
@@ -103,10 +104,10 @@ class Pinhole_Intrinsic : public IntrinsicBase
   }
 
   /// Return the un-distorted pixel (with removed distortion)
-  virtual Vec2 get_ud_pixel(const Vec2& p) const {return p;}
+  Vec2 get_ud_pixel(const Vec2& p) const override {return p;}
 
   /// Return the distorted pixel (with added distortion)
-  virtual Vec2 get_d_pixel(const Vec2& p) const {return p;}
+  Vec2 get_d_pixel(const Vec2& p) const override {return p;}
 
   // Serialization
   template <class Archive>

--- a/src/openMVG/cameras/Camera_Pinhole_Brown.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Brown.hpp
@@ -10,6 +10,8 @@
 
 #include "openMVG/numeric/numeric.h"
 #include "openMVG/cameras/Camera_Common.hpp"
+#include "openMVG/cameras/Camera_Pinhole.hpp"
+
 
 #include <vector>
 
@@ -37,11 +39,11 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
         _params = {k1, k2, k3, t1, t2};
     }
 
-    EINTRINSIC getType() const { return PINHOLE_CAMERA_BROWN; }
+    EINTRINSIC getType() const override { return PINHOLE_CAMERA_BROWN; }
 
-    virtual bool have_disto() const { return true;}
+    bool have_disto() const override { return true;}
 
-    virtual Vec2 add_disto(const Vec2 & p) const{
+    Vec2 add_disto(const Vec2 & p) const override {
         return (p + distoFunction(_params, p));
     }
 
@@ -49,7 +51,7 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
     // Heikkila J (2000) Geometric Camera Calibration Using Circular Control Points.
     // IEEE Trans. Pattern Anal. Mach. Intell., 22:1066-1077
 
-    virtual Vec2 remove_disto(const Vec2 & p) const{
+    Vec2 remove_disto(const Vec2 & p) const override {
         const double epsilon = 1e-8; //criteria to stop the iteration
         Vec2 p_u = p;
 
@@ -62,7 +64,7 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
     }
 
     // Data wrapper for non linear optimization (get data)
-    virtual std::vector<double> getParams() const
+    std::vector<double> getParams() const override
     {
         std::vector<double> params = Pinhole_Intrinsic::getParams();
         params.push_back(_params[0]);
@@ -74,7 +76,7 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
     }
 
     // Data wrapper for non linear optimization (update from data)
-    virtual bool updateFromParams(const std::vector<double> & params)
+    bool updateFromParams(const std::vector<double> & params) override
     {
         if (params.size() == 8) {
           *this = Pinhole_Intrinsic_Brown_T2(
@@ -90,13 +92,13 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
     }
 
     /// Return the un-distorted pixel (with removed distortion)
-    virtual Vec2 get_ud_pixel(const Vec2& p) const
+    Vec2 get_ud_pixel(const Vec2& p) const override
     {
       return cam2ima( remove_disto(ima2cam(p)) );
     }
 
     /// Return the distorted pixel (with added distortion)
-    virtual Vec2 get_d_pixel(const Vec2& p) const
+    Vec2 get_d_pixel(const Vec2& p) const override
     {
       return cam2ima( add_disto(ima2cam(p)) );
     }

--- a/src/openMVG/cameras/Camera_Pinhole_Fisheye.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Fisheye.hpp
@@ -12,6 +12,7 @@
 
 #include "openMVG/numeric/numeric.h"
 #include "openMVG/cameras/Camera_Common.hpp"
+#include "openMVG/cameras/Camera_Pinhole.hpp"
 
 #include <vector>
 
@@ -37,11 +38,11 @@ class Pinhole_Intrinsic_Fisheye : public Pinhole_Intrinsic
     _params = {k1, k2, k3, k4};
   }
 
-  EINTRINSIC getType() const { return PINHOLE_CAMERA_FISHEYE; }
+  EINTRINSIC getType() const override { return PINHOLE_CAMERA_FISHEYE; }
 
-  virtual bool have_disto() const { return true;}
+  bool have_disto() const override { return true;}
 
-  virtual Vec2 add_disto(const Vec2 & p) const{
+  Vec2 add_disto(const Vec2 & p) const override{
     const double eps = 1e-8;
     const double k1 = _params[0], k2 = _params[1], k3 = _params[2], k4 = _params[3];
     const double r = std::sqrt(p(0)*p(0) + p(1)*p(1));
@@ -61,7 +62,7 @@ class Pinhole_Intrinsic_Fisheye : public Pinhole_Intrinsic
     return  p*cdist;
   }
 
-  virtual Vec2 remove_disto(const Vec2 & p) const{
+  Vec2 remove_disto(const Vec2 & p) const override{
     const double eps = 1e-8;
     double scale = 1.0;
     const double theta_dist = std::sqrt(p[0]*p[0] + p[1]*p[1]);
@@ -87,7 +88,7 @@ class Pinhole_Intrinsic_Fisheye : public Pinhole_Intrinsic
   }
 
   // Data wrapper for non linear optimization (get data)
-  virtual std::vector<double> getParams() const
+  std::vector<double> getParams() const override
   {
     std::vector<double> params = Pinhole_Intrinsic::getParams();
     params.push_back(_params[0]);
@@ -98,7 +99,7 @@ class Pinhole_Intrinsic_Fisheye : public Pinhole_Intrinsic
   }
 
   // Data wrapper for non linear optimization (update from data)
-  virtual bool updateFromParams(const std::vector<double> & params)
+  bool updateFromParams(const std::vector<double> & params) override
   {
     if (params.size() == 7) {
       *this = Pinhole_Intrinsic_Fisheye(
@@ -113,13 +114,13 @@ class Pinhole_Intrinsic_Fisheye : public Pinhole_Intrinsic
   }
 
   /// Return the un-distorted pixel (with removed distortion)
-  virtual Vec2 get_ud_pixel(const Vec2& p) const
+  Vec2 get_ud_pixel(const Vec2& p) const override
   {
     return cam2ima( remove_disto(ima2cam(p)) );
   }
 
   /// Return the distorted pixel (with added distortion)
-  virtual Vec2 get_d_pixel(const Vec2& p) const
+  Vec2 get_d_pixel(const Vec2& p) const override
   {
     return cam2ima( add_disto(ima2cam(p)) );
   }

--- a/src/openMVG/cameras/Camera_Pinhole_Radial.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Radial.hpp
@@ -10,6 +10,7 @@
 
 #include "openMVG/numeric/numeric.h"
 #include "openMVG/cameras/Camera_Common.hpp"
+#include "openMVG/cameras/Camera_Pinhole.hpp"
 
 #include <vector>
 
@@ -66,12 +67,12 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
     _params[0] = k1;
   }
 
-  EINTRINSIC getType() const { return PINHOLE_CAMERA_RADIAL1; }
+  EINTRINSIC getType() const override { return PINHOLE_CAMERA_RADIAL1; }
 
-  virtual bool have_disto() const {  return true; }
+  bool have_disto() const override {  return true; }
 
   /// Add distortion to the point p (assume p is in the camera frame [normalized coordinates])
-  virtual Vec2 add_disto(const Vec2 & p) const {
+  Vec2 add_disto(const Vec2 & p) const override {
 
     const double k1 = _params[0];
 
@@ -82,7 +83,7 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
   }
 
   /// Remove distortion (return p' such that disto(p') = p)
-  virtual Vec2 remove_disto(const Vec2& p) const {
+  Vec2 remove_disto(const Vec2& p) const override {
     // Compute the radius from which the point p comes from thanks to a bisection
     // Minimize disto(radius(p')^2) == actual Squared(radius(p))
 
@@ -94,7 +95,7 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
   }
 
   // Data wrapper for non linear optimization (get data)
-  virtual std::vector<double> getParams() const
+  std::vector<double> getParams() const override
   {
     std::vector<double> params = Pinhole_Intrinsic::getParams();
     params.push_back(_params[0]);
@@ -102,7 +103,7 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
   }
 
   // Data wrapper for non linear optimization (update from data)
-  virtual bool updateFromParams(const std::vector<double> & params)
+  bool updateFromParams(const std::vector<double> & params) override
   {
     if (params.size() == 4) {
       *this = Pinhole_Intrinsic_Radial_K1(
@@ -117,13 +118,13 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
   }
 
   /// Return the un-distorted pixel (with removed distortion)
-  virtual Vec2 get_ud_pixel(const Vec2& p) const
+  Vec2 get_ud_pixel(const Vec2& p) const override
   {
     return cam2ima( remove_disto(ima2cam(p)) );
   }
 
   /// Return the distorted pixel (with added distortion)
-  virtual Vec2 get_d_pixel(const Vec2& p) const
+  Vec2 get_d_pixel(const Vec2& p) const override
   {
     return cam2ima( add_disto(ima2cam(p)) );
   }
@@ -176,12 +177,12 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
     _params[2] = k3;
   }
 
-  EINTRINSIC getType() const { return PINHOLE_CAMERA_RADIAL3; }
+  EINTRINSIC getType() const override { return PINHOLE_CAMERA_RADIAL3; }
 
-  virtual bool have_disto() const {  return true; }
+  bool have_disto() const override {  return true; }
 
   /// Add distortion to the point p (assume p is in the camera frame [normalized coordinates])
-  virtual Vec2 add_disto(const Vec2 & p) const {
+  Vec2 add_disto(const Vec2 & p) const override {
 
     const double k1 = _params[0], k2 = _params[1], k3 = _params[2];
 
@@ -194,7 +195,7 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
   }
 
   /// Remove distortion (return p' such that disto(p') = p)
-  virtual Vec2 remove_disto(const Vec2& p) const {
+  Vec2 remove_disto(const Vec2& p) const override {
     // Compute the radius from which the point p comes from thanks to a bisection
     // Minimize disto(radius(p')^2) == actual Squared(radius(p))
 
@@ -206,7 +207,7 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
   }
 
   // Data wrapper for non linear optimization (get data)
-  virtual std::vector<double> getParams() const
+  std::vector<double> getParams() const override
   {
     std::vector<double> params = Pinhole_Intrinsic::getParams();
     params.push_back(_params[0]);
@@ -216,7 +217,7 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
   }
 
   // Data wrapper for non linear optimization (update from data)
-  virtual bool updateFromParams(const std::vector<double> & params)
+  bool updateFromParams(const std::vector<double> & params) override
   {
     if (params.size() == 6) {
       *this = Pinhole_Intrinsic_Radial_K3(
@@ -231,13 +232,13 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
   }
 
   /// Return the un-distorted pixel (with removed distortion)
-  virtual Vec2 get_ud_pixel(const Vec2& p) const
+  Vec2 get_ud_pixel(const Vec2& p) const override
   {
     return cam2ima( remove_disto(ima2cam(p)) );
   }
 
   /// Return the distorted pixel (with added distortion)
-  virtual Vec2 get_d_pixel(const Vec2& p) const
+  Vec2 get_d_pixel(const Vec2& p) const override
   {
     return cam2ima( add_disto(ima2cam(p)) );
   }

--- a/src/openMVG/cameras/Camera_undistort_image.hpp
+++ b/src/openMVG/cameras/Camera_undistort_image.hpp
@@ -9,6 +9,8 @@
 #define OPENMVG_CAMERA_UNDISTORT_IMAGE_HPP
 
 #include "openMVG/image/image.hpp"
+#include "openMVG/cameras/Camera_Intrinsics.hpp"
+
 
 namespace openMVG {
 namespace cameras {

--- a/src/openMVG/color_harmonization/global_quantile_gain_offset_alignment.hpp
+++ b/src/openMVG/color_harmonization/global_quantile_gain_offset_alignment.hpp
@@ -27,7 +27,7 @@ struct relativeColorHistogramEdge
   size_t I,J;
   std::vector<size_t> histoI, histoJ;
 
-  relativeColorHistogramEdge() {}
+  relativeColorHistogramEdge() = default ;
 
   relativeColorHistogramEdge(
     size_t i, size_t j,
@@ -60,7 +60,7 @@ static void cdf(const std::vector<T> & vec_df, std::vector<T> & vec_cdf)
       vec_cdf[i] = vec_cdf[i] + vec_cdf[i-1];
 }
 
-};
+}; // namespace histogram
 
 // Implementation of the formula (1) of [1] with 10 quantiles.
 //-- L_infinity alignment of pair of histograms over a graph thanks to a linear program.

--- a/src/openMVG/color_harmonization/selection_VLDSegment.hpp
+++ b/src/openMVG/color_harmonization/selection_VLDSegment.hpp
@@ -28,8 +28,7 @@ class commonDataByPair_VLDSegment  : public commonDataByPair
            _vec_featsL( vec_featsL ), _vec_featsR( vec_featsR )
   {}
 
-  virtual ~commonDataByPair_VLDSegment()
-  {}
+  ~commonDataByPair_VLDSegment() override = default ; 
 
   /**
    * Put masks to white, images are conserved
@@ -39,9 +38,9 @@ class commonDataByPair_VLDSegment  : public commonDataByPair
    *
    * \return True.
    */
-  virtual bool computeMask(
+  bool computeMask(
     image::Image< unsigned char > & maskLeft,
-    image::Image< unsigned char > & maskRight )
+    image::Image< unsigned char > & maskRight ) override
   {
     std::vector< matching::IndMatch > vec_KVLDMatches;
 

--- a/src/openMVG/color_harmonization/selection_fullFrame.hpp
+++ b/src/openMVG/color_harmonization/selection_fullFrame.hpp
@@ -21,7 +21,7 @@ public:
         commonDataByPair( sLeftImage, sRightImage )
   {}
 
-  virtual ~commonDataByPair_FullFrame() {}
+  ~commonDataByPair_FullFrame() override = default ; 
 
   /**
    * Put masks to white, all image is considered as valid pixel selection
@@ -31,7 +31,7 @@ public:
    *
    * \return True.
    */
-  virtual bool computeMask( image::Image< unsigned char > & maskLeft, image::Image< unsigned char > & maskRight )
+  bool computeMask( image::Image< unsigned char > & maskLeft, image::Image< unsigned char > & maskRight ) override 
   {
     maskLeft.fill( image::WHITE );
     maskRight.fill( image::WHITE );

--- a/src/openMVG/color_harmonization/selection_interface.hpp
+++ b/src/openMVG/color_harmonization/selection_interface.hpp
@@ -25,7 +25,7 @@ public:
     _sLeftImage( sLeftImage ), _sRightImage( sRightImage )
   {}
 
-  virtual ~commonDataByPair() {}
+  virtual ~commonDataByPair() = default ; 
 
   /**
    * Compute mask forthe two images

--- a/src/openMVG/color_harmonization/selection_matchedPoints.hpp
+++ b/src/openMVG/color_harmonization/selection_matchedPoints.hpp
@@ -31,8 +31,7 @@ public:
      _vec_featsL( vec_featsL ), _vec_featsR( vec_featsR ), _radius( radius )
   {}
 
-  virtual ~commonDataByPair_MatchedPoints()
-  {}
+  ~commonDataByPair_MatchedPoints() override = default ; 
 
   /**
    * Fill mask from corresponding points (each point pictured by a disk of radius _radius)
@@ -42,7 +41,7 @@ public:
    *
    * \return True if some pixel have been set to true.
    */
-  virtual bool computeMask( image::Image< unsigned char > & maskLeft, image::Image< unsigned char > & maskRight )
+  bool computeMask( image::Image< unsigned char > & maskLeft, image::Image< unsigned char > & maskRight ) override 
   {
     maskLeft.fill(0);
     maskRight.fill(0);

--- a/src/openMVG/exif/exif_IO_EasyExif.hpp
+++ b/src/openMVG/exif/exif_IO_EasyExif.hpp
@@ -44,7 +44,7 @@ class Exif_IO_EasyExif : public Exif_IO
       open(sFileName);
     }
 
-    bool open( const std::string & sFileName )
+    bool open( const std::string & sFileName ) override 
     {
       // Read the file into a buffer
       FILE *fp = fopen(sFileName.c_str(), "rb");
@@ -67,49 +67,49 @@ class Exif_IO_EasyExif : public Exif_IO
       return bHaveExifInfo_;
     }
 
-    size_t getWidth() const
+    size_t getWidth() const override
     {
       return exifInfo_.ImageWidth;
     }
 
-    size_t getHeight() const
+    size_t getHeight() const override
     {
       return exifInfo_.ImageHeight;
     }
 
-    float getFocal() const
+    float getFocal() const override
     {
       return static_cast<float>(exifInfo_.FocalLength);
     }
 
-    std::string getBrand() const
+    std::string getBrand() const override
     {
       return trim_copy(exifInfo_.Make);
     }
 
-    std::string getModel() const
+    std::string getModel() const override
     {
       return trim_copy(exifInfo_.Model);
     }
 
-    std::string getLensModel() const
+    std::string getLensModel() const override
     {
       return trim_copy(exifInfo_.LensInfo.Model);
     }
 
-     std::string getImageUniqueID() const
+     std::string getImageUniqueID() const override
     {
       return exifInfo_.ImageUniqueID;
     }
 
     /**Verify if the file has metadata*/
-    bool doesHaveExifInfo() const
+    bool doesHaveExifInfo() const override
     {
       return bHaveExifInfo_;
     }
 
     /** Print all data*/
-    std::string allExifData() const
+    std::string allExifData() const override
     {
       std::ostringstream os;
       os

--- a/src/openMVG/features/descriptor.hpp
+++ b/src/openMVG/features/descriptor.hpp
@@ -35,7 +35,7 @@ public:
   static const size_type static_size = N;
 
   /// Constructor
-  inline Descriptor() {}
+  inline Descriptor() = default ; 
 
   /// capacity
   inline size_type size() const { return N; }
@@ -187,7 +187,7 @@ static bool loadDescsFromBinFile(
   vec_desc.resize(cardDesc);
   for (typename DescriptorsT::const_iterator iter = vec_desc.begin();
     iter != vec_desc.end(); ++iter) {
-    fileIn.read((char*) (*iter).getData(),
+    fileIn.read( reinterpret_cast<char*>( (*iter).getData() ) ,
       VALUE::static_size*sizeof(typename VALUE::bin_type));
   }
   const bool bOk = !fileIn.bad();

--- a/src/openMVG/features/image_describer.hpp
+++ b/src/openMVG/features/image_describer.hpp
@@ -27,8 +27,8 @@ enum EDESCRIBER_PRESET
 class Image_describer
 {
 public:
-  Image_describer() {}
-  virtual ~Image_describer() {}
+  Image_describer() = default ; 
+  virtual ~Image_describer() = default ; 
 
   /**
   @brief Use a preset to control the number of detected regions
@@ -46,7 +46,7 @@ public:
   */
   virtual bool Describe(const image::Image<unsigned char> & image,
     std::unique_ptr<Regions> &regions,
-    const image::Image<unsigned char> * mask = NULL) = 0;
+    const image::Image<unsigned char> * mask = nullptr ) = 0;
 
   /// Allocate regions depending of the Image_describer
   virtual void Allocate(std::unique_ptr<Regions> &regions) const = 0;

--- a/src/openMVG/features/image_describer_akaze.hpp
+++ b/src/openMVG/features/image_describer_akaze.hpp
@@ -57,7 +57,7 @@ public:
   ):Image_describer(), _params(params), _bOrientation(bOrientation) {}
 
 
-  bool Set_configuration_preset(EDESCRIBER_PRESET preset)
+  bool Set_configuration_preset(EDESCRIBER_PRESET preset) override 
   {
     switch(preset)
     {
@@ -85,7 +85,7 @@ public:
   */
   bool Describe(const image::Image<unsigned char>& image,
     std::unique_ptr<Regions> &regions,
-    const image::Image<unsigned char> * mask = NULL)
+    const image::Image<unsigned char> * mask = nullptr ) override 
   {
     _params._options.fDesc_factor =
       (_params._eAkazeDescriptor == AKAZE_MSURF ||
@@ -245,7 +245,7 @@ public:
   };
 
   /// Allocate Regions type depending of the Image_describer
-  void Allocate(std::unique_ptr<Regions> &regions) const
+  void Allocate(std::unique_ptr<Regions> &regions) const override
   {
     switch(_params._eAkazeDescriptor)
     {

--- a/src/openMVG/features/regions.hpp
+++ b/src/openMVG/features/regions.hpp
@@ -25,7 +25,7 @@ class Regions
 {
 public:
 
-  virtual ~Regions() {}
+  virtual ~Regions() = default ; 
 
   //--
   // IO - one file for region features, one file for region descriptors
@@ -99,15 +99,15 @@ public:
   //-- Class functions
   //--
 
-  bool IsScalar() const {return true;}
-  bool IsBinary() const {return false;}
-  std::string Type_id() const {return typeid(T).name();}
-  size_t DescriptorLength() const {return static_cast<size_t>(L);}
+  bool IsScalar() const override {return true;}
+  bool IsBinary() const override {return false;}
+  std::string Type_id() const override {return typeid(T).name();}
+  size_t DescriptorLength() const override {return static_cast<size_t>(L);}
 
   /// Read from files the regions and their corresponding descriptors.
   bool Load(
     const std::string& sfileNameFeats,
-    const std::string& sfileNameDescs)
+    const std::string& sfileNameDescs) override 
   {
     return loadFeatsFromFile(sfileNameFeats, _vec_feats)
           & loadDescsFromBinFile(sfileNameDescs, _vec_descs);
@@ -116,29 +116,29 @@ public:
   /// Export in two separate files the regions and their corresponding descriptors.
   bool Save(
     const std::string& sfileNameFeats,
-    const std::string& sfileNameDescs) const
+    const std::string& sfileNameDescs) const override 
   {
     return saveFeatsToFile(sfileNameFeats, _vec_feats)
           & saveDescsToBinFile(sfileNameDescs, _vec_descs);
   }
 
-  bool LoadFeatures(const std::string& sfileNameFeats)
+  bool LoadFeatures(const std::string& sfileNameFeats) override 
   {
     return loadFeatsFromFile(sfileNameFeats, _vec_feats);
   }
 
-  PointFeatures GetRegionsPositions() const
+  PointFeatures GetRegionsPositions() const override 
   {
     return PointFeatures(_vec_feats.begin(), _vec_feats.end());
   }
 
-  Vec2 GetRegionPosition(size_t i) const
+  Vec2 GetRegionPosition(size_t i) const override 
   {
     return Vec2f(_vec_feats[i].coords()).cast<double>();
   }
 
   /// Return the number of defined regions
-  size_t RegionCount() const {return _vec_feats.size();}
+  size_t RegionCount() const override {return _vec_feats.size();}
 
   /// Mutable and non-mutable FeatureT getters.
   inline std::vector<FeatureT> & Features() { return _vec_feats; }
@@ -148,7 +148,7 @@ public:
   inline std::vector<DescriptorT> & Descriptors() { return _vec_descs; }
   inline const std::vector<DescriptorT> & Descriptors() const { return _vec_descs; }
 
-  const void * DescriptorRawData() const { return &_vec_descs[0];}
+  const void * DescriptorRawData() const override { return &_vec_descs[0];}
 
   template<class Archive>
   void serialize(Archive & ar)
@@ -157,13 +157,13 @@ public:
     ar(_vec_descs);
   }
 
-  Regions * EmptyClone() const
+  Regions * EmptyClone() const override 
   {
     return new Scalar_Regions();
   }
 
   // Return the L2 distance between two descriptors
-  double SquaredDescriptorDistance(size_t i, const Regions * regions, size_t j) const
+  double SquaredDescriptorDistance(size_t i, const Regions * regions, size_t j) const override 
   {
     assert(i < _vec_descs.size());
     assert(regions);
@@ -175,7 +175,7 @@ public:
   }
 
   /// Add the Inth region to another Region container
-  void CopyRegion(size_t i, Regions * region_container) const
+  void CopyRegion(size_t i, Regions * region_container) const override 
   {
     assert(i < _vec_feats.size() && i < _vec_descs.size());
     static_cast<Scalar_Regions<FeatT, T, L> *>(region_container)->_vec_feats.push_back(_vec_feats[i]);
@@ -213,15 +213,15 @@ public:
   //-- Class functions
   //--
 
-  bool IsScalar() const {return false;}
-  bool IsBinary() const {return true;}
-  std::string Type_id() const {return typeid(typename DescriptorT::bin_type).name();}
-  size_t DescriptorLength() const {return static_cast<size_t>(L);}
+  bool IsScalar() const override {return false;}
+  bool IsBinary() const override {return true;}
+  std::string Type_id() const override {return typeid(typename DescriptorT::bin_type).name();}
+  size_t DescriptorLength() const override {return static_cast<size_t>(L);}
 
   /// Read from files the regions and their corresponding descriptors.
   bool Load(
     const std::string& sfileNameFeats,
-    const std::string& sfileNameDescs)
+    const std::string& sfileNameDescs) override 
   {
     return loadFeatsFromFile(sfileNameFeats, _vec_feats)
           & loadDescsFromBinFile(sfileNameDescs, _vec_descs);
@@ -230,29 +230,29 @@ public:
   /// Export in two separate files the regions and their corresponding descriptors.
   bool Save(
     const std::string& sfileNameFeats,
-    const std::string& sfileNameDescs) const
+    const std::string& sfileNameDescs) const override
   {
     return saveFeatsToFile(sfileNameFeats, _vec_feats)
           & saveDescsToBinFile(sfileNameDescs, _vec_descs);
   }
 
-  bool LoadFeatures(const std::string& sfileNameFeats)
+  bool LoadFeatures(const std::string& sfileNameFeats) override
   {
     return loadFeatsFromFile(sfileNameFeats, _vec_feats);
   }
 
-  PointFeatures GetRegionsPositions() const
+  PointFeatures GetRegionsPositions() const override
   {
     return PointFeatures(_vec_feats.begin(), _vec_feats.end());
   }
 
-  Vec2 GetRegionPosition(size_t i) const
+  Vec2 GetRegionPosition(size_t i) const override
   {
     return Vec2f(_vec_feats[i].coords()).cast<double>();
   }
 
   /// Return the number of defined regions
-  size_t RegionCount() const {return _vec_feats.size();}
+  size_t RegionCount() const override {return _vec_feats.size();}
 
   /// Mutable and non-mutable FeatureT getters.
   inline std::vector<FeatureT> & Features() { return _vec_feats; }
@@ -262,7 +262,7 @@ public:
   inline std::vector<DescriptorT> & Descriptors() { return _vec_descs; }
   inline const std::vector<DescriptorT> & Descriptors() const { return _vec_descs; }
 
-  const void * DescriptorRawData() const { return &_vec_descs[0];}
+  const void * DescriptorRawData() const override { return &_vec_descs[0];}
 
   template<class Archive>
   void serialize(Archive & ar)
@@ -271,13 +271,13 @@ public:
     ar(_vec_descs);
   }
 
-  Regions * EmptyClone() const
+  Regions * EmptyClone() const override 
   {
     return new Binary_Regions();
   }
 
   // Return the squared Hamming distance between two descriptors
-  double SquaredDescriptorDistance(size_t i, const Regions * regions, size_t j) const
+  double SquaredDescriptorDistance(size_t i, const Regions * regions, size_t j) const override 
   {
     assert(i < _vec_descs.size());
     assert(regions);
@@ -291,7 +291,7 @@ public:
   }
 
   /// Add the Inth region to another Region container
-  void CopyRegion(size_t i, Regions * region_container) const
+  void CopyRegion(size_t i, Regions * region_container) const override 
   {
     assert(i < _vec_feats.size() && i < _vec_descs.size());
     static_cast<Binary_Regions<FeatT, L> *>(region_container)->_vec_feats.push_back(_vec_feats[i]);

--- a/src/openMVG/geometry/Similarity3.hpp
+++ b/src/openMVG/geometry/Similarity3.hpp
@@ -7,6 +7,8 @@
 #ifndef OPENMVG_GEOMETRY_SIMILARITY3_H_
 #define OPENMVG_GEOMETRY_SIMILARITY3_H_
 
+#include "openMVG/types.hpp"
+#include "openMVG/geometry/pose3.hpp"
 
 namespace openMVG {
 namespace geometry {

--- a/src/openMVG/geometry/half_space_intersection.hpp
+++ b/src/openMVG/geometry/half_space_intersection.hpp
@@ -84,8 +84,8 @@ static bool isNotEmpty(const Half_planes & hplanes)
   return bIntersect;
 }
 
+} // namespace halfPlane
 } // namespace geometry
 } // namespace openMVG
-} // namespace halfPlane
 
 #endif // OPENMVG_GEOMETRY_HALF_SPACE_HPP_

--- a/src/openMVG/graph/connectedComponent.hpp
+++ b/src/openMVG/graph/connectedComponent.hpp
@@ -107,10 +107,9 @@ std::set<IndexT> CleanGraph_KeepLargestBiEdge_Nodes(
       {
         // list all nodes that belong to the current CC and update the Node Ids list
         const std::set<lemon::ListGraph::Node> & ccSet = iter->second;
-        for (std::set<lemon::ListGraph::Node>::const_iterator iter2 = ccSet.begin();
-          iter2 != ccSet.end(); ++iter2)
+        for (auto & elt : ccSet ) 
         {
-          const IndexT Id = (*putativeGraph.map_nodeMapIndex)[*iter2];
+          const IndexT Id = (*putativeGraph.map_nodeMapIndex)[elt];
           largestBiEdgeCC.insert(Id);
         }
       }
@@ -118,11 +117,10 @@ std::set<IndexT> CleanGraph_KeepLargestBiEdge_Nodes(
       {
         // remove the edges from the graph
         const std::set<lemon::ListGraph::Node> & ccSet = iter->second;
-        for (std::set<lemon::ListGraph::Node>::const_iterator iter2 = ccSet.begin();
-          iter2 != ccSet.end(); ++iter2)
+        for ( auto & elt : ccSet ) 
         {
           typedef Graph::OutArcIt OutArcIt;
-          for (OutArcIt e(putativeGraph.g, *iter2); e!=lemon::INVALID; ++e)
+          for (OutArcIt e(putativeGraph.g, elt ); e!=lemon::INVALID; ++e)
           {
             putativeGraph.g.erase(e);
           }

--- a/src/openMVG/graph/graph_builder.hpp
+++ b/src/openMVG/graph/graph_builder.hpp
@@ -7,8 +7,14 @@
 #ifndef OPENMVG_GRAPH_BUILDER_H_
 #define OPENMVG_GRAPH_BUILDER_H_
 
+#include "openMVG/types.hpp"
+
+#include "lemon/list_graph.h"
+
 #include <memory>
 #include <set>
+#include <map>
+
 
 namespace openMVG {
 namespace graph  {
@@ -42,12 +48,14 @@ struct indexedGraph
     }
 
     //B-- Create a node graph for each element of the set
-    for (std::set<IndexT>::const_iterator iter = setNodes.begin();
+    for ( const auto & elt : setNodes ) 
+      /*
+      std::set<IndexT>::const_iterator iter = setNodes.begin();
       iter != setNodes.end();
-      ++iter)
+      ++iter) */
     {
-      map_size_t_to_node[*iter] = g.addNode();
-      (*map_nodeMapIndex) [map_size_t_to_node.at(*iter)] = *iter;
+      map_size_t_to_node[ elt ] = g.addNode();
+      (*map_nodeMapIndex) [map_size_t_to_node.at( elt )] = elt ;
     }
 
     //C-- Add weighted edges from the pairs object

--- a/src/openMVG/graph/graph_graphviz_export.hpp
+++ b/src/openMVG/graph/graph_graphviz_export.hpp
@@ -8,9 +8,14 @@
 #ifndef OPENMVG_GRAPH_EXPORT_H_
 #define OPENMVG_GRAPH_EXPORT_H_
 
+#include "openMVG/types.hpp"
+
+#include "lemon/list_graph.h"
+
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
+#include <map>
 
 namespace openMVG {
 namespace graph {

--- a/src/openMVG/graph/triplet_finder.hpp
+++ b/src/openMVG/graph/triplet_finder.hpp
@@ -127,9 +127,9 @@ static std::vector< graph::Triplet > tripletListing(
   graph::List_Triplets<indexedGraph::GraphT>(putativeGraph.g, vec_triplets);
 
   //Change triplets to ImageIds
-  for (size_t i = 0; i < vec_triplets.size(); ++i)
+  for ( auto & triplet : vec_triplets ) //  size_t i = 0; i < vec_triplets.size(); ++i)
   {
-    graph::Triplet & triplet = vec_triplets[i];
+    // graph::Triplet & triplet = vec_triplets[i];
     IndexT I = triplet.i, J = triplet.j , K = triplet.k;
     I = (*putativeGraph.map_nodeMapIndex)[putativeGraph.g.nodeFromId(I)];
     J = (*putativeGraph.map_nodeMapIndex)[putativeGraph.g.nodeFromId(J)];

--- a/src/openMVG/image/image_container.hpp
+++ b/src/openMVG/image/image_container.hpp
@@ -97,7 +97,7 @@ namespace openMVG
       /**
       * @brief destructor
       */
-      virtual inline ~Image() {};
+      virtual inline ~Image() = default ; 
       //-- Image construction method
       //------------------------------
 

--- a/src/openMVG/image/image_converter.hpp
+++ b/src/openMVG/image/image_converter.hpp
@@ -113,8 +113,12 @@ static void rgbFloat2rgbInt(
   (*imaOut).resize(imaIn.Width(), imaIn.Height());
   // Convert each int RGB to float RGB values
   for( int j = 0; j < imaIn.Height(); ++j )
+  {
     for( int i = 0; i < imaIn.Width(); ++i )
-      convertFloatToInt( imaIn( j, i ), (*imaOut)( j, i ), factor  );
+    {
+      convertFloatToInt( imaIn( j, i ), (*imaOut)( j, i ), factor  );      
+    }    
+  }
 }
 
 } // namespace image

--- a/src/openMVG/image/image_convolution.hpp
+++ b/src/openMVG/image/image_convolution.hpp
@@ -7,7 +7,12 @@
 #ifndef OPENMVG_IMAGE_IMAGE_CONVOLUTION_HPP_
 #define OPENMVG_IMAGE_IMAGE_CONVOLUTION_HPP_
 
+#include "openMVG/numeric/numeric.h"
 #include "openMVG/numeric/accumulator_trait.hpp"
+#include "openMVG/image/image_container.hpp"
+
+#include <cassert>
+#include <vector>
 
 /**
  ** @file Standard 2D image convolution functions :

--- a/src/openMVG/image/image_convolution_base.hpp
+++ b/src/openMVG/image/image_convolution_base.hpp
@@ -7,6 +7,8 @@
 #ifndef OPENMVG_IMAGE_IMAGE_CONVOLUTION_BASE_HPP
 #define OPENMVG_IMAGE_IMAGE_CONVOLUTION_BASE_HPP
 
+#include <cstddef>
+
 namespace openMVG {
 namespace image {
   /**

--- a/src/openMVG/image/image_diffusion.hpp
+++ b/src/openMVG/image/image_diffusion.hpp
@@ -11,6 +11,11 @@
 #pragma warning(once:4244)
 #endif
 
+#include "openMVG/numeric/numeric.h"
+
+#include <vector>
+#include <cmath>
+
 namespace openMVG {
 namespace image {
 

--- a/src/openMVG/image/image_io.hpp
+++ b/src/openMVG/image/image_io.hpp
@@ -8,6 +8,7 @@
 #define OPENMVG_IMAGE_IMAGE_IMAGE_IO_HPP
 
 #include "openMVG/image/image_container.hpp"
+#include "openMVG/image/image_converter.hpp"
 #include "openMVG/image/pixel_types.hpp"
 
 namespace openMVG {

--- a/src/openMVG/image/image_io.hpp
+++ b/src/openMVG/image/image_io.hpp
@@ -98,7 +98,7 @@ inline int ReadImage(const char * path, Image<unsigned char> * im)
   else
   if (res == 1 && depth == 3) {
     //-- Must convert RGB to gray
-    RGBColor * ptrCol = (RGBColor*) &ptr[0];
+    RGBColor * ptrCol = reinterpret_cast<RGBColor*>( &ptr[0] ) ;
     Image<RGBColor> rgbColIm;
     rgbColIm = Eigen::Map<Image<RGBColor>::Base>(ptrCol, h, w);
     //convert RGB to gray
@@ -107,7 +107,7 @@ inline int ReadImage(const char * path, Image<unsigned char> * im)
   else
   if (res == 1 && depth == 4) {
     //-- Must convert RGBA to gray
-    RGBAColor * ptrCol = (RGBAColor*) &ptr[0];
+    RGBAColor * ptrCol = reinterpret_cast<RGBAColor*>( &ptr[0] ) ;
     Image<RGBAColor> rgbaColIm;
     rgbaColIm = Eigen::Map<Image<RGBAColor>::Base>(ptrCol, h, w);
     //convert RGBA to gray
@@ -125,14 +125,14 @@ inline int ReadImage(const char * path, Image<RGBColor> * im)
   int w, h, depth;
   const int res = ReadImage(path, &ptr, &w, &h, &depth);
   if (res == 1 && depth == 3) {
-    RGBColor * ptrCol = (RGBColor*) &ptr[0];
+    RGBColor * ptrCol = reinterpret_cast<RGBColor*>( &ptr[0] ) ;
     //convert raw array to Image
     (*im) = Eigen::Map<Image<RGBColor>::Base>(ptrCol, h, w);
   }
   else
   if (res == 1 && depth == 4) {
     //-- Must convert RGBA to RGB
-    RGBAColor * ptrCol = (RGBAColor*) &ptr[0];
+    RGBAColor * ptrCol = reinterpret_cast<RGBAColor*>( &ptr[0] ) ;
     Image<RGBAColor> rgbaColIm;
     rgbaColIm = Eigen::Map<Image<RGBAColor>::Base>(ptrCol, h, w);
     //convert RGBA to RGB
@@ -151,7 +151,7 @@ inline int ReadImage(const char * path, Image<RGBAColor> * im)
   const int res = ReadImage(path, &ptr, &w, &h, &depth);
   if (depth !=4) return 0;
   if (res == 1) {
-    RGBAColor * ptrCol = (RGBAColor*) &ptr[0];
+    RGBAColor * ptrCol = reinterpret_cast<RGBAColor*>( &ptr[0] ) ;
     //convert raw array to Image
     (*im) = Eigen::Map<Image<RGBAColor>::Base>(ptrCol, h, w);
   }

--- a/src/openMVG/image/image_resampling.hpp
+++ b/src/openMVG/image/image_resampling.hpp
@@ -7,6 +7,7 @@
 #ifndef OPENMVG_IMAGE_IMAGE_RESAMPLING_HPP_
 #define OPENMVG_IMAGE_IMAGE_RESAMPLING_HPP_
 
+#include "openMVG/image/sample.hpp"
 
 namespace openMVG {
 namespace image {

--- a/src/openMVG/image/image_warping.hpp
+++ b/src/openMVG/image/image_warping.hpp
@@ -8,6 +8,9 @@
 #ifndef OPENMVG_IMAGE_HOMOGRAPHY_WARP
 #define OPENMVG_IMAGE_HOMOGRAPHY_WARP
 
+#include "openMVG/numeric/numeric.h"
+#include "openMVG/image/sample.hpp"
+
 namespace openMVG{
 namespace image{
 

--- a/src/openMVG/linearProgramming/bisectionLP.hpp
+++ b/src/openMVG/linearProgramming/bisectionLP.hpp
@@ -30,7 +30,7 @@ bool BisectionLP(
   double gammaLow = 0.0,  // lower bound
   double eps      = 1e-8, // precision that stop dichotomy
   const int maxIteration = 20, // max number of iteration
-  double * bestFeasibleGamma = NULL, // value of best bisection found value
+  double * bestFeasibleGamma = nullptr , // value of best bisection found value
   bool bVerbose = false)
 {
   int k = 0;

--- a/src/openMVG/linearProgramming/linearProgrammingMOSEK.hpp
+++ b/src/openMVG/linearProgramming/linearProgrammingMOSEK.hpp
@@ -31,12 +31,12 @@ public :
   // Inherited functions :
   //--
 
-  bool setup(const LP_Constraints & constraints);
-  bool setup(const LP_Constraints_Sparse & constraints);
+  bool setup(const LP_Constraints & constraints) override ;
+  bool setup(const LP_Constraints_Sparse & constraints) override ;
 
-  bool solve();
+  bool solve() override ;
 
-  bool getSolution(std::vector<double> & estimatedParams);
+  bool getSolution(std::vector<double> & estimatedParams) override ;
 
 private :
   //MSKenv_t     env;

--- a/src/openMVG/linearProgramming/linearProgrammingOSI_X.hpp
+++ b/src/openMVG/linearProgramming/linearProgrammingOSI_X.hpp
@@ -36,10 +36,10 @@ public :
   // Inherited functions :
   //--
 
-  bool setup(const LP_Constraints & constraints);
-  bool setup(const LP_Constraints_Sparse & constraints);
+  bool setup(const LP_Constraints & constraints) override;
+  bool setup(const LP_Constraints_Sparse & constraints) override ;
 
-  bool solve();
+  bool solve() override ;
 
   bool getSolution(std::vector<double> & estimatedParams);
 

--- a/src/openMVG/linearProgramming/linearProgrammingOSI_X.hpp
+++ b/src/openMVG/linearProgramming/linearProgrammingOSI_X.hpp
@@ -41,7 +41,7 @@ public :
 
   bool solve() override ;
 
-  bool getSolution(std::vector<double> & estimatedParams);
+  bool getSolution(std::vector<double> & estimatedParams) override;
 
 private :
   SOLVERINTERFACE *si;

--- a/src/openMVG/matching/indMatch.hpp
+++ b/src/openMVG/matching/indMatch.hpp
@@ -77,8 +77,8 @@ typedef std::map< Pair, IndMatches > PairWiseMatches;
 static Pair_Set getPairs(const PairWiseMatches & matches)
 {
   Pair_Set pairs;
-  for(PairWiseMatches::const_iterator it = matches.begin(); it != matches.end(); ++it)
-    pairs.insert(it->first);
+  for( const auto & cur_pair : matches ) 
+    pairs.insert(cur_pair.first);
   return pairs;
 }
 

--- a/src/openMVG/matching/indMatchDecoratorXY.hpp
+++ b/src/openMVG/matching/indMatchDecoratorXY.hpp
@@ -64,12 +64,16 @@ public:
     const std::vector<features::SIOPointFeature> & rightFeat)
     :_vec_matches(vec_matches)
   {
-    for (size_t i = 0; i < vec_matches.size(); ++i) {
-      const size_t I = vec_matches[i]._i;
-      const size_t J = vec_matches[i]._j;
+    for ( const auto & cur_vec_match : vec_matches ) // size_t i = 0; i < vec_matches.size(); ++i) 
+    {
+      const size_t I = cur_vec_match._i ;
+      const size_t J = cur_vec_match._j ; 
+      
+      // const size_t I = vec_matches[i]._i;
+      // const size_t J = vec_matches[i]._j;
       _vecDecoredMatches.push_back(
         IndMatchDecoratorStruct(leftFeat[I].x(),leftFeat[I].y(),
-        rightFeat[J].x(), rightFeat[J].y(), vec_matches[i]));
+        rightFeat[J].x(), rightFeat[J].y(), cur_vec_match ) );
     }
   }
 
@@ -78,12 +82,16 @@ public:
     const std::vector<features::PointFeature> & rightFeat)
     :_vec_matches(vec_matches)
   {
-    for (size_t i = 0; i < vec_matches.size(); ++i) {
-      const size_t I = vec_matches[i]._i;
-      const size_t J = vec_matches[i]._j;
+    for ( const auto & cur_vec_match : vec_matches ) 
+    {
+      //  size_t i = 0; i < vec_matches.size(); ++i) {
+      const size_t I = cur_vec_match._i ;
+      const size_t J = cur_vec_match._j ;      
+      // const size_t I = vec_matches[i]._i;
+      // const size_t J = vec_matches[i]._j;
       _vecDecoredMatches.push_back(
         IndMatchDecoratorStruct(leftFeat[I].x(),leftFeat[I].y(),
-        rightFeat[J].x(), rightFeat[J].y(), vec_matches[i]));
+        rightFeat[J].x(), rightFeat[J].y(), cur_vec_match ) );
     }
   }
 
@@ -92,12 +100,17 @@ public:
     const Mat & rightFeat)
     :_vec_matches(vec_matches)
   {
-    for (size_t i = 0; i < vec_matches.size(); ++i) {
-      const size_t I = vec_matches[i]._i;
-      const size_t J = vec_matches[i]._j;
+    for ( const auto & cur_vec_match : vec_matches )
+    {
+      //size_t i = 0; i < vec_matches.size(); ++i) {
+        const size_t I = cur_vec_match._i ;
+        const size_t J = cur_vec_match._j ;
+        
+      // const size_t I = vec_matches[i]._i;
+      // const size_t J = vec_matches[i]._j;
       _vecDecoredMatches.push_back(
         IndMatchDecoratorStruct(leftFeat.col(I)(0),leftFeat.col(I)(1),
-        rightFeat.col(J)(0), rightFeat.col(J)(1), vec_matches[i]));
+        rightFeat.col(J)(0), rightFeat.col(J)(1), cur_vec_match ) ) ;
     }
   }
 

--- a/src/openMVG/matching/indMatch_utils.hpp
+++ b/src/openMVG/matching/indMatch_utils.hpp
@@ -89,12 +89,12 @@ static bool Save
     {
       return false;
     }
-    for (PairWiseMatches::const_iterator iter = matches.begin();
-      iter != matches.end(); ++iter)
+    for ( const auto & cur_match : matches ) 
     {
-      const size_t I = iter->first.first;
-      const size_t J = iter->first.second;
-      const std::vector<IndMatch> & pair_matches = iter->second;
+      const size_t I = cur_match.first.first ;
+      const size_t J = cur_match.first.second ; 
+      
+      const std::vector<IndMatch> & pair_matches = cur_match.second ;
       stream << I << " " << J << '\n' << pair_matches.size() << '\n';
       copy(pair_matches.begin(), pair_matches.end(),
            std::ostream_iterator<IndMatch>(stream, "\n"));

--- a/src/openMVG/matching/matcher_brute_force.hpp
+++ b/src/openMVG/matching/matcher_brute_force.hpp
@@ -24,7 +24,7 @@ class ArrayMatcherBruteForce  : public ArrayMatcher<Scalar, Metric>
   public:
   typedef typename Metric::ResultType DistanceType;
 
-  ArrayMatcherBruteForce()   {}
+  ArrayMatcherBruteForce() = default ;
   virtual ~ArrayMatcherBruteForce() {
     memMapping.reset();
   }

--- a/src/openMVG/matching/matcher_cascade_hashing.hpp
+++ b/src/openMVG/matching/matcher_cascade_hashing.hpp
@@ -34,7 +34,7 @@ class ArrayMatcherCascadeHashing  : public ArrayMatcher<Scalar, Metric>
   public:
   typedef typename Metric::ResultType DistanceType;
 
-  ArrayMatcherCascadeHashing()   {}
+  ArrayMatcherCascadeHashing() = default ; 
   virtual ~ArrayMatcherCascadeHashing() {
     memMapping.reset();
   }

--- a/src/openMVG/matching/matcher_kdtree_flann.hpp
+++ b/src/openMVG/matching/matcher_kdtree_flann.hpp
@@ -27,7 +27,7 @@ class ArrayMatcher_Kdtree_Flann : public ArrayMatcher<Scalar, Metric>
   public:
   typedef typename Metric::ResultType DistanceType;
 
-  ArrayMatcher_Kdtree_Flann() {}
+  ArrayMatcher_Kdtree_Flann() = default ; 
 
   virtual ~ArrayMatcher_Kdtree_Flann()  {
     _datasetM.reset();
@@ -134,7 +134,7 @@ class ArrayMatcher_Kdtree_Flann : public ArrayMatcher<Scalar, Metric>
         {
           for (size_t j = 0; j < NN; ++j)
           {
-            if (indices[i] > 0)
+            if (indices[i] > 0) // rperrot : nullptr here ? 
             {
               pvec_indices->emplace_back(IndMatch(i, vec_indices[i*NN+j]));
               pvec_distances->emplace_back(vec_distances[i*NN+j]);

--- a/src/openMVG/matching/matching_filters.hpp
+++ b/src/openMVG/matching/matching_filters.hpp
@@ -197,7 +197,7 @@ static void Filter( int NN,
   // Remove multi-index
   {
     std::sort(vec_outIndex.begin(), vec_outIndex.end());
-    std::vector<IndMatch>::iterator end = std::unique(vec_outIndex.begin(), vec_outIndex.end());
+    auto end = std::unique(vec_outIndex.begin(), vec_outIndex.end());
     if(end != vec_outIndex.end()) {
       vec_outIndex.erase(end, vec_outIndex.end());
     }

--- a/src/openMVG/matching/matching_interface.hpp
+++ b/src/openMVG/matching/matching_interface.hpp
@@ -25,8 +25,8 @@ class ArrayMatcher
   typedef typename Metric::ResultType DistanceType;
   typedef Metric MetricT;
 
-  ArrayMatcher() {}
-  virtual ~ArrayMatcher() {};
+  ArrayMatcher() = default ; 
+  virtual ~ArrayMatcher() = default ;
 
   /**
    * Build the matching structure

--- a/src/openMVG/matching/pairwiseAdjacencyDisplay.hpp
+++ b/src/openMVG/matching/pairwiseAdjacencyDisplay.hpp
@@ -29,8 +29,7 @@ void PairWiseMatchingToAdjacencyMatrixSVG(const size_t NbImages,
     for (size_t I = 0; I < NbImages; ++I) {
       for (size_t J = 0; J < NbImages; ++J) {
         // If the pair have matches display a blue boxes at I,J position.
-        matching::PairWiseMatches::const_iterator iterSearch =
-          map_Matches.find(std::make_pair(I,J));
+        auto iterSearch = map_Matches.find(std::make_pair(I,J));
         if (iterSearch != map_Matches.end() && !iterSearch->second.empty())
         {
           // Display as a tooltip: (IndexI, IndexJ NbMatches)

--- a/src/openMVG/matching/regions_matcher.hpp
+++ b/src/openMVG/matching/regions_matcher.hpp
@@ -35,7 +35,7 @@ void DistanceRatioMatch
 class RegionsMatcher
 {
   public:
-  ~RegionsMatcher() {}
+  ~RegionsMatcher() = default ; 
 
   /**
    * @brief Initialize the retrieval database
@@ -103,7 +103,7 @@ public:
   typedef typename ArrayMatcherT::ScalarT Scalar;
   typedef typename ArrayMatcherT::DistanceType DistanceType;
 
-  RegionsMatcherT() :regions_(NULL) {}
+  RegionsMatcherT() :regions_(nullptr) {}
 
   /**
    * @brief Init the matcher with some reference regions.
@@ -121,7 +121,7 @@ public:
   void Init_database
   (
     const features::Regions& regions
-  )
+  ) override
   {
     regions_ = &regions;
     if (regions_->RegionCount() == 0)
@@ -137,7 +137,7 @@ public:
   bool Match(
     const float f_dist_ratio,
     const features::Regions& queryregions_,
-    matching::IndMatches & vec_putative_matches)
+    matching::IndMatches & vec_putative_matches) override
   {
     if (regions_ == nullptr)
       return false;
@@ -165,9 +165,9 @@ public:
       b_squared_metric_ ? Square(f_dist_ratio) : f_dist_ratio);
 
     vec_putative_matches.reserve(vec_nn_ratio_idx.size());
-    for (size_t k=0; k < vec_nn_ratio_idx.size(); ++k)
+    for ( const auto & index : vec_nn_ratio_idx ) //  size_t k=0; k < vec_nn_ratio_idx.size(); ++k)
     {
-      const size_t index = vec_nn_ratio_idx[k];
+//      const size_t index = vec_nn_ratio_idx[k];
       vec_putative_matches.emplace_back(vec_nIndice[index*NNN__]._j, vec_nIndice[index*NNN__]._i);
     }
 

--- a/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions_AllInMemory.hpp
+++ b/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions_AllInMemory.hpp
@@ -34,12 +34,12 @@ class Cascade_Hashing_Matcher_Regions_AllInMemory : public Matcher
     const std::shared_ptr<sfm::Regions_Provider> & regions_provider,
     const Pair_Set & pairs,
     matching::PairWiseMatches & map_PutativesMatches // the pairwise photometric corresponding points
-  )const;
+  )const override ;
 
   private:
   // Distance ratio used to discard spurious correspondence
   float f_dist_ratio_;
 };
 
-} // namespace openMVG
 } // namespace matching_image_collection
+} // namespace openMVG 

--- a/src/openMVG/matching_image_collection/E_ACRobust.hpp
+++ b/src/openMVG/matching_image_collection/E_ACRobust.hpp
@@ -88,8 +88,8 @@ struct GeometricFilter_EMatrix_AC
         Mat3>
         KernelType;
 
-    const cameras::Pinhole_Intrinsic * ptrPinhole_I = (const cameras::Pinhole_Intrinsic*)(cam_I);
-    const cameras::Pinhole_Intrinsic * ptrPinhole_J = (const cameras::Pinhole_Intrinsic*)(cam_J);
+    const cameras::Pinhole_Intrinsic * ptrPinhole_I = dynamic_cast<const cameras::Pinhole_Intrinsic*>(cam_I);
+    const cameras::Pinhole_Intrinsic * ptrPinhole_J = dynamic_cast<const cameras::Pinhole_Intrinsic*>(cam_J);
 
     KernelType kernel(
       xI, sfm_data->GetViews().at(iIndex)->ui_width, sfm_data->GetViews().at(iIndex)->ui_height,
@@ -149,8 +149,8 @@ struct GeometricFilter_EMatrix_AC
       if ( !isPinhole(cam_I->getType()) || !isPinhole(cam_J->getType()))
         return false;
 
-      const cameras::Pinhole_Intrinsic * ptrPinhole_I = (const cameras::Pinhole_Intrinsic*)(cam_I);
-      const cameras::Pinhole_Intrinsic * ptrPinhole_J = (const cameras::Pinhole_Intrinsic*)(cam_J);
+      const cameras::Pinhole_Intrinsic * ptrPinhole_I = dynamic_cast<const cameras::Pinhole_Intrinsic*>(cam_I);
+      const cameras::Pinhole_Intrinsic * ptrPinhole_J = dynamic_cast<const cameras::Pinhole_Intrinsic*>(cam_J);
 
       Mat3 F;
       FundamentalFromEssential(m_E, ptrPinhole_I->K(), ptrPinhole_J->K(), &F);
@@ -176,6 +176,6 @@ struct GeometricFilter_EMatrix_AC
   double m_dPrecision_robust;
 };
 
-} // namespace openMVG
 } //namespace matching_image_collection
+}  // namespace openMVG
 

--- a/src/openMVG/matching_image_collection/F_ACRobust.hpp
+++ b/src/openMVG/matching_image_collection/F_ACRobust.hpp
@@ -141,6 +141,6 @@ struct GeometricFilter_FMatrix_AC
   double m_dPrecision_robust;
 };
 
-} // namespace openMVG
 } //namespace matching_image_collection
+} // namespace openMVG 
 

--- a/src/openMVG/matching_image_collection/GeometricFilter.hpp
+++ b/src/openMVG/matching_image_collection/GeometricFilter.hpp
@@ -67,7 +67,7 @@ void ImageCollectionGeometricFilter::Robust_model_estimation
 #endif
   for (int i = 0; i < (int)putative_matches.size(); ++i)
   {
-    PairWiseMatches::const_iterator iter = putative_matches.begin();
+    auto iter = putative_matches.begin();
     advance(iter,i);
 
     const Pair current_pair = iter->first;
@@ -104,7 +104,7 @@ void ImageCollectionGeometricFilter::Robust_model_estimation
   }
 }
 
-} // namespace openMVG
 } // namespace matching_image_collection
+} // namespace openMVG 
 
 

--- a/src/openMVG/matching_image_collection/Geometric_Filter_utils.hpp
+++ b/src/openMVG/matching_image_collection/Geometric_Filter_utils.hpp
@@ -7,6 +7,12 @@
 
 #pragma once
 
+#include "openMVG/features/feature.hpp"
+#include "openMVG/matching/indMatch.hpp"
+#include "openMVG/sfm/pipelines/sfm_features_provider.hpp"
+#include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
+
+
 namespace openMVG {
 namespace matching_image_collection {
 
@@ -76,10 +82,10 @@ void MatchesPairToMat
   // Retrieve corresponding pair camera intrinsic if any
   const cameras::IntrinsicBase * cam_I =
     sfm_data->GetIntrinsics().count(view_I->id_intrinsic) ?
-      sfm_data->GetIntrinsics().at(view_I->id_intrinsic).get() : NULL;
+      sfm_data->GetIntrinsics().at(view_I->id_intrinsic).get() : nullptr ;
   const cameras::IntrinsicBase * cam_J =
     sfm_data->GetIntrinsics().count(view_J->id_intrinsic) ?
-      sfm_data->GetIntrinsics().at(view_J->id_intrinsic).get() : NULL;
+      sfm_data->GetIntrinsics().at(view_J->id_intrinsic).get() : nullptr ;
 
   // Load features of Inth and Jnth images
   const features::PointFeatures feature_I = regions_provider->regions_per_view.at(pairIndex.first)->GetRegionsPositions();
@@ -117,10 +123,10 @@ void MatchesPairToMat
   // Retrieve corresponding pair camera intrinsic if any
   const cameras::IntrinsicBase * cam_I =
     sfm_data->GetIntrinsics().count(view_I->id_intrinsic) ?
-      sfm_data->GetIntrinsics().at(view_I->id_intrinsic).get() : NULL;
+      sfm_data->GetIntrinsics().at(view_I->id_intrinsic).get() : nullptr ;
   const cameras::IntrinsicBase * cam_J =
     sfm_data->GetIntrinsics().count(view_J->id_intrinsic) ?
-      sfm_data->GetIntrinsics().at(view_J->id_intrinsic).get() : NULL;
+      sfm_data->GetIntrinsics().at(view_J->id_intrinsic).get() : nullptr ;
 
   // Load features of Inth and Jnth images
   const features::PointFeatures feature_I = features_provider->feats_per_view.at(pairIndex.first);
@@ -133,5 +139,5 @@ void MatchesPairToMat
     x_I, x_J);
 }
 
-} // namespace openMVG
 } //namespace matching_image_collection
+} // namespace openMVG 

--- a/src/openMVG/matching_image_collection/H_ACRobust.hpp
+++ b/src/openMVG/matching_image_collection/H_ACRobust.hpp
@@ -184,7 +184,7 @@ struct GeometricFilter_HMatrix_AC
   double m_dPrecision_robust;
 };
 
+} //namespace matching_image_collection 
 } // namespace openMVG
-} //namespace matching_image_collection
 
 

--- a/src/openMVG/matching_image_collection/Matcher.hpp
+++ b/src/openMVG/matching_image_collection/Matcher.hpp
@@ -24,9 +24,9 @@ namespace matching_image_collection {
 class Matcher
 {
   public:
-  Matcher() {};
+  Matcher() = default ;
 
-  virtual ~Matcher() {};
+  virtual ~Matcher() = default ;
 
   /// Find corresponding points between some pair of view Ids
   virtual void Match(
@@ -37,5 +37,5 @@ class Matcher
     )const = 0;
 };
 
-} // namespace openMVG
 } // namespace matching_image_collection
+} // namespace openMVG 

--- a/src/openMVG/matching_image_collection/Matcher_Regions_AllInMemory.hpp
+++ b/src/openMVG/matching_image_collection/Matcher_Regions_AllInMemory.hpp
@@ -33,7 +33,7 @@ class Matcher_Regions_AllInMemory : public Matcher
     const std::shared_ptr<sfm::Regions_Provider> & regions_provider,
     const Pair_Set & pairs,
     matching::PairWiseMatches & map_PutativesMatches // the pairwise photometric corresponding points
-  )const;
+  )const override ;
 
   private:
   // Distance ratio used to discard spurious correspondence
@@ -42,5 +42,5 @@ class Matcher_Regions_AllInMemory : public Matcher
   matching::EMatcherType _eMatcherType;
 };
 
-} // namespace openMVG
 } // namespace matching_image_collection
+} // namespace openMVG 

--- a/src/openMVG/matching_image_collection/Pair_Builder.hpp
+++ b/src/openMVG/matching_image_collection/Pair_Builder.hpp
@@ -103,10 +103,9 @@ static bool savePairs(const std::string &sFileName, const Pair_Set & pairs)
       << "savePairs: Impossible to open the output specified file: \"" << sFileName << "\"." << std::endl;
     return false;
   }
-  for (Pair_Set::const_iterator iterP = pairs.begin();
-    iterP != pairs.end(); ++iterP)
-  {
-    outStream << iterP->first << ' ' << iterP->second << '\n';
+  for ( const auto & cur_pair : pairs ) 
+    {
+    outStream << cur_pair.first << ' ' << cur_pair.second << '\n';
   }
   bool bOk = !outStream.bad();
   outStream.close();

--- a/src/openMVG/multiview/rotation_averaging_common.hpp
+++ b/src/openMVG/multiview/rotation_averaging_common.hpp
@@ -34,8 +34,8 @@ typedef std::map<Pair, RelativeRotation> RelativeRotations_map;
 static Pair_Set getPairs(const RelativeRotations & relRots)
 {
   Pair_Set pairs;
-  for(RelativeRotations::const_iterator it = relRots.begin(); it != relRots.end(); ++it)
-    pairs.insert(std::make_pair(it->i, it->j));
+  for( const auto & cur_rotation : relRots ) 
+    pairs.insert(std::make_pair(cur_rotation.i, cur_rotation.j));
   return pairs;
 }
 
@@ -43,8 +43,8 @@ static Pair_Set getPairs(const RelativeRotations & relRots)
 static RelativeRotations_map getMap(const RelativeRotations & relRots)
 {
   RelativeRotations_map map_rots;
-  for(RelativeRotations::const_iterator it = relRots.begin(); it != relRots.end(); ++it)
-    map_rots[std::make_pair(it->i, it->j)] = *it;
+  for( const auto & cur_rotation : relRots ) 
+    map_rots[std::make_pair(cur_rotation.i, cur_rotation.j)] = cur_rotation ;
   return map_rots;
 }
 

--- a/src/openMVG/multiview/rotation_averaging_l1.hpp
+++ b/src/openMVG/multiview/rotation_averaging_l1.hpp
@@ -53,7 +53,7 @@ bool GlobalRotationsRobust(
   Matrix3x3Arr& Rs,
   const size_t nMainViewID,
   float threshold = 0.f,
-  std::vector<bool> * vec_inliers = NULL);
+  std::vector<bool> * vec_inliers = nullptr );
 
 /**
  * @brief Implementation of Iteratively Reweighted Least Squares (IRLS) [1].
@@ -81,7 +81,7 @@ unsigned int FilterRelativeRotations(
   const RelativeRotations& RelRs,
   const Matrix3x3Arr& Rs,
   float threshold = 0.f,
-  std::vector<bool> * vec_inliers = NULL);
+  std::vector<bool> * vec_inliers = nullptr );
 
 } // namespace l1
 } // namespace rotation_averaging

--- a/src/openMVG/multiview/solver_resection_p3p.hpp
+++ b/src/openMVG/multiview/solver_resection_p3p.hpp
@@ -35,8 +35,11 @@
 #ifndef OPENMVG_MULTIVIEW_RESECTION_P3P_H_
 #define OPENMVG_MULTIVIEW_RESECTION_P3P_H_
 
-#include <iostream>
 #include "openMVG/numeric/numeric.h"
+#include "openMVG/multiview/projection.hpp"
+
+#include <iostream>
+#include <cmath>
 
 namespace openMVG {
 namespace euclidean_resection {

--- a/src/openMVG/multiview/translation_averaging_common.hpp
+++ b/src/openMVG/multiview/translation_averaging_common.hpp
@@ -25,9 +25,8 @@ typedef std::map< Pair, std::pair<Mat3, Vec3> > RelativeInfo_Map;
 static Pair_Set getPairs(const RelativeInfo_Vec & vec_relative)
 {
   Pair_Set pair_set;
-  for(size_t i = 0; i < vec_relative.size(); ++i)
+  for( const auto & rel : vec_relative ) 
   {
-    const relativeInfo & rel = vec_relative[i];
     pair_set.insert(Pair(rel.first.first, rel.first.second));
   }
   return pair_set;
@@ -37,11 +36,10 @@ static Pair_Set getPairs(const RelativeInfo_Vec & vec_relative)
 static std::set<IndexT> getIndexT(const RelativeInfo_Vec & vec_relative)
 {
   std::set<IndexT> indexT_set;
-  for (RelativeInfo_Vec::const_iterator iter = vec_relative.begin();
-    iter != vec_relative.end(); ++iter)
+  for ( const auto & rel : vec_relative ) 
   {
-    indexT_set.insert(iter->first.first);
-    indexT_set.insert(iter->first.second);
+    indexT_set.insert(rel.first.first);
+    indexT_set.insert(rel.first.second);
   }
   return indexT_set;
 }

--- a/src/openMVG/multiview/translation_averaging_solver.hpp
+++ b/src/openMVG/multiview/translation_averaging_solver.hpp
@@ -34,6 +34,10 @@
 #ifndef __TRANS_SOLVER_H__
 #define __TRANS_SOLVER_H__
 
+#include "openMVG/multiview/translation_averaging_common.hpp"
+
+#include <vector>
+
 //------------------
 //-- Bibliography --
 //------------------

--- a/src/openMVG/numeric/l1_solver_admm.hpp
+++ b/src/openMVG/numeric/l1_solver_admm.hpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <string>
+#include <iostream>
 
 namespace openMVG {
 

--- a/src/openMVG/numeric/l1_solver_decode_pd.hpp
+++ b/src/openMVG/numeric/l1_solver_decode_pd.hpp
@@ -7,6 +7,8 @@
 #ifndef OPENMVG_NUMERIC_L1_SOLVER_DECODE_PD_H_
 #define OPENMVG_NUMERIC_L1_SOLVER_DECODE_PD_H_
 
+#include <Eigen/Dense>
+
 namespace openMVG {
 
 // Minimum l1 error approximation:

--- a/src/openMVG/numeric/math_trait.hpp
+++ b/src/openMVG/numeric/math_trait.hpp
@@ -394,6 +394,6 @@ namespace openMVG
   {
     return fabsl( val ) ;
   }
-}
+} // namespace openMVG 
 
 #endif

--- a/src/openMVG/robust_estimation/guided_matching.hpp
+++ b/src/openMVG/robust_estimation/guided_matching.hpp
@@ -368,9 +368,8 @@ void GuidedMatching_Fundamental_Fast(
       itBs != buckets.begin() + bucket_stop; ++itBs)
     {
       const Bucket_vec & bucket = *itBs;
-      for(Bucket_vec::const_iterator itB = bucket.begin(); itB != bucket.end(); ++itB)
+      for( const auto & i : bucket )
       {
-        const IndexT i = *itB;
         // Compute descriptor distance
         const double descDist = lRegions.SquaredDescriptorDistance(i, &rRegions, j);
         // Update the corresponding points & distance (if required)

--- a/src/openMVG/robust_estimation/rand_sampling.hpp
+++ b/src/openMVG/robust_estimation/rand_sampling.hpp
@@ -35,10 +35,11 @@
 namespace openMVG {
 namespace robust{
 
+// rperrot : is this legal ? why using an anonymous namespace here ? 
 namespace
 {
   std::default_random_engine random_generator;
-}
+} // 
 
 /**
 * Pick a random subset of the integers [0, total), in random order.

--- a/src/openMVG/robust_estimation/robust_estimator_ACRansac.hpp
+++ b/src/openMVG/robust_estimation/robust_estimator_ACRansac.hpp
@@ -49,7 +49,7 @@
 namespace openMVG {
 namespace robust{
 
-namespace acrancac_nfa_internal {
+namespace acransac_nfa_internal {
 
 /// logarithm (base 10) of binomial coefficient
 template <typename T>
@@ -368,7 +368,7 @@ std::pair<double, double> ACRANSAC(const Kernel &kernel,
 
   // Initialize the NFA computation interface
   // (quantified NFA computation is used if a valid upper bound is provided)
-  acrancac_nfa_internal::NFA_Interface<Kernel> nfa_interface
+  acransac_nfa_internal::NFA_Interface<Kernel> nfa_interface
     (kernel, maxThreshold, (precision!=std::numeric_limits<double>::infinity()));
 
   // Output parameters

--- a/src/openMVG/robust_estimation/robust_estimator_ACRansacKernelAdaptator.hpp
+++ b/src/openMVG/robust_estimation/robust_estimator_ACRansacKernelAdaptator.hpp
@@ -27,6 +27,8 @@
 //  by the generic ACRANSAC routine.
 //
 
+#include "openMVG/numeric/numeric.h"
+
 namespace openMVG {
 namespace robust{
 

--- a/src/openMVG/robust_estimation/robust_estimator_LMeds.hpp
+++ b/src/openMVG/robust_estimation/robust_estimator_LMeds.hpp
@@ -28,8 +28,8 @@ namespace robust{
 /// IJCV 1998
 template <typename Kernel>
   double LeastMedianOfSquares(const Kernel &kernel,
-	  typename Kernel::Model * model = NULL,
-    double* outlierThreshold = NULL,
+	  typename Kernel::Model * model = nullptr ,
+    double* outlierThreshold = nullptr ,
     double outlierRatio=0.5,
 	  double minProba=0.99)
 {
@@ -63,7 +63,7 @@ template <typename Kernel>
       }
 
 			// Compute median
-			std::vector<double>::iterator itMedian = residuals.begin() +
+			auto itMedian = residuals.begin() +
 				std::size_t( total_samples*(1.-outlierRatio) );
 			std::nth_element(residuals.begin(), itMedian, residuals.end());
 			double median = *itMedian;

--- a/src/openMVG/robust_estimation/robust_estimator_MaxConsensus.hpp
+++ b/src/openMVG/robust_estimation/robust_estimator_MaxConsensus.hpp
@@ -33,7 +33,7 @@ namespace robust{
 template<typename Kernel, typename Scorer>
 typename Kernel::Model MaxConsensus(const Kernel &kernel,
   const Scorer &scorer,
-  std::vector<size_t> *best_inliers = NULL, size_t max_iteration = 1024) {
+  std::vector<size_t> *best_inliers = nullptr , size_t max_iteration = 1024) {
 
     const size_t min_samples = Kernel::MINIMUM_SAMPLES;
     const size_t total_samples = kernel.NumSamples();

--- a/src/openMVG/robust_estimation/robust_estimator_MaxConsensus_test.cpp
+++ b/src/openMVG/robust_estimation/robust_estimator_MaxConsensus_test.cpp
@@ -105,7 +105,7 @@ TEST(MaxConsensusLineFitter, RealisticCase) {
 
   //-- Add some noise (for the asked percentage amount)
   int nbPtToNoise = (int) NbPoints*inlierPourcentAmount/100.0;
-  vector<size_t> vec_samples; // Fit with unique random index
+  std::vector<size_t> vec_samples; // Fit with unique random index
   UniformSample(nbPtToNoise, NbPoints, &vec_samples);
   for(size_t i = 0; i <vec_samples.size(); ++i)
   {

--- a/src/openMVG/robust_estimation/robust_estimator_Ransac.hpp
+++ b/src/openMVG/robust_estimation/robust_estimator_Ransac.hpp
@@ -13,6 +13,7 @@
 #include <limits>
 #include <numeric>
 #include <vector>
+#include <cassert>
 
 namespace openMVG {
 namespace robust{
@@ -33,8 +34,8 @@ template<typename Kernel, typename Scorer>
 typename Kernel::Model RANSAC(
   const Kernel &kernel,
   const Scorer &scorer,
-  std::vector<size_t> *best_inliers = NULL,
-  double *best_score = NULL,
+  std::vector<size_t> *best_inliers = nullptr ,
+  double *best_score = nullptr ,
   double outliers_probability = 1e-2)
 {
   assert(outliers_probability < 1.0);

--- a/src/openMVG/robust_estimation/robust_estimator_Ransac_test.cpp
+++ b/src/openMVG/robust_estimation/robust_estimator_Ransac_test.cpp
@@ -87,7 +87,7 @@ TEST(MaxConsensusLineFitter, RealisticCase) {
 
   //-- Add some noise (for the asked percentage amount)
   int nbPtToNoise = (int) NbPoints*inlierPourcentAmount/100.0;
-  vector<size_t> vec_samples; // Fit with unique random index
+  std::vector<size_t> vec_samples; // Fit with unique random index
   UniformSample(nbPtToNoise, NbPoints, &vec_samples);
   for(size_t i = 0; i <vec_samples.size(); ++i)
   {

--- a/src/openMVG/robust_estimation/score_evaluator.hpp
+++ b/src/openMVG/robust_estimation/score_evaluator.hpp
@@ -28,10 +28,10 @@
 #ifndef OPENMVG_ROBUST_ESTIMATION_SCORE_EVALUATOR_H_
 #define OPENMVG_ROBUST_ESTIMATION_SCORE_EVALUATOR_H_
 
+#include <vector>
+
 namespace openMVG {
 namespace robust{
-
-using namespace std;
 
 /// Templated Functor class to evaluate a given model over a set of samples.
 template<typename Kernel>

--- a/src/openMVG/sfm/sfm_data.hpp
+++ b/src/openMVG/sfm/sfm_data.hpp
@@ -58,7 +58,7 @@ struct SfM_Data
   /// Check if the View have defined intrinsic and pose
   bool IsPoseAndIntrinsicDefined(const View * view) const
   {
-    if (view == NULL) return false;
+    if (view == nullptr ) return false;
     return (
       view->id_intrinsic != UndefinedIndexT &&
       view->id_pose != UndefinedIndexT &&

--- a/src/openMVG/sfm/sfm_data_BA.hpp
+++ b/src/openMVG/sfm/sfm_data_BA.hpp
@@ -7,6 +7,8 @@
 #ifndef OPENMVG_SFM_DATA_BA_HPP
 #define OPENMVG_SFM_DATA_BA_HPP
 
+#include "openMVG/sfm/sfm_data.hpp"
+
 namespace openMVG {
 namespace sfm {
 

--- a/src/openMVG/sfm/sfm_data_BA_ceres.hpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.hpp
@@ -45,7 +45,7 @@ class Bundle_Adjustment_Ceres : public Bundle_Adjustment
     bool bRefineRotations = true,   // tell if pose rotations will be refined
     bool bRefineTranslations = true,// tell if the pose translation will be refined
     bool bRefineIntrinsics = true,  // tell if the camera intrinsic will be refined
-    bool bRefineStructure = true);  // tell if the structure will be refined
+    bool bRefineStructure = true) override ;  // tell if the structure will be refined
 };
 
 } // namespace sfm

--- a/src/openMVG/sfm/sfm_data_filters.hpp
+++ b/src/openMVG/sfm/sfm_data_filters.hpp
@@ -8,8 +8,12 @@
 #ifndef OPENMVG_SFM_DATA_FILTERS_HPP
 #define OPENMVG_SFM_DATA_FILTERS_HPP
 
+#include "openMVG/types.hpp"
 #include "openMVG/stl/stl.hpp"
+#include "openMVG/sfm/sfm_data.hpp"
+
 #include <iterator>
+#include <set>
 
 namespace openMVG {
 namespace sfm {
@@ -21,10 +25,9 @@ static std::set<IndexT> Get_Valid_Views
 )
 {
   std::set<IndexT> valid_idx;
-  for (Views::const_iterator it = sfm_data.GetViews().begin();
-    it != sfm_data.GetViews().end(); ++it)
+  for (const auto & it : sfm_data.GetViews() ) 
   {
-    const View * v = it->second.get();
+    const View * v = it.second.get();
     if (sfm_data.IsPoseAndIntrinsicDefined(v))
     {
       valid_idx.insert(v->id_view);
@@ -61,11 +64,11 @@ static IndexT RemoveOutliers_PixelResidualError
 )
 {
   IndexT outlier_count = 0;
-  Landmarks::iterator iterTracks = sfm_data.structure.begin();
+  auto iterTracks = sfm_data.structure.begin();
   while (iterTracks != sfm_data.structure.end())
   {
     Observations & obs = iterTracks->second.obs;
-    Observations::iterator itObs = obs.begin();
+    auto itObs = obs.begin();
     while (itObs != obs.end())
     {
       const View * view = sfm_data.views.at(itObs->first).get();
@@ -109,7 +112,7 @@ static IndexT RemoveOutliers_AngleError
       const geometry::Pose3 pose1 = sfm_data.GetPoseOrDie(view1);
       const cameras::IntrinsicBase * intrinsic1 = sfm_data.intrinsics.at(view1->id_intrinsic).get();
 
-      Observations::const_iterator itObs2 = itObs1;
+      auto itObs2 = itObs1;
       ++itObs2;
       for (; itObs2 != obs.end(); ++itObs2)
       {
@@ -142,21 +145,18 @@ static bool eraseMissingPoses(SfM_Data & sfm_data, const IndexT min_points_per_p
   // Count the observation poses occurence
   Hash_Map<IndexT, IndexT> map_PoseId_Count;
   // Init with 0 count (in order to be able to remove non referenced elements)
-  for (Poses::const_iterator itPoses = sfm_data.GetPoses().begin();
-    itPoses != sfm_data.GetPoses().end(); ++itPoses)
+  for (const auto & itPoses : sfm_data.GetPoses() )
   {
-    map_PoseId_Count[itPoses->first] = 0;
+    map_PoseId_Count[itPoses.first] = 0;
   }
 
   // Count occurence of the poses in the Landmark observations
-  for (Landmarks::const_iterator itLandmarks = landmarks.begin();
-    itLandmarks != landmarks.end(); ++itLandmarks)
+  for (const auto & itLandmarks : landmarks )
   {
-    const Observations & obs = itLandmarks->second.obs;
-    for (Observations::const_iterator itObs = obs.begin();
-      itObs != obs.end(); ++itObs)
+    const Observations & obs = itLandmarks.second.obs;
+    for ( const auto & itObs : obs ) 
     {
-      const IndexT ViewId = itObs->first;
+      const IndexT ViewId = itObs.first;
       const View * v = sfm_data.GetViews().at(ViewId).get();
       if (map_PoseId_Count.count(v->id_pose))
         map_PoseId_Count.at(v->id_pose) += 1;
@@ -187,11 +187,11 @@ static bool eraseObservationsWithMissingPoses(SfM_Data & sfm_data, const IndexT 
 
   // For each landmark:
   //  - Check if we need to keep the observations & the track
-  Landmarks::iterator itLandmarks = sfm_data.structure.begin();
+  auto itLandmarks = sfm_data.structure.begin();
   while (itLandmarks != sfm_data.structure.end())
   {
     Observations & obs = itLandmarks->second.obs;
-    Observations::iterator itObs = obs.begin();
+    auto itObs = obs.begin();
     while (itObs != obs.end())
     {
       const IndexT ViewId = itObs->first;

--- a/src/openMVG/sfm/sfm_data_io_baf.hpp
+++ b/src/openMVG/sfm/sfm_data_io_baf.hpp
@@ -46,22 +46,19 @@ static bool Save_BAF(
       << sfm_data.GetLandmarks().size() << '\n';
 
     const Intrinsics & intrinsics = sfm_data.GetIntrinsics();
-    for (Intrinsics::const_iterator iterIntrinsic = intrinsics.begin();
-      iterIntrinsic != intrinsics.end(); ++iterIntrinsic)
+    for (const auto & iterIntrinsic : intrinsics ) 
     {
       //get params
-      const std::vector<double> intrinsicsParams = iterIntrinsic->second.get()->getParams();
+      const std::vector<double> intrinsicsParams = iterIntrinsic.second.get()->getParams();
       std::copy(intrinsicsParams.begin(), intrinsicsParams.end(),
         std::ostream_iterator<double>(stream, " "));
       stream << '\n';
     }
 
     const Poses & poses = sfm_data.GetPoses();
-    for (Views::const_iterator iterV = sfm_data.GetViews().begin();
-      iterV != sfm_data.GetViews().end();
-      ++ iterV)
+    for ( const auto & iterV : sfm_data.GetViews() )
     {
-      const View * view = iterV->second.get();
+      const View * view = iterV.second.get();
       if (!sfm_data.IsPoseAndIntrinsicDefined(view))
       {
         const Mat3 R = Mat3::Identity();
@@ -84,25 +81,22 @@ static bool Save_BAF(
     }
 
     const Landmarks & landmarks = sfm_data.GetLandmarks();
-    for (Landmarks::const_iterator iterLandmarks = landmarks.begin();
-      iterLandmarks != landmarks.end();
-      ++iterLandmarks)
+    for (const auto & iterLandmarks : landmarks )
     {
       // Export visibility information
       // X Y Z #observations id_cam id_pose x y ...
-      const double * X = iterLandmarks->second.X.data();
+      const double * X = iterLandmarks.second.X.data();
       std::copy(X, X+3, std::ostream_iterator<double>(stream, " "));
-      const Observations & obs = iterLandmarks->second.obs;
+      const Observations & obs = iterLandmarks.second.obs;
       stream << obs.size() << " ";
-      for (Observations::const_iterator iterOb = obs.begin();
-        iterOb != obs.end(); ++iterOb)
+      for ( const auto & iterOb : obs )
       {
-        const IndexT id_view = iterOb->first;
+        const IndexT id_view = iterOb.first;
         const View * v = sfm_data.GetViews().at(id_view).get();
         stream
           << v->id_intrinsic << ' '
           << v->id_pose << ' '
-          << iterOb->second.x(0) << ' ' << iterOb->second.x(1) << ' ';
+          << iterOb.second.x(0) << ' ' << iterOb.second.x(1) << ' ';
       }
       stream << '\n';
     }
@@ -120,16 +114,14 @@ static bool Save_BAF(
     stream.open(sFile.c_str());
     if (!stream.is_open())
       return false;
-    for (Views::const_iterator iterV = sfm_data.GetViews().begin();
-      iterV != sfm_data.GetViews().end();
-      ++ iterV)
+    for ( const auto & iterV : sfm_data.GetViews() )
     {
       const std::string sView_filename = stlplus::create_filespec(sfm_data.s_root_path,
-        iterV->second->s_Img_path);
+        iterV.second->s_Img_path);
       stream
         << sView_filename
-        << ' ' << iterV->second->id_intrinsic
-        << ' ' << iterV->second->id_pose << "\n";
+        << ' ' << iterV.second->id_intrinsic
+        << ' ' << iterV.second->id_pose << "\n";
     }
     stream.flush();
     bOk = stream.good();

--- a/src/openMVG/sfm/sfm_data_io_ply.hpp
+++ b/src/openMVG/sfm/sfm_data_io_ply.hpp
@@ -72,10 +72,9 @@ static bool Save_PLY(
       if (b_structure)
       {
         const Landmarks & landmarks = sfm_data.GetLandmarks();
-        for (Landmarks::const_iterator iterLandmarks = landmarks.begin();
-          iterLandmarks != landmarks.end();
-          ++iterLandmarks)  {
-          stream << iterLandmarks->second.X.transpose() << " 255 255 255" << "\n";
+        for ( const auto & iterLandmarks : landmarks )
+        {
+          stream << iterLandmarks.second.X.transpose() << " 255 255 255" << "\n";
         }
       }
       stream.flush();

--- a/src/openMVG/sfm/sfm_data_triangulation.hpp
+++ b/src/openMVG/sfm/sfm_data_triangulation.hpp
@@ -32,7 +32,7 @@ struct SfM_Data_Structure_Computation_Blind: public SfM_Data_Structure_Computati
 {
   SfM_Data_Structure_Computation_Blind(bool bConsoleVerbose = false);
 
-  virtual void triangulate(SfM_Data & sfm_data) const;
+  void triangulate(SfM_Data & sfm_data) const override;
 };
 
 /// Triangulation of track data contained in the structure of a SfM_Data scene.
@@ -43,7 +43,7 @@ struct SfM_Data_Structure_Computation_Robust: public SfM_Data_Structure_Computat
 {
   SfM_Data_Structure_Computation_Robust(bool bConsoleVerbose = false);
 
-  virtual void triangulate(SfM_Data & sfm_data) const;
+  void triangulate(SfM_Data & sfm_data) const override;
 
   /// Robust triangulation of track data contained in the structure
   /// All observations must have View with valid Intrinsic and Pose data

--- a/src/openMVG/sfm/sfm_landmark.hpp
+++ b/src/openMVG/sfm/sfm_landmark.hpp
@@ -7,7 +7,9 @@
 #ifndef OPENMVG_SFM_LANDMARK_HPP
 #define OPENMVG_SFM_LANDMARK_HPP
 
+#include "openMVG/types.hpp"
 #include "openMVG/numeric/numeric.h"
+
 #include <cereal/cereal.hpp> // Serialization
 
 namespace openMVG {

--- a/src/openMVG/sfm/sfm_report.hpp
+++ b/src/openMVG/sfm/sfm_report.hpp
@@ -7,6 +7,8 @@
 #ifndef OPENMVG_SFM_REPORT_HPP
 #define OPENMVG_SFM_REPORT_HPP
 
+#include "openMVG/sfm/sfm_data.hpp"
+
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 #include "third_party/htmlDoc/htmlDoc.hpp"
 #include "third_party/histogram/histogram.hpp"
@@ -24,22 +26,18 @@ static bool Generate_SfM_Report
   // Compute mean,max,median residual values per View
   IndexT residualCount = 0;
   Hash_Map< IndexT, std::vector<double> > residuals_per_view;
-  for (Landmarks::const_iterator iterTracks = sfm_data.GetLandmarks().begin();
-    iterTracks != sfm_data.GetLandmarks().end();
-    ++iterTracks
-  )
+  for ( const auto & iterTracks : sfm_data.GetLandmarks() )
   {
-    const Observations & obs = iterTracks->second.obs;
-    for (Observations::const_iterator itObs = obs.begin();
-      itObs != obs.end(); ++itObs)
+    const Observations & obs = iterTracks.second.obs;
+    for ( const auto & itObs : obs ) 
     {
-      const View * view = sfm_data.GetViews().at(itObs->first).get();
+      const View * view = sfm_data.GetViews().at(itObs.first).get();
       const geometry::Pose3 pose = sfm_data.GetPoseOrDie(view);
       const cameras::IntrinsicBase * intrinsic = sfm_data.GetIntrinsics().at(view->id_intrinsic).get();
       // Use absolute values
-      const Vec2 residual = intrinsic->residual(pose, iterTracks->second.X, itObs->second.x).array().abs();
-      residuals_per_view[itObs->first].push_back(residual(0));
-      residuals_per_view[itObs->first].push_back(residual(1));
+      const Vec2 residual = intrinsic->residual(pose, iterTracks.second.X, itObs.second.x).array().abs();
+      residuals_per_view[itObs.first].push_back(residual(0));
+      residuals_per_view[itObs.first].push_back(residual(1));
       ++residualCount;
     }
   }
@@ -81,11 +79,9 @@ static bool Generate_SfM_Report
     << sRowEnd;
   htmlDocStream.pushInfo( os.str() );
 
-  for (Views::const_iterator iterV = sfm_data.GetViews().begin();
-    iterV != sfm_data.GetViews().end();
-    ++iterV)
+  for (const auto & iterV : sfm_data.GetViews() )
   {
-    const View * v = iterV->second.get();
+    const View * v = iterV.second.get();
     const IndexT id_view = v->id_view;
 
     os.str("");

--- a/src/openMVG/sfm/sfm_view.hpp
+++ b/src/openMVG/sfm/sfm_view.hpp
@@ -7,6 +7,9 @@
 #ifndef OPENMVG_SFM_VIEW_HPP
 #define OPENMVG_SFM_VIEW_HPP
 
+#include "openMVG/types.hpp"
+
+
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 #include <cereal/cereal.hpp> // Serialization
 

--- a/src/openMVG/stl/dynamic_bitset.hpp
+++ b/src/openMVG/stl/dynamic_bitset.hpp
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include <limits>
+#include <cassert>
+#include <vector>
+
 namespace stl
 {
 

--- a/src/openMVG/stl/indexed_sort.hpp
+++ b/src/openMVG/stl/indexed_sort.hpp
@@ -8,6 +8,8 @@
 #ifndef OPENMVG_STL_INDEXED_SORT_H
 #define OPENMVG_STL_INDEXED_SORT_H
 
+#include <vector>
+
 namespace stl
 {
 namespace indexed_sort
@@ -42,9 +44,7 @@ namespace indexed_sort
 
   /// Sort by default all indexed value, else sort only the NN smallest element of the indexed array.
   template<typename packet_type, typename eT>
-  void
-    inline
-    sort_index_helper(std::vector<packet_type>& packet_vec,
+  inline void sort_index_helper(std::vector<packet_type>& packet_vec,
                       const eT* in_mem, int NN = -1)  {
     const size_t n_elem = packet_vec.size();
 

--- a/src/openMVG/tracks/tracks.hpp
+++ b/src/openMVG/tracks/tracks.hpp
@@ -70,19 +70,17 @@ struct TracksBuilder
     typedef std::set<indexedFeaturePair> SetIndexedPair;
     SetIndexedPair allFeatures;
     // For each couple of images list the used features
-    for (PairWiseMatches::const_iterator iter = map_pair_wise_matches.begin();
-      iter != map_pair_wise_matches.end();
-      ++iter)
+    for ( const auto & iter : map_pair_wise_matches )
     {
-      const size_t & I = iter->first.first;
-      const size_t & J = iter->first.second;
-      const std::vector<IndMatch> & vec_FilteredMatches = iter->second;
+      const size_t & I = iter.first.first;
+      const size_t & J = iter.first.second;
+      const std::vector<IndMatch> & vec_FilteredMatches = iter.second;
 
       // Retrieve all shared features and add them to a set
-      for( size_t k = 0; k < vec_FilteredMatches.size(); ++k)
+      for( const auto & cur_filtered_match : vec_FilteredMatches ) 
       {
-        allFeatures.emplace(I,vec_FilteredMatches[k]._i);
-        allFeatures.emplace(J,vec_FilteredMatches[k]._j);
+        allFeatures.emplace(I,cur_filtered_match._i);
+        allFeatures.emplace(J,cur_filtered_match._j);
       }
     }
 
@@ -104,13 +102,11 @@ struct TracksBuilder
     uf_tree.InitSets(map_node_to_index.size());
 
     // 4. Union of the matched features corresponding UF tree sets
-    for (PairWiseMatches::const_iterator iter = map_pair_wise_matches.begin();
-      iter != map_pair_wise_matches.end();
-      ++iter)
+    for ( const auto & iter : map_pair_wise_matches )
     {
-      const auto & I = iter->first.first;
-      const auto & J = iter->first.second;
-      const std::vector<IndMatch> & vec_FilteredMatches = iter->second;
+      const auto & I = iter.first.first;
+      const auto & J = iter.first.second;
+      const std::vector<IndMatch> & vec_FilteredMatches = iter.second;
       for (const IndMatch & match : vec_FilteredMatches)
       {
         const indexedFeaturePair pairI(I, match._i);
@@ -228,24 +224,23 @@ struct TracksUtilsMap
     map_tracksOut.clear();
 
     // Go along the tracks
-    for (STLMAPTracks::const_iterator iterT = map_tracksIn.begin();
-      iterT != map_tracksIn.end(); ++iterT)
+    for ( const auto & iterT : map_tracksIn )
     {
       // Look if the track contains the provided view index & save the point ids
       submapTrack map_temp;
       bool bTest = true;
-      for (std::set<size_t>::const_iterator iterIndex = set_imageIndex.begin();
+      for (auto iterIndex = set_imageIndex.begin();
         iterIndex != set_imageIndex.end() && bTest; ++iterIndex)
       {
-        submapTrack::const_iterator iterSearch = iterT->second.find(*iterIndex);
-        if (iterSearch != iterT->second.end())
+        auto iterSearch = iterT.second.find(*iterIndex);
+        if (iterSearch != iterT.second.end())
           map_temp[iterSearch->first] = iterSearch->second;
         else
           bTest = false;
       }
 
       if (!map_temp.empty() && map_temp.size() == set_imageIndex.size())
-        map_tracksOut[iterT->first] = std::move(map_temp);
+        map_tracksOut[iterT.first] = std::move(map_temp);
     }
     return !map_tracksOut.empty();
   }
@@ -256,10 +251,9 @@ struct TracksUtilsMap
     std::set<size_t> * set_tracksIds)
   {
     set_tracksIds->clear();
-    for (STLMAPTracks::const_iterator iterT = map_tracks.begin();
-      iterT != map_tracks.end(); ++iterT)
+    for ( const auto & iterT : map_tracks ) 
     {
-      set_tracksIds->insert(iterT->first);
+      set_tracksIds->insert(iterT.first);
     }
   }
 
@@ -270,15 +264,14 @@ struct TracksUtilsMap
     size_t nImageIndex,
     std::vector<size_t> * pvec_featIndex)
   {
-    for (STLMAPTracks::const_iterator iterT = map_tracks.begin();
-      iterT != map_tracks.end(); ++iterT)
+    for ( const auto & iterT : map_tracks )
     {
-      const size_t trackId = iterT->first;
+      const size_t trackId = iterT.first;
       if (set_trackId.find(trackId) != set_trackId.end())
       {
         //try to find imageIndex
-        const submapTrack & map_ref = iterT->second;
-        submapTrack::const_iterator iterSearch = map_ref.find(nImageIndex);
+        const submapTrack & map_ref = iterT.second;
+        auto iterSearch = map_ref.find(nImageIndex);
         if (iterSearch != map_ref.end())
         {
           pvec_featIndex->emplace_back(iterSearch->second);
@@ -317,11 +310,11 @@ struct TracksUtilsMap
 
     std::vector<IndMatch> & vec_indexref = *pvec_index;
     vec_indexref.clear();
-    for (size_t i = 0; i < vec_filterIndex.size(); ++i)
+    for ( const auto & filter_index : vec_filterIndex ) 
     {
       // Retrieve the track information from the current index i.
-      STLMAPTracks::const_iterator itF =
-        find_if(map_tracks.begin(), map_tracks.end(), FunctorMapFirstEqual(vec_filterIndex[i]));
+      auto itF =
+        find_if(map_tracks.begin(), map_tracks.end(), FunctorMapFirstEqual( filter_index ) ) ;
       // The current track.
       const submapTrack & map_ref = itF->second;
 
@@ -338,10 +331,9 @@ struct TracksUtilsMap
   static void TracksLength(const STLMAPTracks & map_tracks,
     std::map<size_t, size_t> & map_Occurence_TrackLength)
   {
-    for (STLMAPTracks::const_iterator iterT = map_tracks.begin();
-      iterT != map_tracks.end(); ++iterT)
+    for ( const auto & iterT : map_tracks ) 
     {
-      const size_t trLength = iterT->second.size();
+      const size_t trLength = iterT.second.size();
       if (map_Occurence_TrackLength.end() ==
         map_Occurence_TrackLength.find(trLength))
       {
@@ -358,15 +350,12 @@ struct TracksUtilsMap
   static void ImageIdInTracks(const STLMAPTracks & map_tracks,
     std::set<size_t> & set_imagesId)
   {
-    for (STLMAPTracks::const_iterator iterT = map_tracks.begin();
-      iterT != map_tracks.end(); ++iterT)
+    for ( const auto & iterT : map_tracks ) 
     {
-      const submapTrack & map_ref = iterT->second;
-      for (submapTrack::const_iterator iter = map_ref.begin();
-        iter != map_ref.end();
-        ++iter)
+      const submapTrack & map_ref = iterT.second;
+      for ( const auto & iter : map_ref )
       {
-        set_imagesId.insert(iter->first);
+        set_imagesId.insert(iter.first);
       }
     }
   }

--- a/src/openMVG/types.hpp
+++ b/src/openMVG/types.hpp
@@ -33,7 +33,7 @@ typedef std::vector<Pair> Pair_Vec;
 #if defined OPENMVG_NO_UNORDERED_MAP
 template<typename K, typename V>
 struct Hash_Map : std::map<K, V, std::less<K>,
- Eigen::aligned_allocator<std::pair<K,V> > > {};
+ Eigen::aligned_allocator<std::pair<const K,V> > > {};
 #endif
 
 #if defined OPENMVG_STD_UNORDERED_MAP


### PR DESCRIPTION
This is an attempt to clean some part of the code and making it more C++11 like. 

- Code cleanup fix : 
* some typo (acrancac -> acransac namespace)
* some end namespace comments 

- Code cleanup change some of the for loops on iterators to have range based for loop 
- Code cleanup use C++11 OOP construct (=default, override and so on)