### PR TITLE
Parallelize MVE2 export

### DIFF
--- a/src/software/SfM/main_openMVG2MVE2.cpp
+++ b/src/software/SfM/main_openMVG2MVE2.cpp
@@ -26,6 +26,7 @@ using namespace openMVG::features;
 #include <cmath>
 #include <iterator>
 #include <iomanip>
+#include <atomic>
 
 /// Naive image bilinear resampling of an image for thumbnail generation
 template <typename ImageT>
@@ -41,7 +42,7 @@ create_thumbnail
  * - An MVE2 scene appears to duplicate camera rot matrix and trans vector per-view data in 'meta.ini'
  *   within the first section of 'synth_0.out'.
  * - We do not save the original, instead we rely on the undistorted image from openMVG.
- * - We do not output thumbnails or EXIF blobs, as these appear only to be used only for the GUI UMVE.
+ * - We do not output EXIF blobs, as these appear only to be used for the GUI UMVE.
  * - To avoid encoding loss, openMVG images should be written as .PNG if undistorted images are *not* computed.
  * - In OpenMVG, some views may have some missing poses; MVE does *not* require a contiguous camera index.
  *
@@ -54,7 +55,7 @@ bool exportToMVE2Format(
   const std::string & sOutDirectory // Output MVE2 files directory
   )
 {
-  bool bOk = true;
+  std::atomic<bool> bOk(true);
   // Create basis directory structure
   if (!stlplus::is_folder(sOutDirectory))
   {
@@ -71,20 +72,13 @@ bool exportToMVE2Format(
 
   // Export the SfM_Data scene to the MVE2 format
   {
-    // Create 'views' subdirectory
-    const string sOutViewsDirectory = stlplus::folder_append_separator(sOutDirectory) + "views";
-    if (!stlplus::folder_exists(sOutViewsDirectory))
-    {
-      cout << "\033[1;31mCreating directory:  " << sOutViewsDirectory << "\033[0m\n";
-      stlplus::folder_create(sOutViewsDirectory);
-    }
-
     // Prepare to write bundle file
     // Get cameras and features from OpenMVG
-    const size_t cameraCount = std::distance(sfm_data.GetViews().begin(), sfm_data.GetViews().end());
+    const Views & views = sfm_data.GetViews();
+    const size_t cameraCount = views.size();
     // Tally global set of feature landmarks
     const Landmarks & landmarks = sfm_data.GetLandmarks();
-    const size_t featureCount = std::distance(landmarks.begin(), landmarks.end());
+    const size_t featureCount = landmarks.size();
     const std::string filename = "synth_0.out";
     std::cout << "Writing bundle (" << cameraCount << " cameras, "
         << featureCount << " features): to " << filename << "...\n";
@@ -92,150 +86,47 @@ bool exportToMVE2Format(
     out << "drews 1.0\n";  // MVE expects this header
     out << cameraCount << " " << featureCount << "\n";
 
-    // Export (calibrated) views as undistorted images
-    C_Progress_display my_progress_bar(sfm_data.GetViews().size());
-    Image<RGBColor> image, image_ud, thumbnail;
-    std::string sOutViewIteratorDirectory;
-    for(Views::const_iterator iter = sfm_data.GetViews().begin();
-      iter != sfm_data.GetViews().end(); ++iter, ++my_progress_bar)
+    for (const auto & views_it : views)
     {
-      const View * view = iter->second.get();
-
-      // Create current view subdirectory 'view_xxxx.mve'
-      std::ostringstream padding;
-      padding << std::setw(4) << std::setfill('0') << view->id_view;
-      sOutViewIteratorDirectory = stlplus::folder_append_separator(sOutViewsDirectory) + "view_" + padding.str() + ".mve";
-
-      // We have a valid view with a corresponding camera & pose
-      const std::string srcImage = stlplus::create_filespec(sfm_data.s_root_path, view->s_Img_path);
-      const std::string dstImage =
-        stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory), "undistorted","png");
-
-      if (sfm_data.IsPoseAndIntrinsicDefined(view))
-      {
-        if (!stlplus::folder_exists(sOutViewIteratorDirectory))
+        const View * view = views_it.second.get();
+        if (sfm_data.IsPoseAndIntrinsicDefined(view))
         {
-          stlplus::folder_create(sOutViewIteratorDirectory);
+            Intrinsics::const_iterator iterIntrinsic = sfm_data.GetIntrinsics().find(view->id_intrinsic);
+            const IntrinsicBase * cam = iterIntrinsic->second.get();
+            const Pose3 & pose = sfm_data.GetPoseOrDie(view);
+            const Pinhole_Intrinsic * pinhole_cam = static_cast<const Pinhole_Intrinsic *>(cam);
+            const Mat3 & rotation = pose.rotation();
+            const Vec3 & translation = pose.translation();
+            // Focal length and principal point must be normalized (0..1)
+            const float flen = pinhole_cam->focal() / static_cast<double>(std::max(cam->w(), cam->h()));
+            out
+              << flen << " " << "0" << " " << "0" << "\n"  // Write '0' distortion values for pre-corrected images
+              << rotation(0, 0) << " " << rotation(0, 1) << " " << rotation(0, 2) << "\n"
+              << rotation(1, 0) << " " << rotation(1, 1) << " " << rotation(1, 2) << "\n"
+              << rotation(2, 0) << " " << rotation(2, 1) << " " << rotation(2, 2) << "\n"
+              << translation[0] << " " << translation[1] << " " << translation[2] << "\n";
         }
-
-        Intrinsics::const_iterator iterIntrinsic = sfm_data.GetIntrinsics().find(view->id_intrinsic);
-        const IntrinsicBase * cam = iterIntrinsic->second.get();
-        if (cam->have_disto())
+        else
         {
-          // Undistort and save the image
-          if (!ReadImage(srcImage.c_str(), &image))
-          {
-            std::cerr
-              << "Unable to read the input image as a RGB image:\n"
-              << srcImage << std::endl;
-            return EXIT_FAILURE;
-          }
-          UndistortImage(image, cam, image_ud, BLACK);
-          if (!WriteImage(dstImage.c_str(), image_ud))
-          {
-            std::cerr
-              << "Unable to write the output image as a RGB image:\n"
-              << dstImage << std::endl;
-            return EXIT_FAILURE;
-          }
+            // export a camera without pose & intrinsic info (export {0})
+            // see: https://github.com/simonfuhrmann/mve/blob/952a80b0be48e820b8c72de1d3df06efc3953bd3/libs/mve/bundle_io.cc#L448
+            for (int i = 0; i < 5 * 3; ++i)
+              out << "0" << (i % 3 == 2 ? "\n" : " ");
         }
-        else // (no distortion)
-        {
-          // If extensions match, copy the PNG image
-          if (stlplus::extension_part(srcImage) == "PNG" ||
-              stlplus::extension_part(srcImage) == "png")
-          {
-            stlplus::file_copy(srcImage, dstImage);
-          }
-          else
-          {
-            if (!ReadImage( srcImage.c_str(), &image) ||
-                !WriteImage( dstImage.c_str(), image))
-            {
-              std::cerr << "Unable to read and write the image" << std::endl;
-              return EXIT_FAILURE;
-            }
-          }
-        }
-
-        // Prepare to write an MVE 'meta.ini' file for the current view
-        const Pose3 pose = sfm_data.GetPoseOrDie(view);
-        const Pinhole_Intrinsic * pinhole_cam = static_cast<const Pinhole_Intrinsic *>(cam);
-
-        const Mat3 rotation = pose.rotation();
-        const Vec3 translation = pose.translation();
-        // Pixel aspect: assuming square pixels
-        const float pixelAspect = 1.f;
-        // Focal length and principal point must be normalized (0..1)
-        const float flen = pinhole_cam->focal() / static_cast<double>(std::max(cam->w(), cam->h()));
-        const float ppX = std::abs(pinhole_cam->principal_point()(0)/cam->w());
-        const float ppY = std::abs(pinhole_cam->principal_point()(1)/cam->h());
-
-        // For each camera, write to bundle:  focal length, radial distortion[0-1], rotation matrix[0-8], translation vector[0-2]
-        std::ostringstream fileOut;
-        fileOut
-          << "# MVE view meta data is stored in INI-file syntax." << fileOut.widen('\n')
-          << "# This file is generated, formatting will get lost." << fileOut.widen('\n')
-          << fileOut.widen('\n')
-          << "[camera]" << fileOut.widen('\n')
-          << "focal_length = " << flen << fileOut.widen('\n')
-          << "pixel_aspect = " << pixelAspect << fileOut.widen('\n')
-          << "principal_point = " << ppX << " " << ppY << fileOut.widen('\n')
-          << "rotation = " << rotation(0, 0) << " " << rotation(0, 1) << " " << rotation(0, 2) << " "
-          << rotation(1, 0) << " " << rotation(1, 1) << " " << rotation(1, 2) << " "
-          << rotation(2, 0) << " " << rotation(2, 1) << " " << rotation(2, 2) << fileOut.widen('\n')
-          << "translation = " << translation[0] << " " << translation[1] << " "
-          << translation[2] << " " << fileOut.widen('\n')
-          << fileOut.widen('\n')
-          << "[view]" << fileOut.widen('\n')
-          << "id = " << view->id_view << fileOut.widen('\n')
-          << "name = " << stlplus::filename_part(srcImage.c_str()) << fileOut.widen('\n');
-
-        // To do:  trim any extra separator(s) from openMVG name we receive, e.g.:
-        // '/home/insight/openMVG_KevinCain/openMVG_Build/software/SfM/ImageDataset_SceauxCastle/images//100_7100.JPG'
-        std::ofstream file(
-          stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory),
-          "meta","ini").c_str());
-        file << fileOut.str();
-        file.close();
-
-        out
-          << flen << " " << "0" << " " << "0" << "\n"  // Write '0' distortion values for pre-corrected images
-          << rotation(0, 0) << " " << rotation(0, 1) << " " << rotation(0, 2) << "\n"
-          << rotation(1, 0) << " " << rotation(1, 1) << " " << rotation(1, 2) << "\n"
-          << rotation(2, 0) << " " << rotation(2, 1) << " " << rotation(2, 2) << "\n"
-          << translation[0] << " " << translation[1] << " " << translation[2] << "\n";
-      }
-      else
-      {
-        // export a camera without pose & intrinsic info (export {0})
-        // see: https://github.com/simonfuhrmann/mve/blob/952a80b0be48e820b8c72de1d3df06efc3953bd3/libs/mve/bundle_io.cc#L448
-        for (int i = 0; i < 5 * 3; ++i)
-          out << "0" << (i % 3 == 2 ? "\n" : " ");
-        continue;
-      }
-
-      // Save a thumbnail image "thumbnail.png", 50x50 pixels
-      thumbnail = create_thumbnail(image, 50, 50);
-      const std::string dstThumbnailImage =
-        stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory), "thumbnail","png");
-      WriteImage(dstThumbnailImage.c_str(), thumbnail);
     }
 
-    // For each feature, write to bundle:  position XYZ[0-3], color RGB[0-2], all ref.view_id & ref.feature_id
+    // For each feature, write to bundle: position XYZ[0-3], color RGB[0-2], all ref.view_id & ref.feature_id
     // The following method is adapted from Simon Fuhrmann's MVE project:
     // https://github.com/simonfuhrmann/mve/blob/e3db7bc60ce93fe51702ba77ef480e151f927c23/libs/mve/bundle_io.cc
-
     for (const auto & landmarks_it : landmarks)
     {
-      const Vec3 exportPoint = landmarks_it.second.X;
+      const Vec3 & exportPoint = landmarks_it.second.X;
       out << exportPoint.x() << " " << exportPoint.y() << " " << exportPoint.z() << "\n";
       out << 250 << " " << 100 << " " << 150 << "\n";  // Write arbitrary RGB color, see above note
 
-      // Tally set of feature observations
+      // Write number of observations (features)
       const Observations & obs = landmarks_it.second.obs;
-      const size_t featureCount = std::distance(obs.begin(), obs.end());
-      out << featureCount;
+      out << obs.size();
 
       for (const auto & obs_it : obs)
       {
@@ -246,6 +137,136 @@ bool exportToMVE2Format(
       out << "\n";
     }
     out.close();
+
+    // Export (calibrated) views as undistorted images in parallel
+    std::cout << "Exporting views..." << std::endl;
+
+    // Create 'views' subdirectory
+    const string sOutViewsDirectory = stlplus::folder_append_separator(sOutDirectory) + "views";
+    if (!stlplus::folder_exists(sOutViewsDirectory))
+    {
+        cout << "\033[1;31mCreating directory:  " << sOutViewsDirectory << "\033[0m\n";
+        stlplus::folder_create(sOutViewsDirectory);
+    }
+
+    C_Progress_display my_progress_bar(views.size());
+
+    #pragma omp parallel for schedule(dynamic)
+    for (int i = 0; i < static_cast<int>(views.size()); ++i)
+    {
+      if (!bOk) continue;
+      const View * view = views.at(i).get();
+
+      if (!sfm_data.IsPoseAndIntrinsicDefined(view))
+          continue;
+
+      // Create current view subdirectory 'view_xxxx.mve'
+      std::ostringstream padding;
+      padding << std::setw(4) << std::setfill('0') << view->id_view;
+      std::string sOutViewIteratorDirectory;
+      sOutViewIteratorDirectory = stlplus::folder_append_separator(sOutViewsDirectory) + "view_" + padding.str() + ".mve";
+
+      // We have a valid view with a corresponding camera & pose
+      const std::string srcImage = stlplus::create_filespec(sfm_data.s_root_path, view->s_Img_path);
+      const std::string dstImage =
+        stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory), "undistorted","png");
+
+      if (!stlplus::folder_exists(sOutViewIteratorDirectory))
+        stlplus::folder_create(sOutViewIteratorDirectory);
+
+      Image<RGBColor> image, image_ud, thumbnail;
+      Intrinsics::const_iterator iterIntrinsic = sfm_data.GetIntrinsics().find(view->id_intrinsic);
+      const IntrinsicBase * cam = iterIntrinsic->second.get();
+      if (cam->have_disto())
+      {
+        // Undistort and save the image
+        if (!ReadImage(srcImage.c_str(), &image))
+        {
+          std::cerr
+            << "Unable to read the input image as a RGB image:\n"
+            << srcImage << std::endl;
+          bOk = false;
+          continue;
+        }
+        UndistortImage(image, cam, image_ud, BLACK);
+        if (!WriteImage(dstImage.c_str(), image_ud))
+        {
+          std::cerr
+            << "Unable to write the output image as a RGB image:\n"
+            << dstImage << std::endl;
+          bOk = false;
+          continue;
+        }
+      }
+      else // (no distortion)
+      {
+        // If extensions match, copy the PNG image
+        if (stlplus::extension_part(srcImage) == "PNG" ||
+            stlplus::extension_part(srcImage) == "png")
+        {
+          stlplus::file_copy(srcImage, dstImage);
+        }
+        else
+        {
+          if (!ReadImage( srcImage.c_str(), &image) ||
+              !WriteImage( dstImage.c_str(), image))
+          {
+            std::cerr << "Unable to read and write the image" << std::endl;
+            bOk = false;
+            continue;
+          }
+        }
+      }
+
+      // Prepare to write an MVE 'meta.ini' file for the current view
+      const Pose3 & pose = sfm_data.GetPoseOrDie(view);
+      const Pinhole_Intrinsic * pinhole_cam = static_cast<const Pinhole_Intrinsic *>(cam);
+      const Mat3 & rotation = pose.rotation();
+      const Vec3 & translation = pose.translation();
+      // Pixel aspect: assuming square pixels
+      const float pixelAspect = 1.f;
+      // Focal length and principal point must be normalized (0..1)
+      const float flen = pinhole_cam->focal() / static_cast<double>(std::max(cam->w(), cam->h()));
+      const float ppX = std::abs(pinhole_cam->principal_point()(0)/cam->w());
+      const float ppY = std::abs(pinhole_cam->principal_point()(1)/cam->h());
+
+      // For each camera, write to bundle: focal length, radial distortion[0-1],
+      // rotation matrix[0-8], translation vector[0-2]
+      std::ostringstream fileOut;
+      fileOut
+        << "# MVE view meta data is stored in INI-file syntax." << fileOut.widen('\n')
+        << "# This file is generated, formatting will get lost." << fileOut.widen('\n')
+        << fileOut.widen('\n')
+        << "[camera]" << fileOut.widen('\n')
+        << "focal_length = " << flen << fileOut.widen('\n')
+        << "pixel_aspect = " << pixelAspect << fileOut.widen('\n')
+        << "principal_point = " << ppX << " " << ppY << fileOut.widen('\n')
+        << "rotation = " << rotation(0, 0) << " " << rotation(0, 1) << " " << rotation(0, 2) << " "
+        << rotation(1, 0) << " " << rotation(1, 1) << " " << rotation(1, 2) << " "
+        << rotation(2, 0) << " " << rotation(2, 1) << " " << rotation(2, 2) << fileOut.widen('\n')
+        << "translation = " << translation[0] << " " << translation[1] << " "
+        << translation[2] << " " << fileOut.widen('\n')
+        << fileOut.widen('\n')
+        << "[view]" << fileOut.widen('\n')
+        << "id = " << view->id_view << fileOut.widen('\n')
+        << "name = " << stlplus::filename_part(srcImage.c_str()) << fileOut.widen('\n');
+
+      // To do:  trim any extra separator(s) from openMVG name we receive, e.g.:
+      // '/home/insight/openMVG_KevinCain/openMVG_Build/software/SfM/ImageDataset_SceauxCastle/images//100_7100.JPG'
+      std::ofstream file(
+        stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory),
+        "meta","ini").c_str());
+      file << fileOut.str();
+      file.close();
+
+      // Save a thumbnail image "thumbnail.png", 50x50 pixels
+      thumbnail = create_thumbnail(image, 50, 50);
+      const std::string dstThumbnailImage =
+        stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory), "thumbnail","png");
+      WriteImage(dstThumbnailImage.c_str(), thumbnail);
+
+      ++my_progress_bar;
+    }
   }
   return bOk;
 }

--- a/src/third_party/progress/progress.hpp
+++ b/src/third_party/progress/progress.hpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <string>
 #include <algorithm>
+#include <atomic>
 using namespace std;
 
 /**
@@ -120,8 +121,8 @@ class C_Progress
 
   protected:
     /// Internal data to _count the number of step (the _count can go to the _expected_count value).
-    unsigned long _count, _expected_count, _next_tic_count;
-    unsigned int  _tic;
+    std::atomic<unsigned long> _count, _expected_count, _next_tic_count;
+    std::atomic<unsigned int> _tic;
 
   private:
     virtual void inc_tic()


### PR DESCRIPTION
With this code change, the MVE2 exporter gets refactored to first write the complete `synth_0.out` file and afterwards export all views in parallel.