### PR TITLE
Added check if OpenCV is enabled when including KLT tracker

### DIFF
--- a/src/software/VO/main_VO.cpp
+++ b/src/software/VO/main_VO.cpp
@@ -11,7 +11,9 @@
 #include "software/VO/CGlWindow.hpp"
 #include "software/VO/Monocular_VO.hpp"
 #include "software/VO/Tracker.hpp"
+#if defined HAVE_OPENCV
 #include "software/VO/Tracker_opencv_klt.hpp"
+#endif
 #include "software/VO/Pose_Estimation.hpp"
 
 #include "third_party/cmdLine/cmdLine.h"


### PR DESCRIPTION
Hi @pmoulon ,

the small corrections adds a check in the VO code for presence of OpenCV when including KLT tracker. Without this the code does not compile (at least on my computer) when OpenCV is not installed. 

Cheers,
Klemen