### PR TITLE
Fix for "Incorrect match from camera database #794"

### DIFF
--- a/src/openMVG/exif/sensor_width_database/ParseDatabase_test.cpp
+++ b/src/openMVG/exif/sensor_width_database/ParseDatabase_test.cpp
@@ -103,6 +103,30 @@ TEST(Matching, ParseDatabaseCanon_EOS_1100D)
   EXPECT_EQ( 22.2, datasheet.sensorSize_ );
 }
 
+TEST(Matching, ParseDatabaseCanon_IXUS_70)
+{
+  std::vector<Datasheet> vec_database;
+  Datasheet datasheet;
+  const std::string sfileDatabase = stlplus::create_filespec( std::string(THIS_SOURCE_DIR), sDatabase );
+  const std::string sModel = "Canon DIGITAL IXUS 70";
+
+  EXPECT_TRUE( parseDatabase( sfileDatabase, vec_database ) );
+  EXPECT_TRUE( getInfo( sModel, vec_database, datasheet ) );
+  EXPECT_EQ( 5.7, datasheet.sensorSize_ );
+}
+
+TEST(Matching, ParseDatabaseCanon_EOS_M)
+{
+  std::vector<Datasheet> vec_database;
+  Datasheet datasheet;
+  const std::string sfileDatabase = stlplus::create_filespec( std::string(THIS_SOURCE_DIR), sDatabase );
+  const std::string sModel = "Canon EOS M";
+
+  EXPECT_TRUE( parseDatabase( sfileDatabase, vec_database ) );
+  EXPECT_TRUE( getInfo( sModel, vec_database, datasheet ) );
+  EXPECT_EQ( 22.3, datasheet.sensorSize_ );
+}
+
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr);}
 /* ************************************************************************* */

--- a/src/openMVG/exif/sensor_width_database/datasheet.hpp
+++ b/src/openMVG/exif/sensor_width_database/datasheet.hpp
@@ -57,7 +57,7 @@ struct Datasheet
       std::string db_model_digit_substring = "";
       for (const std::string & db_sub_model : vec_db_model)
       {
-        if( std::find_if(db_sub_model.begin(), db_sub_model.end(), isdigit) != db_sub_model.end() )
+        if ( std::find_if(db_sub_model.begin(), db_sub_model.end(), isdigit) != db_sub_model.end() )
         {
           db_model_digit_substring = db_sub_model;
           break;
@@ -68,7 +68,7 @@ struct Datasheet
 
       const bool has_digit =
         std::find_if(rhs_model.begin(), rhs_model.end(), isdigit) != rhs_model.end();
-      if (!has_digit || ( db_model_digit_substring == "" ) )
+      if (!has_digit || db_model_digit_substring.empty() )
       {
         // If there is no digit in either the db entry or the image camera then compare the full model string
         return (this_model.compare(rhs_model) == 0);

--- a/src/openMVG/exif/sensor_width_database/datasheet.hpp
+++ b/src/openMVG/exif/sensor_width_database/datasheet.hpp
@@ -51,13 +51,26 @@ struct Datasheet
 
     if (this_maker.compare(rhs_maker) == 0)
     {
-      // Search for digit substring and if there is a match
+      // Extract digit substring from database entry
+      std::vector<std::string> vec_db_model;
+      stl::split(this_model, ' ', vec_db_model);
+      std::string db_model_digit_substring = "";
+      for (const std::string & db_sub_model : vec_db_model)
+      {
+        if( std::find_if(db_sub_model.begin(), db_sub_model.end(), isdigit) != db_sub_model.end() )
+        {
+          db_model_digit_substring = db_sub_model;
+          break;
+        }
+      }
+
+      // Search for digit substring in image camera model and if there is a match
 
       const bool has_digit =
         std::find_if(rhs_model.begin(), rhs_model.end(), isdigit) != rhs_model.end();
-      if (!has_digit)
+      if (!has_digit || ( db_model_digit_substring == "" ) )
       {
-        // If there is no digit compare the full model string
+        // If there is no digit in either the db entry or the image camera then compare the full model string
         return (this_model.compare(rhs_model) == 0);
       }
       else
@@ -71,7 +84,7 @@ struct Datasheet
           const bool sub_has_digit =
             std::find_if(rhs_sub_model.begin(), rhs_sub_model.end(), isdigit) != rhs_sub_model.end();
           // Check that substring containing the camera digit model is corresponding
-          if (sub_has_digit && this_model.find(rhs_sub_model) != std::string::npos)
+          if (sub_has_digit && ( db_model_digit_substring == rhs_sub_model ) )
           {
             return true; // substring that contains digit got a match
           }
@@ -87,4 +100,3 @@ struct Datasheet
 
 
 #endif // OPENMVG_EXIF_SENSOR_WIDTH_DATABASE_DATASHEET_HPP
-


### PR DESCRIPTION
Summary of changes:

1. Fix bug so that the IXUS 70 camera is matched correctly
2. Add two extra test cases - one for IXUS 70 camera that showed the problem and one for a camera with no model number in the string.