### PR TITLE
Fix clang compilation issue with std::move on const objects

### DIFF
--- a/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions_AllInMemory.cpp
+++ b/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions_AllInMemory.cpp
@@ -109,7 +109,7 @@ void Match
     const size_t dimension = regionsI.DescriptorLength();
 
     Eigen::Map<BaseMat> mat_I( (ScalarT*)tabI, regionsI.RegionCount(), dimension);
-    const HashedDescriptions hashed_description = cascade_hasher.CreateHashedDescriptions(mat_I,
+    HashedDescriptions hashed_description = cascade_hasher.CreateHashedDescriptions(mat_I,
       zero_mean_descriptor);
 #ifdef OPENMVG_USE_OPENMP
     #pragma omp critical
@@ -144,7 +144,7 @@ void Match
 #endif
     for (int j = 0; j < (int)indexToCompare.size(); ++j)
     {
-      const size_t J = indexToCompare[j];
+      size_t J = indexToCompare[j];
       const features::Regions &regionsJ = *regions_provider.regions_per_view.at(J).get();
 
       if (regions_provider.regions_per_view.count(J) == 0

--- a/src/openMVG/matching_image_collection/GeometricFilter.hpp
+++ b/src/openMVG/matching_image_collection/GeometricFilter.hpp
@@ -70,7 +70,7 @@ void ImageCollectionGeometricFilter::Robust_model_estimation
     PairWiseMatches::const_iterator iter = putative_matches.begin();
     advance(iter,i);
 
-    const Pair current_pair = iter->first;
+    Pair current_pair = iter->first;
     const std::vector<IndMatch> & vec_PutativeMatches = iter->second;
 
     //-- Apply the geometric filter (robust model estimation)


### PR DESCRIPTION
Here is a quick fix for compilation on recent clang that seems stricter than previous version when using std::move on const objects. Since destination object doesn't have const attribute, this generate an error. 

Here is an example of the error generated without the fix : 

```
openMVG/src/openMVG/matching_image_collection/GeometricFilter.hpp:94:55: error: 
      binding value of type 'const pair<[2 * ...]>' to reference to type 'pair<[2 * ...]>' drops 'const' qualifier
          _map_GeometricMatches.insert(std::make_pair(current_pair, std::move(putative_inliers)));
                                                      ^~~~~~~~~~~~
```