### PR TITLE
Geometry IO ply

### DIFF
--- a/src/openMVG/geometry/CMakeLists.txt
+++ b/src/openMVG/geometry/CMakeLists.txt
@@ -6,3 +6,5 @@ UNIT_TEST(openMVG half_space_intersection "openMVG_numeric;${CLP_LIBRARIES};${CO
 UNIT_TEST(openMVG frustum_intersection "openMVG_numeric;openMVG_multiview_test_data;openMVG_multiview;${CLP_LIBRARIES};${COINUTILS_LIBRARY};${OSI_LIBRARY}")
 
 UNIT_TEST(openMVG frustum_box_intersection "openMVG_numeric;openMVG_multiview_test_data;openMVG_multiview;${CLP_LIBRARIES};${COINUTILS_LIBRARY};${OSI_LIBRARY}")
+
+add_subdirectory( io )

--- a/src/openMVG/geometry/io/CMakeLists.txt
+++ b/src/openMVG/geometry/io/CMakeLists.txt
@@ -1,0 +1,11 @@
+set( OPENMVG_GEOMETRY_IO_SRCS ply.cpp )
+set( OPENMVG_GEOMETRY_IO_HDRS ply.hpp )
+
+add_library(openMVG_geometry_io ${OPENMVG_GEOMETRY_IO_SRCS} ${OPENMVG_GEOMETRY_IO_HDRS} )
+set_target_properties(openMVG_geometry_io PROPERTIES SOVERSION ${OPENMVG_VERSION_MAJOR} VERSION "${OPENMVG_VERSION_MAJOR}.${OPENMVG_VERSION_MINOR}")
+install(TARGETS openMVG_geometry_io DESTINATION lib EXPORT openMVG-targets)
+set_property(TARGET openMVG_geometry_io PROPERTY FOLDER OpenMVG/OpenMVG)
+
+
+UNIT_TEST(openMVG ply "openMVG_numeric;openMVG_geometry_io")
+

--- a/src/openMVG/geometry/io/ply.cpp
+++ b/src/openMVG/geometry/io/ply.cpp
@@ -1,0 +1,430 @@
+#include "ply.hpp"
+#include "ply_helper.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <functional>
+#include <locale>
+
+namespace openMVG
+{
+namespace geometry
+{
+  namespace io
+  {
+    /**
+    * @brief Export a set of points to a PLY file 
+    * @param pts A list of points 
+    * @param nor A list of normal (one for each points) 
+    * @param col A list of color (one for each points) 
+    * @param path Path of the file to save 
+    * @param binary Indicate if the file should be written to binary format 
+    * @retval true if load is successful 
+    * @retval false if load fails 
+    */
+    bool PLYWrite( const std::vector<Vec3> &pts,
+                   const std::vector<Vec3> *nor,
+                   const std::vector<Vec3uc> *col,
+                   const std::string &path,
+                   const bool binary )
+    {
+      std::ofstream file( path );
+      if ( !file )
+      {
+        return false;
+      }
+
+      // Write header
+      file << "ply" << std::endl;
+      if ( binary )
+      {
+        file << "format binary_little_endian 1.0" << std::endl;
+      }
+      else
+      {
+        file << "format ascii 1.0" << std::endl;
+      }
+
+      const size_t nb_vert = pts.size();
+      file << "element vertex " << nb_vert << std::endl;
+      file << "property double x" << std::endl;
+      file << "property double y" << std::endl;
+      file << "property double z" << std::endl;
+      if ( nor )
+      {
+        file << "property double nx" << std::endl;
+        file << "property double ny" << std::endl;
+        file << "property double nz" << std::endl;
+      }
+      if ( col )
+      {
+        file << "property uchar red" << std::endl;
+        file << "property uchar green" << std::endl;
+        file << "property uchar blue" << std::endl;
+      }
+      file << "end_header" << std::endl;
+
+      // now write the points
+      EndianAgnosticWriter<PLY_ASCII> asc_writer;
+      EndianAgnosticWriter<PLY_LITTLE_ENDIAN> le_writer;
+
+      for ( size_t id_vert = 0; id_vert < nb_vert; ++id_vert )
+      {
+        if ( binary )
+        {
+          le_writer.Write( file, pts[ id_vert ] );
+          if ( nor )
+          {
+            le_writer.Write( file, ( *nor )[ id_vert ] );
+          }
+          if ( col )
+          {
+            le_writer.Write( file, ( *col )[ id_vert ] );
+          }
+        }
+        else
+        {
+          asc_writer.Write( file, pts[ id_vert ] );
+          if ( nor )
+          {
+            asc_writer.Write( file, ( *nor )[ id_vert ] );
+          }
+          if ( col )
+          {
+            asc_writer.Write( file, ( *col )[ id_vert ] );
+          }
+          file << std::endl;
+        }
+      }
+      return true;
+    }
+
+    /**
+    * @brief Export a set of points to a PLY file 
+    * @param pts A list of points 
+    * @param path Path of the file to save 
+    * @param binary Indicate if the file should be written to binary format 
+    * @retval true if load is successful 
+    * @retval false if load fails 
+    */
+    bool PLYWrite( const std::vector<Vec3> &pts,
+                   const std::string &path,
+                   const bool binary )
+    {
+      return PLYWrite( pts, nullptr, nullptr, path, binary );
+    }
+
+    /**
+    * @brief Load a ply file and gets is content points 
+    * @param path Path of the file to load 
+    * @param[out] pts The list of points in the given file 
+    * @retval true if load is successful 
+    * @retval false if load fails 
+    */
+    bool PLYRead( const std::string &path,
+                  std::vector<Vec3> &pts )
+    {
+      return PLYRead( path, pts, nullptr, nullptr );
+    }
+
+    // trim from start
+    static inline std::string &ltrim( std::string &s )
+    {
+      s.erase( s.begin(), std::find_if( s.begin(), s.end(),
+                                        std::not1( std::ptr_fun<int, int>( std::isspace ) ) ) );
+      return s;
+    }
+
+    // trim from end
+    static inline std::string &rtrim( std::string &s )
+    {
+      s.erase( std::find_if( s.rbegin(), s.rend(),
+                             std::not1( std::ptr_fun<int, int>( std::isspace ) ) )
+                   .base(),
+               s.end() );
+      return s;
+    }
+
+    // trim from both ends
+    static inline std::string &trim( std::string &s )
+    {
+      return ltrim( rtrim( s ) );
+    }
+
+    // from : http://stackoverflow.com/questions/53849/how-do-i-tokenize-a-string-in-c
+    static inline std::vector<std::string> tokenize( const std::string &str )
+    {
+      // construct a stream from the string
+      std::stringstream strstr( str );
+
+      // use stream iterators to copy the stream to the vector as whitespace separated strings
+      std::istream_iterator<std::string> it( strstr );
+      std::istream_iterator<std::string> end;
+      std::vector<std::string> results( it, end );
+
+      return results;
+    }
+
+    /**
+    * @brief Load a ply file and gets is content points 
+    * @param path Path of the file to load 
+    * @param[out] pts The list of points in the given file 
+    * @param[out] nor The list of normals in the given file 
+    * @param[out] col The list of colors in the given file 
+    * @note If nor or col are equal to nullptr, nothing is retrived 
+    * @note If file does not contains nor or col, corresponding vectors will be empty  
+    * @retval true if load is successful 
+    * @retval false if load fails 
+    */
+    bool PLYRead( const std::string &path,
+                  std::vector<Vec3> &pts,
+                  std::vector<Vec3> *nor,
+                  std::vector<Vec3uc> *col )
+    {
+      std::ifstream file( path );
+      if ( !file )
+      {
+        return false;
+      }
+
+      // Read header
+      std::string line;
+      std::getline( file, line );
+      if ( trim( line ) != "ply" )
+      {
+        return false;
+      }
+
+      int nb_coord_pts = 0;
+      int nb_coord_nor = 0;
+      int nb_coord_col = 0;
+
+      size_t property_pts_size = 0;
+      size_t property_nor_size = 0;
+      size_t property_col_size = 0;
+
+      size_t nb_elt = 0;
+
+      ply_endianness endianness = PLY_ASCII;
+
+      while ( 1 )
+      {
+        std::getline( file, line );
+        std::vector<std::string> tokens = tokenize( line );
+        if ( tokens.size() == 0 )
+        {
+          continue;
+        }
+        if ( tokens[ 0 ] == "comment" )
+        {
+          continue;
+        }
+        else if ( tokens[ 0 ] == "format" )
+        {
+          if ( tokens.size() > 1 )
+          {
+            if ( tokens[ 1 ] == "ascii" )
+            {
+              endianness = PLY_ASCII;
+            }
+            else if ( tokens[ 1 ] == "binary_little_endian" )
+            {
+              endianness = PLY_LITTLE_ENDIAN;
+            }
+            else if ( tokens[ 1 ] == "binary_big_endian" )
+            {
+              endianness = PLY_BIG_ENDIAN;
+            }
+            else
+            {
+              return false;
+            }
+          }
+          else
+          {
+            return false;
+          }
+        }
+        else if ( tokens[ 0 ] == "element" )
+        {
+          if ( tokens.size() > 2 )
+          {
+            if ( tokens[ 1 ] == "vertex" )
+            {
+              Convert( tokens[ 2 ], nb_elt );
+            }
+          }
+          else
+          {
+            return false;
+          }
+        }
+        else if ( tokens[ 0 ] == "property" )
+        {
+          size_t current_size;
+          if ( tokens.size() > 2 )
+          {
+            // read size
+            const std::string type = tokens[ 1 ];
+            if ( type == "uchar" || type == "char" )
+            {
+              current_size = 1;
+            }
+            else if ( type == "short" || type == "ushort" )
+            {
+              current_size = 2;
+            }
+            else if ( type == "int" || type == "uint" )
+            {
+              current_size = 4;
+            }
+            else if ( type == "float" )
+            {
+              current_size = 4;
+            }
+            else if ( type == "double" )
+            {
+              current_size = 8;
+            }
+            // read kind (x,y,z, nx,ny,nz, red, green, blue )
+            const std::string item = tokens[ 2 ];
+            if ( item == "x" || item == "y" || item == "z" )
+            {
+              property_pts_size = current_size;
+              ++nb_coord_pts;
+            }
+            else if ( item == "nx" || item == "ny" || item == "nz" )
+            {
+              property_nor_size = current_size;
+              ++nb_coord_nor;
+            }
+            else if ( item == "red" || item == "green" || item == "blue" )
+            {
+              property_col_size = current_size;
+              ++nb_coord_col;
+            }
+          }
+        }
+        else if ( tokens[ 0 ] == "end_header" )
+        {
+          break;
+        }
+      }
+
+      if ( nb_coord_pts != 3 )
+      {
+        std::cout << "nb_coord_pts != 3" << std::endl;
+        return false;
+      }
+      if ( !( nb_coord_nor == 0 || nb_coord_nor == 3 ) )
+      {
+        std::cout << "!( nb_coord_nor == 0 || nb_coord_nor == 3 )" << __LINE__ << std::endl;
+        return false;
+      }
+      if ( !( nb_coord_col == 0 || nb_coord_col == 3 ) )
+      {
+        std::cout << "!( nb_coord_col == 0 || nb_coord_col == 3 )" << __LINE__ << std::endl;
+        return false;
+      }
+      if ( nb_elt == 0 )
+      {
+        std::cout << "nb_elt == 0" << __LINE__ << std::endl;
+        return false;
+      }
+      if ( nb_coord_pts == 3 && property_pts_size == 0 )
+      {
+        std::cout << "nb_coord_pts == 3 && property_pts_size == 0" << __LINE__ << std::endl;
+        return false;
+      }
+      if ( nb_coord_col == 3 && property_col_size == 0 )
+      {
+        std::cout << "nb_coord_col == 3 && property_col_size == 0" << __LINE__ << std::endl;
+        return false;
+      }
+      if ( nb_coord_nor == 3 && property_nor_size == 0 )
+      {
+        std::cout << "nb_coord_nor == 3 && property_nor_size == 0" << __LINE__ << std::endl;
+        return false;
+      }
+
+      // resize points
+      pts.resize( nb_elt );
+      if ( nor )
+      {
+        if ( nb_coord_nor == 3 )
+        {
+          nor->resize( nb_elt );
+        }
+        else
+        {
+          nor->clear();
+        }
+      }
+
+      if ( col )
+      {
+        if ( nb_coord_col == 3 )
+        {
+          col->resize( nb_elt );
+        }
+        else
+        {
+          col->clear();
+        }
+      }
+
+      EndianAgnosticReader<PLY_ASCII> ascii_reader;
+      EndianAgnosticReader<PLY_LITTLE_ENDIAN> le_reader;
+      EndianAgnosticReader<PLY_BIG_ENDIAN> be_reader;
+
+      // now read the points
+      for ( size_t id_point = 0; id_point < nb_elt; ++id_point )
+      {
+        if ( endianness == PLY_ASCII )
+        {
+          ascii_reader.Read( file, pts[ id_point ] );
+          if ( nor && nb_coord_nor > 0 )
+          {
+            ascii_reader.Read( file, ( *nor )[ id_point ] );
+          }
+          if ( col && nb_coord_col > 0 )
+          {
+            ascii_reader.Read( file, ( *col )[ id_point ] );
+          }
+          // Skip everything until
+          std::string tmp;
+          std::getline( file, tmp );
+        }
+        else if ( endianness == PLY_LITTLE_ENDIAN )
+        {
+          le_reader.Read( file, pts[ id_point ] );
+          if ( nor && nb_coord_pts > 0 )
+          {
+            le_reader.Read( file, ( *nor )[ id_point ] );
+          }
+          if ( col && nb_coord_col > 0 )
+          {
+            le_reader.Read( file, ( *col )[ id_point ] );
+          }
+        }
+        else if ( endianness == PLY_BIG_ENDIAN )
+        {
+          be_reader.Read( file, pts[ id_point ] );
+          if ( nor && nb_coord_pts > 0 )
+          {
+            be_reader.Read( file, ( *nor )[ id_point ] );
+          }
+          if ( col && nb_coord_col > 0 )
+          {
+            be_reader.Read( file, ( *col )[ id_point ] );
+          }
+        }
+      }
+
+      return true;
+    }
+
+  } // namespace io
+} // namespace geometry
+} // namespace openMVG

--- a/src/openMVG/geometry/io/ply.hpp
+++ b/src/openMVG/geometry/io/ply.hpp
@@ -1,0 +1,73 @@
+#ifndef OPENMVG_GEOMETRY_IO_PLY_HPP
+#define OPENMVG_GEOMETRY_IO_PLY_HPP
+
+#include "openMVG/numeric/numeric.h"
+
+#include <string>
+#include <vector>
+
+namespace openMVG
+{
+namespace geometry
+{
+  namespace io
+  {
+    /**
+    * @brief Export a set of points to a PLY file 
+    * @param pts A list of points 
+    * @param path Path of the file to save 
+    * @param binary Indicate if the file should be written to binary format 
+    * @retval true if load is successful 
+    * @retval false if load fails 
+    */
+    bool PLYWrite( const std::vector<Vec3> &pts,
+                   const std::string &path,
+                   const bool binary = true );
+
+    /**
+    * @brief Export a set of points to a PLY file 
+    * @param pts A list of points 
+    * @param nor A list of normal (one for each points) 
+    * @param col A list of color (one for each points) 
+    * @param path Path of the file to save 
+    * @param binary Indicate if the file should be written to binary format 
+    * @retval true if load is successful 
+    * @retval false if load fails 
+    */
+    bool PLYWrite( const std::vector<Vec3> &pts,
+                   const std::vector<Vec3> *nor,
+                   const std::vector<Vec3uc> *col,
+                   const std::string &path,
+                   const bool binary = true );
+
+    /**
+    * @brief Load a ply file and gets is content points 
+    * @param path Path of the file to load 
+    * @param[out] pts The list of points in the given file 
+    * @retval true if load is successful 
+    * @retval false if load fails 
+    */
+    bool PLYRead( const std::string &path,
+                  std::vector<Vec3> &pts );
+
+    /**
+    * @brief Load a ply file and gets is content points 
+    * @param path Path of the file to load 
+    * @param[out] pts The list of points in the given file 
+    * @param[out] nor The list of normals in the given file 
+    * @param[out] col The list of colors in the given file 
+    * @note If nor or col are equal to nullptr, nothing is retrived 
+    * @note If file does not contains nor or col, corresponding vectors will be empty  
+    * @retval true if load is successful 
+    * @retval false if load fails 
+    */
+    bool PLYRead( const std::string &path,
+                  std::vector<Vec3> &pts,
+                  std::vector<Vec3> *nor,
+                  std::vector<Vec3uc> *col );
+
+  } // namespace io
+} // namespace geometry
+} // namespace openMVG
+
+#endif

--- a/src/openMVG/geometry/io/ply_helper.hpp
+++ b/src/openMVG/geometry/io/ply_helper.hpp
@@ -1,0 +1,410 @@
+#ifndef OPENMVG_GEOMETRY_IO_PLY_HELPER_HPP
+#define OPENMVG_GEOMETRY_IO_PLY_HELPER_HPP
+
+#include "openMVG/numeric/numeric.h"
+
+#include <fstream>
+
+namespace openMVG
+{
+namespace geometry
+{
+  namespace io
+  {
+    /**
+    * @brief Store different kind of endianess that can be found on a PLY file 
+    */
+    enum ply_endianness
+    {
+      PLY_ASCII,
+      PLY_BIG_ENDIAN,
+      PLY_LITTLE_ENDIAN
+    };
+
+    /**
+    * @brief Compute runtime endianess 
+    * @return Current system endianess 
+    */
+    static inline ply_endianness GetSystemEndianness()
+    {
+      short int tmp = 0x1;
+      char *first   = (char *)&tmp;
+      return ( first[ 0 ] == 1 ) ? PLY_LITTLE_ENDIAN : PLY_BIG_ENDIAN;
+    }
+
+    /**
+    * @brief Fuction used to swap bytes (from LE to BE)
+    * @param val Value to inverse 
+    */
+    template <typename T>
+    T ByteSwap( T val )
+    {
+      T retVal;
+      char *pVal    = (char *)&val;
+      char *pRetVal = (char *)&retVal;
+      int size      = sizeof( T );
+      for ( int i = 0; i < size; i++ )
+      {
+        pRetVal[ size - 1 - i ] = pVal[ i ];
+      }
+
+      return retVal;
+    }
+
+    /**
+    * @brief Class used to write a value using a specified PLY endianness 
+    */
+    template <int Endianness>
+    struct EndianAgnosticWriter
+    {
+    public:
+      /**
+      * @brief Ctr 
+      */
+      EndianAgnosticWriter();
+
+      /**
+      * @brief Write a 3d vector of double in a file 
+      * @param file File in which data will be written 
+      * @param vec vector to write 
+      */
+      void Write( std::ofstream &file, const Vec3 &vec );
+
+      /**
+      * @brief Write a 3d vector of unsigned char in a file 
+      * @param file File in which data will be written 
+      * @param vec vector to write 
+      */
+      void Write( std::ofstream &file, const Vec3uc &vec );
+
+    private:
+      /// Current system endianess
+      ply_endianness m_system_endianness;
+    };
+
+    // Specialization for ascii
+    template <>
+    struct EndianAgnosticWriter<PLY_ASCII>
+    {
+    public:
+      /**
+      * @brief Ctr 
+      */
+      EndianAgnosticWriter()
+          : m_system_endianness( GetSystemEndianness() )
+      {
+      }
+
+      /**
+      * @brief Write a 3d vector of double in a file 
+      * @param file File in which data will be written 
+      * @param vec vector to write 
+      */
+      void Write( std::ofstream &file, const Vec3 &vec )
+      {
+        file << vec[ 0 ] << " " << vec[ 1 ] << " " << vec[ 2 ] << " ";
+      }
+
+      /**
+      * @brief Write a 3d vector of unsigned char in a file 
+      * @param file File in which data will be written 
+      * @param vec vector to write 
+      */
+      void Write( std::ofstream &file, const Vec3uc &vec )
+      {
+        file << (int)vec[ 0 ] << " " << (int)vec[ 1 ] << " " << (int)vec[ 2 ] << " ";
+      }
+
+    private:
+      /// Current system endianness
+      ply_endianness m_system_endianness;
+    };
+
+    template <>
+    struct EndianAgnosticWriter<PLY_LITTLE_ENDIAN>
+    {
+    public:
+      /**
+      * @brief Ctr 
+      */
+      EndianAgnosticWriter()
+          : m_system_endianness( GetSystemEndianness() )
+      {
+      }
+
+      /**
+      * @brief Write a 3d vector of double in a file 
+      * @param file File in which data will be written 
+      * @param vec vector to write 
+      */
+      void Write( std::ofstream &file, const Vec3 &vec )
+      {
+        if ( m_system_endianness == PLY_LITTLE_ENDIAN )
+        {
+          // No conversion
+          file.write( reinterpret_cast<const char *>( vec.data() ), sizeof( Vec3 ) );
+        }
+        else
+        {
+          // Conversion
+          const Vec3 r( ByteSwap( vec[ 0 ] ), ByteSwap( vec[ 1 ] ), ByteSwap( vec[ 2 ] ) );
+          file.write( reinterpret_cast<const char *>( r.data() ), sizeof( Vec3 ) );
+        }
+      }
+
+      /**
+      * @brief Write a 3d vector of unsigned char in a file 
+      * @param file File in which data will be written 
+      * @param vec vector to write 
+      */
+      void Write( std::ofstream &file, const Vec3uc &vec )
+      {
+        // No reverse because sizeof char == 1
+        file.write( reinterpret_cast<const char *>( vec.data() ), sizeof( Vec3uc ) );
+      }
+
+    private:
+      /// Current system endianness
+      ply_endianness m_system_endianness;
+    };
+
+    template <>
+    struct EndianAgnosticWriter<PLY_BIG_ENDIAN>
+    {
+    public:
+      /**
+      * @brief Ctr 
+      */
+      EndianAgnosticWriter()
+          : m_system_endianness( GetSystemEndianness() )
+      {
+      }
+
+      /**
+      * @brief Write a 3d vector of double in a file 
+      * @param file File in which data will be written 
+      * @param vec vector to write 
+      */
+      void Write( std::ofstream &file, const Vec3 &vec )
+      {
+        if ( m_system_endianness == PLY_BIG_ENDIAN )
+        {
+          // No conversion
+          file.write( reinterpret_cast<const char *>( vec.data() ), sizeof( Vec3 ) );
+        }
+        else
+        {
+          // Conversion
+          const Vec3 r( ByteSwap( vec[ 0 ] ), ByteSwap( vec[ 1 ] ), ByteSwap( vec[ 2 ] ) );
+          file.write( reinterpret_cast<const char *>( r.data() ), sizeof( Vec3 ) );
+        }
+      }
+
+      /**
+      * @brief Write a 3d vector of unsigned char in a file 
+      * @param file File in which data will be written 
+      * @param vec vector to write 
+      */
+      void Write( std::ofstream &file, const Vec3uc &vec )
+      {
+        // No reverse because sizeof char == 1
+        file.write( reinterpret_cast<const char *>( vec.data() ), sizeof( Vec3uc ) );
+      }
+
+    private:
+      /// Current system endianness
+      ply_endianness m_system_endianness;
+    };
+
+    template <typename T>
+    void Convert( const std::string &str, T &val )
+    {
+      std::stringstream sstr( str );
+      sstr >> val;
+    }
+
+    /**
+    * @brief Class used to read Vector data in agnostic way  
+    */
+    template <int Endianness>
+    class EndianAgnosticReader
+    {
+    public:
+      /**
+        * @brief ctr 
+        */
+      EndianAgnosticReader();
+
+      /**
+        * @brief Read vector data in double format 
+        * @param file Stream in which data is read 
+        * @param[out] vec output vector 
+        */
+      void Read( std::ifstream &file, Vec3 &vec );
+
+      /**
+        * @brief Read vector data in unsigned char format 
+        * @param file Stream in which data is read 
+        * @param[out] vec output vector 
+        */
+      void Read( std::ifstream &file, Vec3uc &vec );
+
+    private:
+      /// Current system
+      ply_endianness m_system_endianness;
+    };
+
+    /**
+    * @brief Class used to read Vector data in agnostic way  
+    * -> Specialization for ascii data 
+    */
+    template <>
+    class EndianAgnosticReader<PLY_ASCII>
+    {
+    public:
+      /**
+        * @brief ctr 
+        */
+      EndianAgnosticReader()
+          : m_system_endianness( GetSystemEndianness() )
+      {
+      }
+
+      /**
+        * @brief Read vector data in double format 
+        * @param file Stream in which data is read 
+        * @param[out] vec output vector 
+        */
+      void Read( std::ifstream &file, Vec3 &vec )
+      {
+        double x, y, z;
+        file >> x >> y >> z;
+        vec = Vec3( x, y, z );
+      }
+
+      /**
+        * @brief Read vector data in unsigned char format 
+        * @param file Stream in which data is read 
+        * @param[out] vec output vector 
+        */
+      void Read( std::ifstream &file, Vec3uc &vec )
+      {
+        int a, b, c;
+        file >> a >> b >> c;
+        vec = Vec3uc( a, b, c );
+      }
+
+    private:
+      /// Current system
+      ply_endianness m_system_endianness;
+    };
+
+    /**
+    * @brief Class used to read Vector data in agnostic way  
+    * -> Specialization for ascii data 
+    */
+    template <>
+    class EndianAgnosticReader<PLY_LITTLE_ENDIAN>
+    {
+    public:
+      /**
+        * @brief ctr 
+        */
+      EndianAgnosticReader()
+          : m_system_endianness( GetSystemEndianness() )
+      {
+      }
+
+      /**
+        * @brief Read vector data in double format 
+        * @param file Stream in which data is read 
+        * @param[out] vec output vector 
+        */
+      void Read( std::ifstream &file, Vec3 &vec )
+      {
+        double data[ 3 ];
+        file.read( reinterpret_cast<char *>( data ), 3 * sizeof( double ) );
+
+        if ( m_system_endianness != PLY_LITTLE_ENDIAN )
+        {
+          data[ 0 ] = ByteSwap( data[ 0 ] );
+          data[ 1 ] = ByteSwap( data[ 1 ] );
+          data[ 2 ] = ByteSwap( data[ 2 ] );
+        }
+        vec = Vec3( data[ 0 ], data[ 1 ], data[ 2 ] );
+      }
+
+      /**
+        * @brief Read vector data in unsigned char format 
+        * @param file Stream in which data is read 
+        * @param[out] vec output vector 
+        */
+      void Read( std::ifstream &file, Vec3uc &vec )
+      {
+        unsigned char data[ 3 ];
+        file.read( reinterpret_cast<char *>( data ), 3 * sizeof( unsigned char ) );
+        vec = Vec3uc( data[ 0 ], data[ 1 ], data[ 2 ] );
+      }
+
+    private:
+      /// Current system
+      ply_endianness m_system_endianness;
+    };
+
+    /**
+    * @brief Class used to read Vector data in agnostic way  
+    * -> Specialization for ascii data 
+    */
+    template <>
+    class EndianAgnosticReader<PLY_BIG_ENDIAN>
+    {
+    public:
+      /**
+        * @brief ctr 
+        */
+      EndianAgnosticReader()
+          : m_system_endianness( GetSystemEndianness() )
+      {
+      }
+
+      /**
+        * @brief Read vector data in double format 
+        * @param file Stream in which data is read 
+        * @param[out] vec output vector 
+        */
+      void Read( std::ifstream &file, Vec3 &vec )
+      {
+        double data[ 3 ];
+        file.read( reinterpret_cast<char *>( data ), 3 * sizeof( double ) );
+
+        if ( m_system_endianness != PLY_BIG_ENDIAN )
+        {
+          data[ 0 ] = ByteSwap( data[ 0 ] );
+          data[ 1 ] = ByteSwap( data[ 1 ] );
+          data[ 2 ] = ByteSwap( data[ 2 ] );
+        }
+        vec = Vec3( data[ 0 ], data[ 1 ], data[ 2 ] );
+      }
+
+      /**
+        * @brief Read vector data in unsigned char format 
+        * @param file Stream in which data is read 
+        * @param[out] vec output vector 
+        */
+      void Read( std::ifstream &file, Vec3uc &vec )
+      {
+        unsigned char data[ 3 ];
+        file.read( reinterpret_cast<char *>( data ), 3 * sizeof( unsigned char ) );
+        vec = Vec3uc( data[ 0 ], data[ 1 ], data[ 2 ] );
+      }
+
+    private:
+      /// Current system
+      ply_endianness m_system_endianness;
+    };
+
+  } // namespace io
+} // namespace geometry
+} // namespace openMVG
+
+#endif

--- a/src/openMVG/geometry/io/ply_test.cpp
+++ b/src/openMVG/geometry/io/ply_test.cpp
@@ -1,0 +1,486 @@
+#include "openMVG/geometry/io/ply.hpp"
+
+#include "testing/testing.h"
+
+using Vec3   = openMVG::Vec3;
+using Vec3uc = openMVG::Vec3uc;
+
+TEST( ply, write_ascii )
+{
+  std::vector<Vec3> pts;
+  const double start_x = -2.0;
+  const double start_y = -3.0;
+  const double start_z = -4.0;
+  const double end_x   = 2.0;
+  const double end_y   = 3.0;
+  const double end_z   = 4.0;
+
+  const int nb_split_x = 4;
+  const int nb_split_y = 5;
+  const int nb_split_z = 6;
+
+  const double delta_x = ( end_x - start_x ) / static_cast<double>( nb_split_x );
+  const double delta_y = ( end_y - start_y ) / static_cast<double>( nb_split_y );
+  const double delta_z = ( end_z - start_z ) / static_cast<double>( nb_split_z );
+
+  for ( int id_x = 0; id_x < nb_split_x; ++id_x )
+  {
+    for ( int id_y = 0; id_y < nb_split_y; ++id_y )
+    {
+      for ( int id_z = 0; id_z < nb_split_z; ++id_z )
+      {
+        const double x = start_x + id_x * delta_x;
+        const double y = start_y + id_y * delta_y;
+        const double z = start_z + id_z * delta_z;
+
+        pts.push_back( Vec3( x, y, z ) );
+      }
+    }
+  }
+
+  bool res = openMVG::geometry::io::PLYWrite( pts, "cube_ascii.ply", false );
+  EXPECT_EQ( res, true );
+}
+
+TEST( ply, write_ascii_col )
+{
+  std::vector<Vec3> pts;
+  std::vector<Vec3uc> col;
+  const double start_x = -2.0;
+  const double start_y = -3.0;
+  const double start_z = -4.0;
+  const double end_x   = 2.0;
+  const double end_y   = 3.0;
+  const double end_z   = 4.0;
+
+  const int nb_split_x = 4;
+  const int nb_split_y = 5;
+  const int nb_split_z = 6;
+
+  const double delta_x = ( end_x - start_x ) / static_cast<double>( nb_split_x );
+  const double delta_y = ( end_y - start_y ) / static_cast<double>( nb_split_y );
+  const double delta_z = ( end_z - start_z ) / static_cast<double>( nb_split_z );
+
+  for ( int id_x = 0; id_x < nb_split_x; ++id_x )
+  {
+    for ( int id_y = 0; id_y < nb_split_y; ++id_y )
+    {
+      for ( int id_z = 0; id_z < nb_split_z; ++id_z )
+      {
+        const double x = start_x + id_x * delta_x;
+        const double y = start_y + id_y * delta_y;
+        const double z = start_z + id_z * delta_z;
+
+        pts.push_back( Vec3( x, y, z ) );
+        col.push_back( Vec3uc( id_x * 255 / nb_split_x, id_y * 255 / nb_split_y, id_z * 255 / nb_split_z ) );
+      }
+    }
+  }
+
+  bool res = openMVG::geometry::io::PLYWrite( pts, nullptr, &col, "cube_ascii_col.ply", false );
+  EXPECT_EQ( res, true );
+}
+
+TEST( ply, write_binary )
+{
+  std::vector<Vec3> pts;
+  const double start_x = -2.0;
+  const double start_y = -3.0;
+  const double start_z = -4.0;
+  const double end_x   = 2.0;
+  const double end_y   = 3.0;
+  const double end_z   = 4.0;
+
+  const int nb_split_x = 4;
+  const int nb_split_y = 5;
+  const int nb_split_z = 6;
+
+  const double delta_x = ( end_x - start_x ) / static_cast<double>( nb_split_x );
+  const double delta_y = ( end_y - start_y ) / static_cast<double>( nb_split_y );
+  const double delta_z = ( end_z - start_z ) / static_cast<double>( nb_split_z );
+
+  for ( int id_x = 0; id_x < nb_split_x; ++id_x )
+  {
+    for ( int id_y = 0; id_y < nb_split_y; ++id_y )
+    {
+      for ( int id_z = 0; id_z < nb_split_z; ++id_z )
+      {
+        const double x = start_x + id_x * delta_x;
+        const double y = start_y + id_y * delta_y;
+        const double z = start_z + id_z * delta_z;
+
+        pts.push_back( Vec3( x, y, z ) );
+      }
+    }
+  }
+
+  bool res = openMVG::geometry::io::PLYWrite( pts, "cube_bin.ply", true );
+  EXPECT_EQ( res, true );
+}
+
+TEST( ply, write_binary_col )
+{
+  std::vector<Vec3> pts;
+  std::vector<Vec3uc> col;
+  const double start_x = -2.0;
+  const double start_y = -3.0;
+  const double start_z = -4.0;
+  const double end_x   = 2.0;
+  const double end_y   = 3.0;
+  const double end_z   = 4.0;
+
+  const int nb_split_x = 4;
+  const int nb_split_y = 5;
+  const int nb_split_z = 6;
+
+  const double delta_x = ( end_x - start_x ) / static_cast<double>( nb_split_x );
+  const double delta_y = ( end_y - start_y ) / static_cast<double>( nb_split_y );
+  const double delta_z = ( end_z - start_z ) / static_cast<double>( nb_split_z );
+
+  for ( int id_x = 0; id_x < nb_split_x; ++id_x )
+  {
+    for ( int id_y = 0; id_y < nb_split_y; ++id_y )
+    {
+      for ( int id_z = 0; id_z < nb_split_z; ++id_z )
+      {
+        const double x = start_x + id_x * delta_x;
+        const double y = start_y + id_y * delta_y;
+        const double z = start_z + id_z * delta_z;
+
+        pts.push_back( Vec3( x, y, z ) );
+        col.push_back( Vec3uc( id_x * 255 / nb_split_x, id_y * 255 / nb_split_y, id_z * 255 / nb_split_z ) );
+      }
+    }
+  }
+
+  bool res = openMVG::geometry::io::PLYWrite( pts, nullptr, &col, "cube_bin_col.ply", true );
+  EXPECT_EQ( res, true );
+}
+
+TEST( ply, write_read_ascii )
+{
+  std::vector<Vec3> pts;
+  const double start_x = -2.0;
+  const double start_y = -3.0;
+  const double start_z = -4.0;
+  const double end_x   = 2.0;
+  const double end_y   = 3.0;
+  const double end_z   = 4.0;
+
+  const int nb_split_x = 4;
+  const int nb_split_y = 5;
+  const int nb_split_z = 6;
+
+  const double delta_x = ( end_x - start_x ) / static_cast<double>( nb_split_x );
+  const double delta_y = ( end_y - start_y ) / static_cast<double>( nb_split_y );
+  const double delta_z = ( end_z - start_z ) / static_cast<double>( nb_split_z );
+
+  for ( int id_x = 0; id_x < nb_split_x; ++id_x )
+  {
+    for ( int id_y = 0; id_y < nb_split_y; ++id_y )
+    {
+      for ( int id_z = 0; id_z < nb_split_z; ++id_z )
+      {
+        const double x = start_x + id_x * delta_x;
+        const double y = start_y + id_y * delta_y;
+        const double z = start_z + id_z * delta_z;
+
+        pts.push_back( Vec3( x, y, z ) );
+      }
+    }
+  }
+
+  bool res = openMVG::geometry::io::PLYWrite( pts, "cube_rw_ascii.ply", false );
+  EXPECT_EQ( res, true );
+  std::vector<Vec3> pts_r;
+  res = openMVG::geometry::io::PLYRead( "cube_rw_ascii.ply", pts_r );
+  EXPECT_EQ( res, true );
+  EXPECT_EQ( pts.size(), pts_r.size() );
+
+  for ( size_t id_point = 0; id_point < pts.size(); ++id_point )
+  {
+    EXPECT_NEAR( pts[ id_point ][0], pts_r[ id_point ][0] , 0.00001 );
+    EXPECT_NEAR( pts[ id_point ][1], pts_r[ id_point ][1] , 0.00001 );
+    EXPECT_NEAR( pts[ id_point ][2], pts_r[ id_point ][2] , 0.00001 );
+  }
+}
+
+TEST( ply, write_read_ascii_col )
+{
+  std::vector<Vec3> pts;
+  std::vector<Vec3uc> col;
+  const double start_x = -2.0;
+  const double start_y = -3.0;
+  const double start_z = -4.0;
+  const double end_x   = 2.0;
+  const double end_y   = 3.0;
+  const double end_z   = 4.0;
+
+  const int nb_split_x = 4;
+  const int nb_split_y = 5;
+  const int nb_split_z = 6;
+
+  const double delta_x = ( end_x - start_x ) / static_cast<double>( nb_split_x );
+  const double delta_y = ( end_y - start_y ) / static_cast<double>( nb_split_y );
+  const double delta_z = ( end_z - start_z ) / static_cast<double>( nb_split_z );
+
+  for ( int id_x = 0; id_x < nb_split_x; ++id_x )
+  {
+    for ( int id_y = 0; id_y < nb_split_y; ++id_y )
+    {
+      for ( int id_z = 0; id_z < nb_split_z; ++id_z )
+      {
+        const double x = start_x + id_x * delta_x;
+        const double y = start_y + id_y * delta_y;
+        const double z = start_z + id_z * delta_z;
+
+        pts.push_back( Vec3( x, y, z ) );
+        col.push_back( Vec3uc( id_x * 255 / nb_split_x, id_y * 255 / nb_split_y, id_z * 255 / nb_split_z ) );
+      }
+    }
+  }
+
+  bool res = openMVG::geometry::io::PLYWrite( pts, nullptr, &col, "cube_rw_ascii_col.ply", false );
+  EXPECT_EQ( res, true );
+  std::vector<Vec3> pts_r;
+  std::vector<Vec3uc> col_r; 
+  res = openMVG::geometry::io::PLYRead( "cube_rw_ascii_col.ply", pts_r , nullptr , &col_r );
+  EXPECT_EQ( res, true );
+  EXPECT_EQ( pts.size(), pts_r.size() );
+  EXPECT_EQ( col.size() , col_r.size() ) ; 
+
+  for ( size_t id_point = 0; id_point < pts.size(); ++id_point )
+  {
+    EXPECT_NEAR( pts[ id_point ][0], pts_r[ id_point ][0] , 0.00001 );
+    EXPECT_NEAR( pts[ id_point ][1], pts_r[ id_point ][1] , 0.00001 );
+    EXPECT_NEAR( pts[ id_point ][2], pts_r[ id_point ][2] , 0.00001 );
+
+    EXPECT_EQ( col[id_point] , col_r[id_point] ) ; 
+  }
+}
+
+TEST( ply, write_read_ascii_col_nor )
+{
+  std::vector<Vec3> pts;
+  std::vector<Vec3> nor;
+  std::vector<Vec3uc> col;
+  const double start_x = -2.0;
+  const double start_y = -3.0;
+  const double start_z = -4.0;
+  const double end_x   = 2.0;
+  const double end_y   = 3.0;
+  const double end_z   = 4.0;
+
+  const int nb_split_x = 4;
+  const int nb_split_y = 5;
+  const int nb_split_z = 6;
+
+  const double delta_x = ( end_x - start_x ) / static_cast<double>( nb_split_x );
+  const double delta_y = ( end_y - start_y ) / static_cast<double>( nb_split_y );
+  const double delta_z = ( end_z - start_z ) / static_cast<double>( nb_split_z );
+
+  for ( int id_x = 0; id_x < nb_split_x; ++id_x )
+  {
+    for ( int id_y = 0; id_y < nb_split_y; ++id_y )
+    {
+      for ( int id_z = 0; id_z < nb_split_z; ++id_z )
+      {
+        const double x = start_x + id_x * delta_x;
+        const double y = start_y + id_y * delta_y;
+        const double z = start_z + id_z * delta_z;
+
+        pts.push_back( Vec3( x, y, z ) );
+        col.push_back( Vec3uc( id_x * 255 / nb_split_x, id_y * 255 / nb_split_y, id_z * 255 / nb_split_z ) );
+        nor.push_back( Vec3( x , y , z ).normalized() );
+      }
+    }
+  }
+
+  bool res = openMVG::geometry::io::PLYWrite( pts, &nor, &col, "cube_rw_ascii_col.ply", false );
+  EXPECT_EQ( res, true );
+  std::vector<Vec3> pts_r;
+  std::vector<Vec3> nor_r; 
+  std::vector<Vec3uc> col_r; 
+  res = openMVG::geometry::io::PLYRead( "cube_rw_ascii_col.ply", pts_r , &nor_r , &col_r );
+  EXPECT_EQ( res, true );
+  EXPECT_EQ( pts.size(), pts_r.size() );
+  EXPECT_EQ( col.size() , col_r.size() ) ; 
+
+  for ( size_t id_point = 0; id_point < pts.size(); ++id_point )
+  {
+    EXPECT_NEAR( pts[ id_point ][0], pts_r[ id_point ][0] , 0.00001 );
+    EXPECT_NEAR( pts[ id_point ][1], pts_r[ id_point ][1] , 0.00001 );
+    EXPECT_NEAR( pts[ id_point ][2], pts_r[ id_point ][2] , 0.00001 );
+
+    EXPECT_NEAR( nor[ id_point ][0] , nor_r[ id_point ][0] , 0.00001 ) ;
+    EXPECT_NEAR( nor[ id_point ][1] , nor_r[ id_point ][1] , 0.00001 ) ;
+    EXPECT_NEAR( nor[ id_point ][2] , nor_r[ id_point ][2] , 0.00001 ) ;
+    
+
+    EXPECT_EQ( col[id_point] , col_r[id_point] ) ; 
+  }
+}
+
+
+TEST( ply, write_read_binary )
+{
+  std::vector<Vec3> pts;
+  const double start_x = -2.0;
+  const double start_y = -3.0;
+  const double start_z = -4.0;
+  const double end_x   = 2.0;
+  const double end_y   = 3.0;
+  const double end_z   = 4.0;
+
+  const int nb_split_x = 4;
+  const int nb_split_y = 5;
+  const int nb_split_z = 6;
+
+  const double delta_x = ( end_x - start_x ) / static_cast<double>( nb_split_x );
+  const double delta_y = ( end_y - start_y ) / static_cast<double>( nb_split_y );
+  const double delta_z = ( end_z - start_z ) / static_cast<double>( nb_split_z );
+
+  for ( int id_x = 0; id_x < nb_split_x; ++id_x )
+  {
+    for ( int id_y = 0; id_y < nb_split_y; ++id_y )
+    {
+      for ( int id_z = 0; id_z < nb_split_z; ++id_z )
+      {
+        const double x = start_x + id_x * delta_x;
+        const double y = start_y + id_y * delta_y;
+        const double z = start_z + id_z * delta_z;
+
+        pts.push_back( Vec3( x, y, z ) );
+      }
+    }
+  }
+
+  bool res = openMVG::geometry::io::PLYWrite( pts, "cube_wr_bin.ply" );
+  EXPECT_EQ( res, true );
+  std::vector<Vec3> pts_r;
+  res = openMVG::geometry::io::PLYRead( "cube_wr_bin.ply", pts_r );
+  EXPECT_EQ( res, true );
+  EXPECT_EQ( pts.size(), pts_r.size() );
+
+  for ( size_t id_point = 0; id_point < pts.size(); ++id_point )
+  {
+    EXPECT_EQ( pts[ id_point ], pts_r[ id_point ] );
+  }
+}
+
+TEST( ply, write_read_binary_col )
+{
+  std::vector<Vec3> pts;
+  std::vector<Vec3uc> col;
+  const double start_x = -2.0;
+  const double start_y = -3.0;
+  const double start_z = -4.0;
+  const double end_x   = 2.0;
+  const double end_y   = 3.0;
+  const double end_z   = 4.0;
+
+  const int nb_split_x = 4;
+  const int nb_split_y = 5;
+  const int nb_split_z = 6;
+
+  const double delta_x = ( end_x - start_x ) / static_cast<double>( nb_split_x );
+  const double delta_y = ( end_y - start_y ) / static_cast<double>( nb_split_y );
+  const double delta_z = ( end_z - start_z ) / static_cast<double>( nb_split_z );
+
+  for ( int id_x = 0; id_x < nb_split_x; ++id_x )
+  {
+    for ( int id_y = 0; id_y < nb_split_y; ++id_y )
+    {
+      for ( int id_z = 0; id_z < nb_split_z; ++id_z )
+      {
+        const double x = start_x + id_x * delta_x;
+        const double y = start_y + id_y * delta_y;
+        const double z = start_z + id_z * delta_z;
+
+        pts.push_back( Vec3( x, y, z ) );
+        col.push_back( Vec3uc( id_x * 255 / nb_split_x, id_y * 255 / nb_split_y, id_z * 255 / nb_split_z ) );
+      }
+    }
+  }
+
+  bool res = openMVG::geometry::io::PLYWrite( pts, nullptr, &col, "cube_rw_bin_col.ply", true );
+  EXPECT_EQ( res, true );
+  std::vector<Vec3> pts_r;
+  std::vector<Vec3uc> col_r;
+  res = openMVG::geometry::io::PLYRead( "cube_rw_bin_col.ply", pts_r, nullptr, &col_r );
+  EXPECT_EQ( res, true );
+  EXPECT_EQ( pts.size(), pts_r.size() );
+  EXPECT_EQ( col.size(), col_r.size() );
+  EXPECT_EQ( pts.size(), col.size() );
+
+  for ( size_t id_point = 0; id_point < pts.size(); ++id_point )
+  {
+    EXPECT_EQ( pts[ id_point ], pts_r[ id_point ] );
+    EXPECT_EQ( col[ id_point ], col_r[ id_point ] );
+  }
+}
+
+TEST( ply, write_read_binary_col_nor )
+{
+  std::vector<Vec3> pts;
+  std::vector<Vec3> nor; 
+  std::vector<Vec3uc> col;
+  const double start_x = -2.0;
+  const double start_y = -3.0;
+  const double start_z = -4.0;
+  const double end_x   = 2.0;
+  const double end_y   = 3.0;
+  const double end_z   = 4.0;
+
+  const int nb_split_x = 4;
+  const int nb_split_y = 5;
+  const int nb_split_z = 6;
+
+  const double delta_x = ( end_x - start_x ) / static_cast<double>( nb_split_x );
+  const double delta_y = ( end_y - start_y ) / static_cast<double>( nb_split_y );
+  const double delta_z = ( end_z - start_z ) / static_cast<double>( nb_split_z );
+
+  for ( int id_x = 0; id_x < nb_split_x; ++id_x )
+  {
+    for ( int id_y = 0; id_y < nb_split_y; ++id_y )
+    {
+      for ( int id_z = 0; id_z < nb_split_z; ++id_z )
+      {
+        const double x = start_x + id_x * delta_x;
+        const double y = start_y + id_y * delta_y;
+        const double z = start_z + id_z * delta_z;
+
+        pts.push_back( Vec3( x, y, z ) );
+        col.push_back( Vec3uc( id_x * 255 / nb_split_x, id_y * 255 / nb_split_y, id_z * 255 / nb_split_z ) );
+        nor.push_back( Vec3(x,y,z).normalized() ) ;
+      }
+    }
+  }
+
+  bool res = openMVG::geometry::io::PLYWrite( pts, &nor , &col, "cube_rw_bin_col.ply", true );
+  EXPECT_EQ( res, true );
+  std::vector<Vec3> pts_r;
+  std::vector<Vec3> nor_r; 
+  std::vector<Vec3uc> col_r;
+  res = openMVG::geometry::io::PLYRead( "cube_rw_bin_col.ply", pts_r, &nor_r , &col_r );
+  EXPECT_EQ( res, true );
+  EXPECT_EQ( pts.size(), pts_r.size() );
+  EXPECT_EQ( col.size(), col_r.size() );
+  EXPECT_EQ( pts.size(), col.size() );
+
+  for ( size_t id_point = 0; id_point < pts.size(); ++id_point )
+  {
+    EXPECT_EQ( pts[ id_point ], pts_r[ id_point ] );
+    EXPECT_EQ( nor[ id_point ], nor_r[ id_point ] );
+    EXPECT_EQ( col[ id_point ], col_r[ id_point ] );
+  }
+}
+
+
+/* ************************************************************************* */
+int main()
+{
+  TestResult tr;
+  return TestRegistry::runAllTests( tr );
+}
+/* ************************************************************************* */

--- a/src/openMVG/numeric/eigen_alias_definition.hpp
+++ b/src/openMVG/numeric/eigen_alias_definition.hpp
@@ -70,6 +70,9 @@ namespace openMVG
   /// 3d vector using double internal format
   using Vec3 = Eigen::Vector3d;
 
+  /// 3d vector using unsigned char internal format 
+  using Vec3uc = Eigen::Matrix<unsigned char,3,1> ; 
+
   /// 2d vector using int internal format
   using Vec2i = Eigen::Vector2i;
 
@@ -118,6 +121,7 @@ namespace openMVG
 
   /// Unconstrained vector using unsigned int internal format
   using Vecu = Eigen::Matrix<unsigned int, Eigen::Dynamic, 1>;
+
 
   /// Unconstrained matrix using float internal format
   using Matf = Eigen::MatrixXf;


### PR DESCRIPTION
Hi, 

this PR aims at creating a new sublibrary geometry::io with the support of saving and loading various point cloud formats. This PR only concerns ply file type (as it is already used in openMVG). 

It supports : reading and writing ply files either in ascii or binary format (little and big endian are supported). It supports point cloud with only points, points with normals, points with colors and points with normals and colors. 

There are some limitations for now : 
- Data must be in canonical order : (ie we must have ptX ptY ptZ [normX normY normZ] [R G B], element could not be interleaved)
- Color data is only supported using uchar data 
- Point and normal data are only supported in float or double format (no integer support)

However it should cover most of openMVG usages. 

The library aims also to be simple enough for the users : just use PLY_Read or PLY_Write in ply.hpp file. 

Hope it helps !