### PR TITLE
Disable warning about size_t conversions for 3rd party libraries

### DIFF
--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -10,6 +10,11 @@ if(UNIX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif(UNIX)
 
+if (MSVC)
+  # Disable warning about size_t conversions for all third_party libraries.
+  add_compile_options(/wd4267)
+endif()
+
 # Unit test library
 if (OpenMVG_BUILD_TESTS)
   add_subdirectory(CppUnitLite)


### PR DESCRIPTION
There are many warnings C4267 when compiling with msvc2015 64bit about
conversion from size_t to smaller data types, possible loss of data.
There is not much we can do about it for third_party libraries here, so
we just disable the warning.