### PR TITLE
Added missing header files for VO example and dipole

### DIFF
--- a/src/openMVG/features/dipole/dipole_descriptor.hpp
+++ b/src/openMVG/features/dipole/dipole_descriptor.hpp
@@ -9,7 +9,9 @@
 #ifndef OPENMVG_FEATURES_DIPOLE_DIPOLE_DESCRIPTOR_HPP
 #define OPENMVG_FEATURES_DIPOLE_DIPOLE_DESCRIPTOR_HPP
 
+
 #include "openMVG/features/feature.hpp"
+#include "openMVG/features/descriptor.hpp"
 #include "openMVG/image/image_container.hpp"
 #include "openMVG/image/sample.hpp"
 

--- a/src/software/VO/Tracker.hpp
+++ b/src/software/VO/Tracker.hpp
@@ -8,11 +8,13 @@
 
 #ifndef TRACKER_VO_HPP
 #define TRACKER_VO_HPP
-
 #include <software/VO/Abstract_Tracker.hpp>
 #include <openMVG/features/dipole/dipole_descriptor.hpp>
-#include <openMVG/features/feature.hpp>
 
+#include <openMVG/features/fast/fast_detector.hpp>
+#include <openMVG/features/feature.hpp>
+#include <openMVG/features/feature_container.hpp>
+#include "openMVG/matching/metric.hpp"
 #include <vector>
 
 namespace openMVG  {
@@ -63,6 +65,7 @@ struct Tracker_fast_dipole : public Abstract_Tracker
         for (int i=0; i < (int)pt_to_track.size(); ++i)
         {
           size_t best_idx = std::numeric_limits<size_t>::infinity();
+          
           typedef openMVG::matching::L2<float> metricT;
           metricT metric;
           metricT::ResultType best_distance = 30;//std::numeric_limits<double>::infinity();


### PR DESCRIPTION
Hi,

I have noticed that after recent changes to the code (removal of features.hpp) the VO example (and dipole descriptor used there) does not compile anymore. Or I'm overlooking something.

The Tracker.hpp in VO is missing headers:

#include <openMVG/features/fast/fast_detector.hpp>
#include <openMVG/features/feature_container.hpp>
#include "openMVG/matching/metric.hpp"

and dipole_descriptor.hpp:

#include "openMVG/features/descriptor.hpp"

Cheers,
Klemen