### PR TITLE
Define NCOMPLEX also for users of cxsparse.

### DIFF
--- a/src/third_party/cxsparse/CMakeLists.txt
+++ b/src/third_party/cxsparse/CMakeLists.txt
@@ -10,9 +10,10 @@ INCLUDE_DIRECTORIES(./
 
 FILE(GLOB CXSparse_SRCS "Source/*.c")
 set_source_files_properties(${CXSparse_SRCS} PROPERTIES LANGUAGE C)
-add_definitions(-DNCOMPLEX)
 
 ADD_LIBRARY(cxsparse STATIC ${CXSparse_SRCS})
+target_compile_definitions(cxsparse PUBLIC NCOMPLEX)
+
 if(UNIX)
   TARGET_LINK_LIBRARIES(cxsparse m)
   SET_TARGET_PROPERTIES(cxsparse PROPERTIES COMPILE_FLAGS -fPIC)


### PR DESCRIPTION
Make NCOMPLEX defined not only when compiling cxsparse but also when
using it. Fixes some warnings and makes compiling and using cxsparse
consistent.