### PR TITLE
Added weights for each of the dimension of GPS prior

### DIFF
--- a/src/openMVG/sfm/sfm_data_BA_ceres.cpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.cpp
@@ -27,13 +27,13 @@ using namespace openMVG::geometry;
 // Ceres CostFunctor used for SfM pose center to GPS pose center minimization
 struct PoseCenterConstraintCostFunction
 {
-  double weight_;
+  Vec3 weight_;
   Vec3 pose_center_constraint_;
 
   PoseCenterConstraintCostFunction
   (
     const Vec3 & center,
-    const double weight
+    const Vec3 & weight
   ): weight_(weight), pose_center_constraint_(center)
   {
   }
@@ -59,9 +59,9 @@ struct PoseCenterConstraintCostFunction
     pose_center[2] *= T(-1);
 
 
-    residuals[0] = T(weight_) * (pose_center[0] - T(pose_center_constraint_[0]));
-    residuals[1] = T(weight_) * (pose_center[1] - T(pose_center_constraint_[1]));
-    residuals[2] = T(weight_) * (pose_center[2] - T(pose_center_constraint_[2]));
+    residuals[0] = T(weight_[0]) * (pose_center[0] - T(pose_center_constraint_[0]));
+    residuals[1] = T(weight_[1]) * (pose_center[1] - T(pose_center_constraint_[1]));
+    residuals[2] = T(weight_[2]) * (pose_center[2] - T(pose_center_constraint_[2]));
     return true;
   }
 };

--- a/src/openMVG/sfm/sfm_view_priors.hpp
+++ b/src/openMVG/sfm/sfm_view_priors.hpp
@@ -46,7 +46,7 @@ struct ViewPriors : public View
   void SetPoseCenterPrior
   (
     const Vec3 & center,
-    const double weight
+    const Vec3 & weight
   )
   {
     b_use_pose_center_  = true;
@@ -77,7 +77,8 @@ struct ViewPriors : public View
     if (b_use_pose_center_)
     {
       ar( cereal::make_nvp( "use_pose_center_prior", b_use_pose_center_ ) );
-      ar( cereal::make_nvp( "center_weight", center_weight_ ) );
+      const std::vector<double> vec_weights = { center_weight_( 0 ), center_weight_( 1 ), center_weight_( 2 ) };
+      ar( cereal::make_nvp( "center_weight", vec_weights ) );
       const std::vector<double> vec = { pose_center_( 0 ), pose_center_( 1 ), pose_center_( 2 ) };
       ar( cereal::make_nvp( "center", vec ) );
     }
@@ -112,8 +113,9 @@ struct ViewPriors : public View
     try
     {
       ar( cereal::make_nvp( "use_pose_center_prior", b_use_pose_center_ ) );
-      ar( cereal::make_nvp( "center_weight", center_weight_ ) );
       std::vector<double> vec( 3 );
+      ar( cereal::make_nvp( "center_weight", vec ) );
+      center_weight_ = Eigen::Map<const Vec3>( &vec[0] );
       ar( cereal::make_nvp( "center", vec ) );
       pose_center_ = Eigen::Map<const Vec3>( &vec[0] );
     }
@@ -146,7 +148,7 @@ struct ViewPriors : public View
 
   // Pose center prior
   bool b_use_pose_center_ = false; // Tell if the pose prior must be used
-  double center_weight_ = 1.0;
+  Vec3 center_weight_ = Vec3(1.0,1.0,1.0);
   Vec3 pose_center_;
 
   // Pose rotation prior

--- a/src/software/SfM/main_SfMInit_ImageListing.cpp
+++ b/src/software/SfM/main_SfMInit_ImageListing.cpp
@@ -84,6 +84,35 @@ std::pair<bool, Vec3> checkGPS
   return val;
 }
 
+
+/// Check string of prior weights
+std::pair<bool, Vec3> checkPriorWeightsString
+(
+  const std::string &sWeights
+)
+{
+  std::pair<bool, Vec3> val(true, Vec3::Zero());
+  std::vector<std::string> vec_str;
+  stl::split(sWeights, ';', vec_str);
+  if (vec_str.size() != 3)
+  {
+    std::cerr << "\n Missing ';' character in prior weights" << std::endl;
+    val.first = false;
+  }
+  // Check that all weight values are valid numbers
+  for (size_t i = 0; i < vec_str.size(); ++i)
+  {
+    double readvalue = 0.0;
+    std::stringstream ss;
+    ss.str(vec_str[i]);
+    if (! (ss >> readvalue) )  {
+      std::cerr << "\n Used an invalid not a number character in local frame origin" << std::endl;
+      val.first = false;
+    }
+    val.second[i] = readvalue;
+  }
+  return val;
+}
 //
 // Create the description of an input image dataset for OpenMVG toolsuite
 // - Export a SfM_Data file with View & Intrinsic data
@@ -96,6 +125,8 @@ int main(int argc, char **argv)
     sfileDatabase = "",
     sOutputDir = "",
     sKmatrix;
+  std::string sPriorWeights;
+  std::pair<bool, Vec3> prior_w_info(false, Vec3::Zero());
 
   int i_User_camera_model = PINHOLE_CAMERA_RADIAL3;
 
@@ -111,6 +142,7 @@ int main(int argc, char **argv)
   cmd.add( make_option('c', i_User_camera_model, "camera_model") );
   cmd.add( make_option('g', b_Group_camera_model, "group_camera_model") );
   cmd.add( make_switch('P', "use_pose_prior") );
+  cmd.add(make_option('W', sPriorWeights, "prior_weigths"));
 
   try {
       if (argc == 1) throw std::string("Invalid command line parameter.");
@@ -133,6 +165,7 @@ int main(int argc, char **argv)
       << "\t 1-> (default) view can share some camera intrinsic parameters\n"
       << "\n"
       << "[-P|--use_pose_prior] Use pose prior if GPS EXIF pose is available"
+      << "[-W|--prior_weigths] \"x;y;z;\" of weights for each dimension of the prior (default: 1.0)\n"
       << std::endl;
 
       std::cerr << s << std::endl;
@@ -198,6 +231,12 @@ int main(int argc, char **argv)
        << ", please specify a valid file." << std::endl;
       return EXIT_FAILURE;
     }
+  }
+
+  // Check if prior weights are given
+  if(cmd.used('P') && !sPriorWeights.empty())
+  {
+    prior_w_info = checkPriorWeightsString(sPriorWeights);
   }
 
   std::vector<std::string> vec_image = stlplus::folder_files( sImageDir );
@@ -352,6 +391,11 @@ int main(int argc, char **argv)
 
       v.b_use_pose_center_ = true;
       v.pose_center_ = gps_info.second;
+      // prior weights
+      if(prior_w_info.first == true)
+      {
+        v.center_weight_ = prior_w_info.second;
+      }
 
       // Add the view to the sfm_container
       views[v.id_view] = std::make_shared<ViewPriors>(v);

--- a/src/software/SfM/main_SfMInit_ImageListing.cpp
+++ b/src/software/SfM/main_SfMInit_ImageListing.cpp
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
     sOutputDir = "",
     sKmatrix;
   std::string sPriorWeights;
-  std::pair<bool, Vec3> prior_w_info(false, Vec3::Zero());
+  std::pair<bool, Vec3> prior_w_info(false, Vec3(1.0,1.0,1.0));
 
   int i_User_camera_model = PINHOLE_CAMERA_RADIAL3;
 
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
   }
 
   // Check if prior weights are given
-  if(cmd.used('P') && !sPriorWeights.empty())
+  if (cmd.used('P') && !sPriorWeights.empty())
   {
     prior_w_info = checkPriorWeightsString(sPriorWeights);
   }
@@ -392,7 +392,7 @@ int main(int argc, char **argv)
       v.b_use_pose_center_ = true;
       v.pose_center_ = gps_info.second;
       // prior weights
-      if(prior_w_info.first == true)
+      if (prior_w_info.first == true)
       {
         v.center_weight_ = prior_w_info.second;
       }


### PR DESCRIPTION
Hi @pmoulon,

in this PR i propose a relatively small change to add the ability to put different weights to each of the dimensions of the prior. This would enable to introduce some knowledge about the uncertainty of the estimations for each of the directions. While maybe in the majority of cases the estimates in all 3 are equally good, this might not be the case when we use different sensors for different estimations (in underwater scenarios depth is usually more accurately estimated than the "2D position").  Simple expansion of the weights would enable to add this knowledge into the SfM process. Additionally I added the possibility to initialize the weights through the SfMInit binary.

Best,
Kklemen