### PR TITLE
Disable warning about size_t conversions for ceres

### DIFF
--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -81,6 +81,10 @@ if (DEFINED OpenMVG_USE_INTERNAL_CERES)
   add_subdirectory(ceres-solver)
   set_property(TARGET cxsparse PROPERTY FOLDER OpenMVG/3rdParty/ceres)
   set_property(TARGET ceres PROPERTY FOLDER OpenMVG/3rdParty/ceres)
+  if (MSVC)
+    # Disable warning about size_t conversions.
+    target_compile_options(ceres PRIVATE "/wd4267")
+  endif()
 endif()
 
 # Add an Approximate Nearest Neighbor library


### PR DESCRIPTION
There are many warnings C4267 when compiling with msvc2015 64bit about
conversion from size_t to smaller data types, possible loss of data.
There is not much we can do about it, so we just disable the warning
here.