### PR TITLE
[sfm] Allow passing z_near/z_far for each view to Frustum_Filter

### DIFF
--- a/src/openMVG/sfm/sfm_data_filters_frustum.cpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.cpp
@@ -23,8 +23,10 @@ using namespace openMVG::geometry::halfPlane;
 
 // Constructor
 Frustum_Filter::Frustum_Filter(const SfM_Data & sfm_data,
-  const double zNear, const double zFar)
+  const double zNear, const double zFar, const NearFarPlanesT & z_near_z_far)
 {
+  z_near_z_far_perView = z_near_z_far;
+
   //-- Init Z_Near & Z_Far for all valid views
   init_z_near_z_far_depth(sfm_data, zNear, zFar);
   const bool bComputed_Z = (zNear == -1. && zFar == -1.) && !sfm_data.structure.empty();
@@ -233,7 +235,8 @@ void Frustum_Filter::init_z_near_z_far_depth(const SfM_Data & sfm_data,
       const View * view = it->second.get();
       if (!sfm_data.IsPoseAndIntrinsicDefined(view))
         continue;
-      z_near_z_far_perView[view->id_view] = std::make_pair(zNear, zFar);
+      if (z_near_z_far_perView.find(view->id_view) == z_near_z_far_perView.end())
+        z_near_z_far_perView[view->id_view] = std::make_pair(zNear, zFar);
     }
   }
 }

--- a/src/openMVG/sfm/sfm_data_filters_frustum.hpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.hpp
@@ -27,7 +27,8 @@ public:
   (
     const SfM_Data & sfm_data,
     const double zNear = -1.,
-    const double zFar = -1.
+    const double zFar = -1.,
+    const NearFarPlanesT & z_near_z_far = NearFarPlanesT()
   );
 
   // Init a frustum for each valid views of the SfM scene


### PR DESCRIPTION
Hi,

This PR may be specific to my scenario, but this should not change anything for the previously supported use cases.
In my case, I already have `zNear`/`zFar` computed for each view, and I want to use these values for the frustum filtering. Unless I'm missing something, the current code either computes these values from the structure and view observations, or initializes them all to the default values given by the user. This PR provides a third option: the  `zNear`/`zFar` map can be provided by the user, and updated if necessary (e.g. if some views are missing, the user-provided  `zNear`/`zFar` are used).