### PR TITLE
[build] fix build for ARM

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,7 +91,8 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmakeFindModules)
 include(OptimizeForArchitecture)
 OptimizeForArchitecture()
-if (SSE2_FOUND OR TARGET_ARCHITECTURE STREQUAL "native")
+
+if (SSE2_FOUND)
   if (MSVC AND NOT ${CMAKE_CL_64})
     add_definitions(/arch:SSE2)
   endif (MSVC AND NOT ${CMAKE_CL_64})

--- a/src/nonFree/sift/vl/host.c
+++ b/src/nonFree/sift/vl/host.c
@@ -399,6 +399,7 @@ _vl_cpuid (vl_int32* info, int function)
 
 #endif
 
+#if defined(HAS_CPUID)
 void
 _vl_x86cpu_info_init (VlX86CpuInfo *self)
 {
@@ -420,6 +421,7 @@ _vl_x86cpu_info_init (VlX86CpuInfo *self)
     self->hasSSE42 = info[2] & (1 << 20) ;
   }
 }
+#endif
 
 char *
 _vl_x86cpu_info_to_string_copy (VlX86CpuInfo const *self)


### PR DESCRIPTION
There were two issues that occurred while compiling on the Jetson TX1 (64-bit ARM architecture):

1. undefined reference to `_vl_cpuid`.  This was originally mentioned in https://github.com/openMVG/openMVG/issues/488 and fixed in https://github.com/openMVG/openMVG/commit/cbc35f63293ea053a85916a45441143f2727d011, but then the issue still persists.  I re-added this solution to the `host.c`.  I also submitted https://github.com/vlfeat/vlfeat/pull/150 to address the issue in vlfeat.

2. CMake attempts to use SSE even when the architecture does not support it.  I fixed this in `CMakeLists.txt` by removing the OR clause.  Is there any reason why SSE should be used when `SSE2_FOUND` is not defined?