### PR TITLE
fixed bug in ApplySimilarity for control points

### DIFF
--- a/src/openMVG/sfm/sfm_data_transform.cpp
+++ b/src/openMVG/sfm/sfm_data_transform.cpp
@@ -41,12 +41,12 @@ void ApplySimilarity
       {
           prior->pose_center_ = sim(prior->pose_center_);
       }
-
-      // Transform the control points
-      for (auto & iterControlPoint : sfm_data.control_points)
-      {
-        iterControlPoint.second.X = sim(iterControlPoint.second.X);
-      }
+    }
+    
+    // Transform the control points
+    for (auto & iterControlPoint : sfm_data.control_points)
+    {
+      iterControlPoint.second.X = sim(iterControlPoint.second.X);
     }
   }
 }


### PR DESCRIPTION
The for loop that transforms control points was accidentally nested in previous for loop causing that each control point was transformed N times (where N is number of view priors)