### PR TITLE
Added camera sensor width for Samsung Galaxy S4 GT-I9500.

### DIFF
--- a/src/openMVG/exif/sensor_width_database/sensor_width_camera_database.txt
+++ b/src/openMVG/exif/sensor_width_database/sensor_width_camera_database.txt
@@ -2999,6 +2999,7 @@ Samsung Digimax 220 SE;5.33
 Samsung Digimax 35 MP3;4.8
 Samsung Digimax 210 SE;5.33
 Samsung-SGH-I537;3
+GT-I9500;4.69
 Sanyo VPC E1500TP;6.08
 Sanyo VPC S1414;6.08
 Sanyo VPC T1495;6.08


### PR DESCRIPTION
Added camera sensor width for Samsung Galaxy S4 GT-I9500

Reference: http://www.devicespecifications.com/en/model/8bb2271a

Tested this with photos taken from my Galaxy S4 phone. Works good.
The pictures had EXIF data as
Make: samsung
Model: GT-I9500