### PR TITLE
[build/continuous integration] Add clang compiler to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,25 @@
 
 language: cpp
 
-compiler:
-  - gcc
-  #- clang: #Consider clang later, since cereal does not build fine on the clang CI version
-  #  - "3.3"
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+      env: COMPILER=g++-4.8
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+      env: COMPILER=clang++-3.7
 
 sudo: false
 
@@ -17,7 +32,6 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - cmake
-      - lcov
       - libpng-dev
       - libjpeg8-dev
       - libtiff4-dev
@@ -25,47 +39,31 @@ addons:
       - libxxf86vm-dev
       - x11proto-xf86vidmode-dev
       - libxrandr-dev
-      - g++-4.8
 
 env:
   global:
-    - NUM_CPU="`grep processor /proc/cpuinfo | wc -l`"; echo $NUM_CPU
     - OPENMVG_SOURCE=${TRAVIS_BUILD_DIR}/src
     - OPENMVG_BUILD=${TRAVIS_BUILD_DIR}/build
 
-before_install:
- - gem install coveralls-lcov
-
 before_script:
-  - export CXX="g++-4.8"
   # Create build folder
   - mkdir $OPENMVG_BUILD
   - cd $OPENMVG_BUILD
   # Classic release build
-  - cmake -DCMAKE_BUILD_TYPE=release -DOpenMVG_BUILD_TESTS=ON -DOpenMVG_BUILD_EXAMPLES=ON . $OPENMVG_SOURCE
-  # Build for code coverage evaluation
-  #- cmake -DOpenMVG_BUILD_COVERAGE=ON -DOpenMVG_BUILD_TESTS=ON -DOpenMVG_BUILD_EXAMPLES=ON . $OPENMVG_SOURCE
+  - >
+    cmake \
+      -DCMAKE_CXX_COMPILER=$COMPILER \
+      -DCMAKE_BUILD_TYPE=release \
+      -DOpenMVG_BUILD_TESTS=ON \
+      -DOpenMVG_BUILD_EXAMPLES=ON \
+      . $OPENMVG_SOURCE
 
 script:
 # limit GCC builds to a reduced number of thread for the virtual machine
   - make -j 2
-# Perform unit tests only on GCC builds
-  - if [ "$CC" = "gcc" ]; then make test; fi
+  - make test
 
 branches:
   only:
     - develop
-
-after_success:
-  #- cd ../openMVG
-  # If GCC: compute code coverage and export it to coveralls
-  #- if [ "$CC" = "gcc" ];
-  #  then
-  #    lcov --directory ../build/openMVG --base-directory=./src --capture --output-file=coverage.info;
-  #    lcov --remove coverage.info '/usr*' -o coverage.info;
-  #    lcov --remove coverage.info '*_test.cpp*' -o coverage.info;
-  #    lcov --remove coverage.info '*/third_party/*' -o coverage.info;
-  #    lcov --remove coverage.info '*/src/dependencies/*' -o coverage.info;
-  #    coveralls-lcov coverage.info;
-  #  fi
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Building
 See [BUILD](https://github.com/openMVG/openMVG/raw/master/BUILD) text file
 
 Continuous integration:
- - linux 64 bits/GCC (Build + tests): [![Build Status](https://travis-ci.org/openMVG/openMVG.png?branch=develop)](https://travis-ci.org/openMVG/openMVG)
+ - linux 64 bits, GCC/CLANG (Build + tests): [![Build Status](https://travis-ci.org/openMVG/openMVG.png?branch=develop)](https://travis-ci.org/openMVG/openMVG)
  - VStudio 2015 64 bits (Build): [![Build status](https://ci.appveyor.com/api/projects/status/3nv6rt41yxqx5v7i?svg=true)](https://ci.appveyor.com/project/pmoulon/openmvg)
  - Unit test coverage: [![Coverage Status](https://coveralls.io/repos/openMVG/openMVG/badge.png?branch=develop)](https://coveralls.io/r/openMVG/openMVG?branch=develop)
 

--- a/src/openMVG/sfm/pipelines/localization/SfM_Localizer.cpp
+++ b/src/openMVG/sfm/pipelines/localization/SfM_Localizer.cpp
@@ -143,7 +143,7 @@ namespace sfm {
     }
 
     // Configure BA options (refine the intrinsic and the pose parameter only if requested)
-    const Optimize_Options ba_refine_options;
+    const Optimize_Options ba_refine_options
     (
       (b_refine_intrinsic) ? cameras::Intrinsic_Parameter_Type::ADJUST_ALL : cameras::Intrinsic_Parameter_Type::NONE,
       (b_refine_pose) ? Extrinsic_Parameter_Type::ADJUST_ALL : Extrinsic_Parameter_Type::NONE,

--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
@@ -1025,9 +1025,11 @@ bool SequentialSfMReconstructionEngine::Resection(const size_t viewIndex)
           return false;
       }
     }
+    const bool b_refine_pose = true;
+    const bool b_refine_intrinsics = false;
     if(!sfm::SfM_Localizer::RefinePose(
-      optional_intrinsic.get(), pose,
-      resection_data, true, b_new_intrinsic))
+        optional_intrinsic.get(), pose,
+        resection_data, b_refine_pose, b_refine_intrinsics))
     {
       return false;
     }

--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM_test.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM_test.cpp
@@ -146,7 +146,7 @@ TEST(SEQUENTIAL_SFM, Partially_Known_Intrinsics) {
 
   const double dResidual = RMSE(sfmEngine.Get_SfM_Data());
   std::cout << "RMSE residual: " << dResidual << std::endl;
-  EXPECT_TRUE( dResidual < 0.5);
+  EXPECT_TRUE( dResidual < 0.55);
   EXPECT_TRUE( sfmEngine.Get_SfM_Data().GetPoses().size() == nviews);
   EXPECT_TRUE( sfmEngine.Get_SfM_Data().GetLandmarks().size() == npoints);
   EXPECT_TRUE( IsTracksOneCC(sfmEngine.Get_SfM_Data()));

--- a/src/software/SfM/InterfaceMVS.h
+++ b/src/software/SfM/InterfaceMVS.h
@@ -150,9 +150,9 @@ ARCHIVE_DEFINE_TYPE(uint32_t)
 ARCHIVE_DEFINE_TYPE(uint64_t)
 ARCHIVE_DEFINE_TYPE(float)
 ARCHIVE_DEFINE_TYPE(double)
-#ifdef __clang__
-ARCHIVE_DEFINE_TYPE(unsigned long)
-#endif
+//#ifdef __clang__
+//ARCHIVE_DEFINE_TYPE(unsigned long)
+//#endif
 
 // Serialization support for cv::Matx
 template<typename _Tp, int m, int n>

--- a/src/third_party/flann/src/cpp/flann/algorithms/kdtree_index.h
+++ b/src/third_party/flann/src/cpp/flann/algorithms/kdtree_index.h
@@ -663,7 +663,7 @@ private:
             ElementType max_span = 0;
             size_t div_feat = 0;
             for (size_t i=0;i<veclen_;++i) {
-                ElementType span = abs(point[i]-leaf_point[i]);
+                ElementType span = std::abs(point[i]-leaf_point[i]);
                 if (span > max_span) {
                     max_span = span;
                     div_feat = i;


### PR DESCRIPTION
- Fix some clang compilation warning,
- Fix a SfM_Localizer error detected by clang,
- [sfm/pipelines/sequential] Do not optimize too early the intrinsic when a resection is performed.