### PR TITLE
[WIP][sfm] Add support for additional bounding volume filtering to Frustum_Filter

### DIFF
--- a/src/openMVG/geometry/frustum_box_intersection_test.cpp
+++ b/src/openMVG/geometry/frustum_box_intersection_test.cpp
@@ -38,6 +38,33 @@ TEST(box_point, intersection)
   EXPECT_FALSE( box.contains(Vec3(1,1,1)) );
 }
 
+TEST(box_box, intersection)
+{
+  double r = 1.;
+
+  // Test with a set of intersecting boxes
+  std::vector<HalfPlaneObject> boxes_ok;
+  for (int i=0; i < 6; ++i)
+  {
+    Vec3 center = Vec3::Zero();
+    center[i/2] += std::pow(-1, i%2) * r / 5.;
+    boxes_ok.emplace_back(Box(center, r));
+  }
+  EXPECT_TRUE( boxes_ok[0].intersect(boxes_ok[1]) );
+  EXPECT_TRUE( intersect(boxes_ok) );
+
+  // Test with a set of non-intersecting boxes
+  std::vector<HalfPlaneObject> boxes_ko;
+  for (int i=0; i < 6; ++i)
+  {
+    Vec3 center = Vec3::Zero();
+    center[i/2] += std::pow(-1, i%2) * 1.5 * r;
+    boxes_ko.emplace_back(Box(center, 1));
+  }
+  EXPECT_FALSE( boxes_ko[0].intersect(boxes_ko[1]) );
+  EXPECT_FALSE( intersect(boxes_ko) );
+}
+
 TEST(box_frustum, intersection)
 {
   const int focal = 1000;
@@ -64,6 +91,7 @@ TEST(box_frustum, intersection)
       const Frustum f (principal_Point*2, principal_Point*2, d._K[i], d._R[i], d._C[i]);
       EXPECT_TRUE(f.intersect(box));
       EXPECT_TRUE(box.intersect(f));
+      EXPECT_TRUE(intersect({f, box}));
 
       std::ostringstream os;
       os << i << "frust.ply";
@@ -91,6 +119,7 @@ TEST(box_frustum, intersection)
 
       EXPECT_TRUE(f.intersect(box));
       EXPECT_TRUE(box.intersect(f));
+      EXPECT_TRUE(intersect({f, box}));
     }
   }
 }
@@ -125,6 +154,7 @@ TEST(box_frustum, no_intersection)
       const Frustum f(principal_Point * 2, principal_Point * 2, d._K[i], d._R[i], d._C[i]);
       EXPECT_FALSE(f.intersect(box));
       EXPECT_FALSE(box.intersect(f));
+      EXPECT_FALSE(intersect({f, box}));
 
       std::ostringstream os;
       os << i << "frust.ply";
@@ -152,6 +182,7 @@ TEST(box_frustum, no_intersection)
 
       EXPECT_FALSE(f.intersect(box));
       EXPECT_FALSE(box.intersect(f));
+      EXPECT_FALSE(intersect({f, box}));
     }
   }
 }

--- a/src/openMVG/geometry/frustum_box_intersection_test.cpp
+++ b/src/openMVG/geometry/frustum_box_intersection_test.cpp
@@ -40,7 +40,7 @@ TEST(box_point, intersection)
 
 TEST(box_box, intersection)
 {
-  double r = 1.;
+  const double r = 1.;
 
   // Test with a set of intersecting boxes
   std::vector<HalfPlaneObject> boxes_ok;

--- a/src/openMVG/geometry/half_space_intersection.hpp
+++ b/src/openMVG/geometry/half_space_intersection.hpp
@@ -148,6 +148,34 @@ struct HalfPlaneObject
   }
 };
 
+/**
+* @brief Test if multiple defined 'volume' intersect
+* @param hplanes A vector of HalfPlaneObject
+* @retval true If a non-empty intersection exists
+* @retval false If there's no intersection
+*/
+inline bool
+intersect
+(
+  const std::vector<HalfPlaneObject> & hplanes
+)
+{
+  // Compute the total number of half-planes
+  std::size_t s = 0;
+  std::for_each(hplanes.cbegin(), hplanes.cend(),
+                [&s](const HalfPlaneObject & hp) { s += hp.planes.size(); });
+
+  // Concatenate the half-planes and see if an intersection exists
+  std::vector<Half_plane> vec_planes;
+  vec_planes.reserve(s);
+  for (const HalfPlaneObject & hp : hplanes)
+  {
+    vec_planes.insert(vec_planes.end(), hp.planes.cbegin(), hp.planes.cend());
+  }
+
+  return halfPlane::isNotEmpty(vec_planes);
+}
+
 } // namespace halfPlane
 } // namespace geometry
 } // namespace openMVG

--- a/src/openMVG/sfm/sfm_data_filters_frustum.cpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.cpp
@@ -23,8 +23,10 @@ using namespace openMVG::geometry::halfPlane;
 
 // Constructor
 Frustum_Filter::Frustum_Filter(const SfM_Data & sfm_data,
-  const double zNear, const double zFar)
+  const double zNear, const double zFar, const NearFarPlanesT & z_near_z_far)
 {
+  z_near_z_far_perView = z_near_z_far;
+
   //-- Init Z_Near & Z_Far for all valid views
   init_z_near_z_far_depth(sfm_data, zNear, zFar);
   const bool bComputed_Z = (zNear == -1. && zFar == -1.) && !sfm_data.structure.empty();
@@ -233,7 +235,8 @@ void Frustum_Filter::init_z_near_z_far_depth(const SfM_Data & sfm_data,
       const View * view = it->second.get();
       if (!sfm_data.IsPoseAndIntrinsicDefined(view))
         continue;
-      z_near_z_far_perView[view->id_view] = std::make_pair(zNear, zFar);
+      if (z_near_z_far_perView.find(view->id_view) == z_near_z_far_perView.end())
+        z_near_z_far_perView[view->id_view] = std::make_pair(zNear, zFar);
     }
   }
 }

--- a/src/openMVG/sfm/sfm_data_filters_frustum.cpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.cpp
@@ -24,9 +24,8 @@ using namespace openMVG::geometry::halfPlane;
 // Constructor
 Frustum_Filter::Frustum_Filter(const SfM_Data & sfm_data,
   const double zNear, const double zFar, const NearFarPlanesT & z_near_z_far)
+  : z_near_z_far_perView(z_near_z_far)
 {
-  z_near_z_far_perView = z_near_z_far;
-
   //-- Init Z_Near & Z_Far for all valid views
   init_z_near_z_far_depth(sfm_data, zNear, zFar);
   const bool bComputed_Z = (zNear == -1. && zFar == -1.) && !sfm_data.structure.empty();
@@ -98,7 +97,7 @@ Pair_Set Frustum_Filter::getFrustumIntersectionPairs(
 
     for (size_t j = i+1; j < viewIds.size(); ++j)
     {
-      objects[bounding_volume.size() + 1] = frustum_perView.at(viewIds[j]);
+      objects.back() = frustum_perView.at(viewIds[j]);
       if (intersect(objects))
       {
 #ifdef OPENMVG_USE_OPENMP

--- a/src/openMVG/sfm/sfm_data_filters_frustum.hpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.hpp
@@ -9,6 +9,7 @@
 #define OPENMVG_SFM_SFM_DATA_FILTERS_FRUSTUM_HPP
 
 #include "openMVG/geometry/frustum.hpp"
+#include "openMVG/geometry/half_space_intersection.hpp"
 #include "openMVG/types.hpp"
 
 namespace openMVG {
@@ -34,8 +35,13 @@ public:
   // Init a frustum for each valid views of the SfM scene
   void initFrustum(const SfM_Data & sfm_data);
 
-  // Return intersecting View frustum pairs
-  Pair_Set getFrustumIntersectionPairs() const;
+  // Return intersecting View frustum pairs. An optional bounding volume
+  // defined as a vector of half-plane objects can also be provided to further
+  // limit the intersection area.
+  Pair_Set getFrustumIntersectionPairs(
+      const std::vector<HalfPlaneObject>& bounding_volume
+        = std::vector<HalfPlaneObject>()
+  ) const;
 
   // Export defined frustum in PLY file for viewing
   bool export_Ply(const std::string & filename) const;

--- a/src/openMVG/sfm/sfm_data_filters_frustum.hpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.hpp
@@ -27,7 +27,8 @@ public:
   (
     const SfM_Data & sfm_data,
     const double zNear = -1.,
-    const double zFar = -1.
+    const double zFar = -1.,
+    const NearFarPlanesT & z_near_z_far = NearFarPlanesT()
   );
 
   // Init a frustum for each valid views of the SfM scene


### PR DESCRIPTION
This PR contains the following changes:
- add a new `intersect` method that takes a vector of half-plane objects.
- add a new box-box test that shows how it can be used for multiple objects (6 boxes). Existing tests have also been updated.
- use that method to add support for bounding volumes to `Frustum_Filter::getFrustumIntersectionPairs`: it now takes an optional vector of half-plane objects used in the intersection check. For example, one can use a bounding box to only keep views whose frustums intersect within that bounding box.

This is a follow-up of #743, and will be rebased once that PR is merged (hence the `[WIP]` tag).