### PR TITLE
Develop geodesy pose sensor

### DIFF
--- a/src/openMVG/sfm/sfm_data_BA_ceres.cpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.cpp
@@ -542,7 +542,8 @@ bool Bundle_Adjustment_Ceres::Adjust
         const sfm::ViewPriors * prior = dynamic_cast<sfm::ViewPriors*>(view_it.second.get());
         if (prior != nullptr && prior->b_use_pose_center_ && sfm_data.IsPoseAndIntrinsicDefined(prior))
         {
-          X_SfM.push_back( sfm_data.GetPoses().at(prior->id_pose).center() );
+          const Pose3 & sfm_pose = sfm_data.GetPoses().at(prior->id_pose);
+          X_SfM.push_back( sfm_pose.inverse()(prior->pose_sensor_transform_.center()) );
           X_GPS.push_back( prior->pose_center_ );
         }
       }

--- a/src/openMVG/sfm/sfm_data_BA_ceres.cpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.cpp
@@ -30,12 +30,18 @@ struct PoseCenterConstraintCostFunction
   Vec3 weight_;
   Vec3 pose_center_constraint_;
 
+  Vec3 pose_sensor_translation_;
+  Vec3 pose_sensor_rotation_;
+
   PoseCenterConstraintCostFunction
   (
     const Vec3 & center,
-    const Vec3 & weight
+    const Vec3 & weight,
+    const Pose3 & pose_sensor_transform = Pose3()
   ): weight_(weight), pose_center_constraint_(center)
   {
+      pose_sensor_translation_ = pose_sensor_transform.translation();
+      ceres::RotationMatrixToAngleAxis((const double*)pose_sensor_transform.rotation().data(), pose_sensor_rotation_.data());
   }
 
   template <typename T> bool
@@ -46,22 +52,54 @@ struct PoseCenterConstraintCostFunction
   )
   const
   {
-    // Compute camera center C = - R.transpose() * t;
     const T * cam_R = &cam_extrinsics[0];
     const T * cam_t = &cam_extrinsics[3];
-    const T cam_R_transpose[3] = {-cam_extrinsics[0], -cam_extrinsics[1], -cam_extrinsics[2]};
+    const T cam_R_transpose[3] = {-cam_R[0], -cam_R[1], -cam_R[2]};
 
-    T pose_center[3];
-    // Rotate the point according the camera rotation
-    ceres::AngleAxisRotatePoint(cam_R_transpose, cam_t, pose_center);
-    pose_center[0] *= T(-1);
-    pose_center[1] *= T(-1);
-    pose_center[2] *= T(-1);
+    const T sensor_R[3] = { T(pose_sensor_rotation_(0)), T(pose_sensor_rotation_(1)), T(pose_sensor_rotation_(2)) };
+    const T sensor_t[3] = { T(pose_sensor_translation_(0)), T(pose_sensor_translation_(1)), T(pose_sensor_translation_(2)) };
+    const T sensor_R_transpose[3] = {-sensor_R[0], -sensor_R[1], -sensor_R[2]};
 
 
-    residuals[0] = T(weight_[0]) * (pose_center[0] - T(pose_center_constraint_[0]));
-    residuals[1] = T(weight_[1]) * (pose_center[1] - T(pose_center_constraint_[1]));
-    residuals[2] = T(weight_[2]) * (pose_center[2] - T(pose_center_constraint_[2]));
+    // Here is a brief summary of what should happen below:
+    // Calculate sensor's position in world coordinate using camera extrinsics and use that value for residual
+    // ---------------
+    // step 1) C_sensor_in_camera_space = inv(R_sensor) * ([0 0 0] - t_sensor)
+    // step 2) C_sensor_in_world_space  = inv(R_camera) * (C_sensor_in_camera_space - t_camera)
+    // step 3) residual = weight * (C_sensor_in_world_space - pose_center_constraint)
+
+
+    // For validation I'll derive steps 1 and 2 in reverse. (the above is actually reverse and this is forward)
+    // C_sensor_in_camera_space = R_camera * C_sensor_in_world_space + t_camera
+    // [0 0 0] = R_sensor * C_sensor_in_camera_space + t_sensor
+
+
+    T C_sensor_in_camera_space[3];
+    T C_sensor_in_world_space[3];
+    T pt[3]; // used as temporary storage
+
+    // pt = -sensor_t
+    pt[0] = -sensor_t[0];
+    pt[1] = -sensor_t[1];
+    pt[2] = -sensor_t[2];
+
+    // step 1
+    // this is constant and should be computed in contructor
+    ceres::AngleAxisRotatePoint(sensor_R_transpose, pt, C_sensor_in_camera_space);
+
+    // pt = C_sensor_in_camera_space - t_camera
+    pt[0] = C_sensor_in_camera_space[0] - cam_t[0];
+    pt[1] = C_sensor_in_camera_space[1] - cam_t[1];
+    pt[2] = C_sensor_in_camera_space[2] - cam_t[2];
+
+    // step 2
+    ceres::AngleAxisRotatePoint(cam_R_transpose, pt, C_sensor_in_world_space);
+
+    // step 3
+    residuals[0] = T(weight_[0]) * (C_sensor_in_world_space[0] - T(pose_center_constraint_[0]));
+    residuals[1] = T(weight_[1]) * (C_sensor_in_world_space[1] - T(pose_center_constraint_[1]));
+    residuals[2] = T(weight_[2]) * (C_sensor_in_world_space[2] - T(pose_center_constraint_[2]));
+
     return true;
   }
 };
@@ -405,7 +443,7 @@ bool Bundle_Adjustment_Ceres::Adjust
         // Add the cost functor (distance from Pose prior to the SfM_Data Pose center)
         ceres::CostFunction * cost_function =
           new ceres::AutoDiffCostFunction<PoseCenterConstraintCostFunction, 3, 6>(
-            new PoseCenterConstraintCostFunction(prior->pose_center_, prior->center_weight_));
+            new PoseCenterConstraintCostFunction(prior->pose_center_, prior->center_weight_, prior->pose_sensor_transform_));
 
         problem.AddResidualBlock(cost_function, new ceres::HuberLoss(Square(pose_center_robust_fitting_error)), &map_poses[prior->id_view][0]);
       }

--- a/src/openMVG/sfm/sfm_view_priors.hpp
+++ b/src/openMVG/sfm/sfm_view_priors.hpp
@@ -6,12 +6,15 @@
 
 #pragma once
 
+#include "openMVG/geometry/pose3.hpp"
 #include "openMVG/numeric/numeric.h"
 #include "openMVG/sfm/sfm_view.hpp"
 #include <cereal/types/polymorphic.hpp>
 
 namespace openMVG {
 namespace sfm {
+
+using namespace openMVG::geometry;
 
 /**
 * @brief Define a View that contains optional Pose priors (pose and/or rotation)
@@ -37,7 +40,8 @@ struct ViewPriors : public View
       height
     ),
     b_use_pose_center_(false),
-    b_use_pose_rotation_(false)
+    b_use_pose_rotation_(false),
+    pose_sensor_transform_(Pose3())
   {
   }
 
@@ -52,6 +56,13 @@ struct ViewPriors : public View
     b_use_pose_center_  = true;
     center_weight_      = weight;
     pose_center_        = center;
+  }
+
+  void SetPoseSensorTransform(
+    const Pose3 & sensor_relative_pose
+  )
+  {
+    pose_sensor_transform_ = sensor_relative_pose;
   }
 
   void SetPoseRotationPrior
@@ -82,6 +93,9 @@ struct ViewPriors : public View
       const std::vector<double> vec = { pose_center_( 0 ), pose_center_( 1 ), pose_center_( 2 ) };
       ar( cereal::make_nvp( "center", vec ) );
     }
+
+    // Pose prior sensor transformation
+    ar( cereal::make_nvp( "pose_sensor_transform", pose_sensor_transform_ ) );
 
     // Pose rotation prior
     /*
@@ -125,6 +139,17 @@ struct ViewPriors : public View
       b_use_pose_center_ = false;
     }
 
+    // Pose prior sensor transformation
+    try
+    {
+      ar( cereal::make_nvp( "pose_sensor_transform", pose_sensor_transform_ ) );
+    }
+    catch( cereal::Exception e )
+    {
+      // if it fails just use a default settings
+      pose_sensor_transform_ = Pose3();
+    }
+
     // Pose rotation prior
     /*
     try
@@ -155,6 +180,10 @@ struct ViewPriors : public View
   bool b_use_pose_rotation_ = false; // Tell if the rotation prior must be used
   double rotation_weight_ = 1.0;
   Mat3 pose_rotation_;
+
+  // Pose prior sensor transformation
+  // Transformation from view to pose's center and rotation sensor (lever arm)
+  Pose3 pose_sensor_transform_;
 };
 
 } // namespace sfm


### PR DESCRIPTION
When considering pose prior, it's position is not perfectly aligned with view's actual position so it's important to take this into account. This pull request makes this possible. I think you refer to this offset as lever arm (as in robotics). If there are some changes that need to be done (especially regarding variable names and comments - my terminology might not be totally on spot and consistent).

I've observed a significant increase in final camera position using this offset and high precision priors.

```
gcp + pose prior (not considering offset)
- Final fitting error:
     min: 0.275869
     mean: 0.799997
     median: 0.572768
     max: 1.50386

gcp + pose prior (considering offset)
- Final fitting error:
     min: 0.00448192
     mean: 0.362217
     median: 0.343606
     max: 1.00708    

pose prior (not considering offset)
- Final fitting error:
     min: 0.0278407
     mean: 0.164822
     median: 0.157084
     max: 0.495048

pose prior (considering offset)
- Final fitting error:
     min: 2.61133e-005
     mean: 0.0570164
     median: 0.0515168
     max: 0.236921
```
