### PR TITLE
Iterative Closest Point algorithm

### DIFF
--- a/src/openMVG/geometry/CMakeLists.txt
+++ b/src/openMVG/geometry/CMakeLists.txt
@@ -6,3 +6,7 @@ UNIT_TEST(openMVG half_space_intersection "openMVG_numeric;${CLP_LIBRARIES};${CO
 UNIT_TEST(openMVG frustum_intersection "openMVG_numeric;openMVG_multiview_test_data;openMVG_multiview;${CLP_LIBRARIES};${COINUTILS_LIBRARY};${OSI_LIBRARY}")
 
 UNIT_TEST(openMVG frustum_box_intersection "openMVG_numeric;openMVG_multiview_test_data;openMVG_multiview;${CLP_LIBRARIES};${COINUTILS_LIBRARY};${OSI_LIBRARY}")
+
+UNIT_TEST(openMVG kd_tree_3d "openMVG_numeric;")
+
+add_subdirectory( registration ) 

--- a/src/openMVG/geometry/kd_tree_3d.hpp
+++ b/src/openMVG/geometry/kd_tree_3d.hpp
@@ -1,0 +1,220 @@
+#ifndef OPENMVG_GEOMETRY_KDTREE3D_HPP
+#define OPENMVG_GEOMETRY_KDTREE3D_HPP
+
+#include "openMVG/numeric/numeric.h"
+
+#include <flann/flann.hpp>
+
+#include <memory>
+
+namespace openMVG
+{
+namespace geometry
+{
+  /**
+   * @brief Efficient data structure for searching neighbors in a 3d point cloud 
+   * @TODO : find a better class name 
+   * @tparam Scalar Scalar type used to define points coordinates 
+   * @tparam Metric Metric used to compute distance between points 
+   */
+  template <typename Scalar, typename Metric = flann::L2<Scalar>>
+  struct KDTree3d
+  {
+  public:
+    using DistanceType = typename Metric::ResultType;
+
+    /**
+      * @brief Ctr 
+      * @param set Set of point used for searching 
+      */
+    KDTree3d( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &set );
+
+    /**
+      * @brief Destructor 
+      */
+    ~KDTree3d();
+
+    /**
+     * @brief Search for the nearest neighbors of a given point
+     * @param query Query point 
+     * @param[out] index Index of the nearest point 
+     * @param[out] dist Distance between query and nearest point 
+     * @retval true if search is done without any problem 
+     * @retval false if there was an error suring search 
+     */
+    bool Search( const Vec3 &query, int &index, DistanceType &dist ) const;
+
+    /**
+     * @brief Search for the nearest neighbor of a list of points 
+     * @param query list of query points (one per row) 
+     * @param[out] indices Index of the nearest point 
+     * @param[out] dist Distance between query and it's nearest point  
+     * @retval true if search is done without any problem 
+     * @retval false if there was an error suring search 
+     */
+    bool Search( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &query,
+                 std::vector<int> &indices,
+                 std::vector<DistanceType> &dists ) const;
+
+    /**
+     * @brief Search for the N nearest neighbors of a given point 
+     * @param query Query point
+     * @param Nb number of point to search  
+     * @param[out] indices Index of the nearest points 
+     * @param[out] dist Distance between query and nearest points 
+     * @retval true if search is done without any problem 
+     * @retval false if there was an error suring search 
+     */
+    bool Search( const Vec3 &query, const int Nb, std::vector<int> &indices, std::vector<DistanceType> &dist ) const;
+
+    /**
+    * @brief Search for the N nearest neighbors of a list of point 
+    * @param query List of query point (one per row) 
+    * @param Nb Number of neighbors to search 
+    * @param[out] indices of the nearest points (One row per query point, Nb columns)
+    * @param[out] dists of the nearest points (One row per query point, Nb columns)
+    * @retval true if search is done without any problem 
+    * @retval false if there was an error suring search 
+    */
+    bool Search( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &query,
+                 const int Nb,
+                 Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &indices,
+                 Eigen::Matrix<DistanceType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &dists ) const;
+
+  private:
+    /// The dataset in flann format
+    std::unique_ptr<flann::Matrix<Scalar>> target_set_;
+    /// The kdtree in flann format
+    std::unique_ptr<flann::Index<Metric>> target_index_;
+  };
+
+  /**
+   * @brief Efficient data structure for searching neighbors in a 3d point cloud 
+   * @TODO : find a better class name 
+   * @tparam Scalar Scalar type used to define points coordinates 
+   */
+  template <typename Scalar, typename Metric>
+  KDTree3d<Scalar, Metric>::KDTree3d( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &set )
+  {
+    // Build the index
+    target_set_.reset( new flann::Matrix<Scalar>( (Scalar *)set.data(), set.rows(), 3 ) );
+    // Use 100% precision (an exact Kd Tree)
+    target_index_.reset( new flann::Index<Metric>( *target_set_, flann::AutotunedIndexParams( 1.0 ) ) );
+    target_index_->buildIndex();
+  }
+
+  /**
+   * @brief Destructor 
+   */
+  template <typename Scalar, typename Metric>
+  KDTree3d<Scalar, Metric>::~KDTree3d()
+  {
+    target_set_.reset();
+    target_index_.reset();
+  }
+
+  /**
+   * @brief Search for the nearest neighbors
+   * @param query Query point 
+   * @param[out] index Index of the nearest point 
+   * @param[out] dist Distance between query and nearest point 
+   */
+  template <typename Scalar, typename Metric>
+  bool KDTree3d<Scalar, Metric>::Search( const Vec3 &query, int &index, DistanceType &dist ) const
+  {
+    // Prepare data
+    int *indexPtr   = &index;
+    Scalar *distPtr = &dist;
+    flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), 1, 3 );
+    flann::Matrix<int> indices( indexPtr, 1, 1 );
+    flann::Matrix<DistanceType> dists( distPtr, 1, 1 );
+
+    // Perform search
+    return target_index_->knnSearch( queries, indices, dists, 1, flann::SearchParams( flann::FLANN_CHECKS_AUTOTUNED ) ) > 0;
+  }
+
+  /**
+     * @brief Search for the nearest neighbor of a list of points 
+     * @param query list of query points (one per row) 
+     * @param[out] indices Index of the nearest point 
+     * @param[out] dist Distance between query and it's nearest point  
+     * @retval true if search is done without any problem 
+     * @retval false if there was an error suring search 
+     */
+  template <typename Scalar, typename Metric>
+  bool KDTree3d<Scalar, Metric>::Search( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &query,
+                                         std::vector<int> &indices,
+                                         std::vector<DistanceType> &dists ) const
+  {
+    // Prepare data
+    indices.resize( query.rows() );
+    dists.resize( query.rows() );
+
+    int *indexPtr   = &( indices[ 0 ] );
+    Scalar *distPtr = &( dists[ 0 ] );
+    flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), query.rows(), 3 );
+    flann::Matrix<int> findices( indexPtr, query.rows(), 1 );
+    flann::Matrix<DistanceType> fdists( distPtr, query.rows(), 1 );
+
+    // Perform search
+    return target_index_->knnSearch( queries, findices, fdists, 1, flann::SearchParams( flann::FLANN_CHECKS_AUTOTUNED ) ) > 0;
+  }
+
+  /**
+   * @brief Search for the N nearest neighbors 
+   * @param query Query point
+   * @param Nb number of point to search  
+   * @param[out] indices Index of the nearest points 
+   * @param[out] dist Distance between query and nearest points 
+   */
+  template <typename Scalar, typename Metric>
+  bool KDTree3d<Scalar, Metric>::Search( const Vec3 &query, const int Nb, std::vector<int> &indices, std::vector<DistanceType> &dist ) const
+  {
+    indices.resize( Nb );
+    dist.resize( Nb );
+
+    // Perform search
+    // Prepare data
+    int *indexPtr   = &( indices[ 0 ] );
+    Scalar *distPtr = &( dist[ 0 ] );
+    flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), 1, 3 );
+    flann::Matrix<int> findices( indexPtr, 1, Nb );
+    flann::Matrix<DistanceType> dists( distPtr, 1, Nb );
+
+    // Perform search
+    return target_index_->knnSearch( queries, findices, dists, Nb, flann::SearchParams( flann::FLANN_CHECKS_AUTOTUNED ) ) > 0;
+  }
+
+  /**
+    * @brief Search for the N nearest neighbors of a list of point 
+    * @param query List of query point (one per row) 
+    * @param Nb Number of neighbors to search 
+    * @param[out] indices of the nearest points (One row per query point, Nb columns)
+    * @param[out] dists of the nearest points (One row per query point, Nb columns)
+    * @retval true if search is done without any problem 
+    * @retval false if there was an error suring search 
+    */
+  template <typename Scalar, typename Metric>
+  bool KDTree3d<Scalar, Metric>::Search( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &query,
+                                         const int Nb,
+                                         Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &indices,
+                                         Eigen::Matrix<DistanceType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &dists ) const
+  {
+    indices.resize( query.rows(), Nb );
+    dists.resize( query.rows(), Nb );
+
+    // Prepare data
+    int *indexPtr   = indices.data();
+    Scalar *distPtr = dists.data();
+    flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), query.rows(), 3 );
+    flann::Matrix<int> findices( indexPtr, query.rows(), Nb );
+    flann::Matrix<DistanceType> fdists( distPtr, query.rows(), Nb );
+
+    // Perform search
+    return target_index_->knnSearch( queries, findices, fdists, Nb, flann::SearchParams( flann::FLANN_CHECKS_AUTOTUNED ) ) > 0;
+  }
+
+} // namespace geometry
+} // namespace openMVG
+
+#endif

--- a/src/openMVG/geometry/kd_tree_3d.hpp
+++ b/src/openMVG/geometry/kd_tree_3d.hpp
@@ -11,70 +11,71 @@ namespace openMVG
 {
 namespace geometry
 {
-  /**
-   * @brief Efficient data structure for searching neighbors in a 3d point cloud 
-   * @TODO : find a better class name 
-   * @tparam Scalar Scalar type used to define points coordinates 
-   * @tparam Metric Metric used to compute distance between points 
-   */
-  template <typename Scalar, typename Metric = flann::L2<Scalar>>
-  struct KDTree3d
-  {
+  
+/**
+ * @brief Efficient data structure for searching neighbors in a 3d point cloud
+ * @TODO : find a better class name
+ * @tparam Scalar Scalar type used to define points coordinates
+ * @tparam Metric Metric used to compute distance between points
+ */
+template <typename Scalar, typename Metric = flann::L2<Scalar>>
+struct KDTree3d
+{
   public:
     using DistanceType = typename Metric::ResultType;
 
     /**
-      * @brief Ctr 
-      * @param set Set of point used for searching 
+      * @brief Ctr
+      * @param set Set of point used for searching
       */
     KDTree3d( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &set );
 
     /**
-      * @brief Destructor 
+      * @brief Destructor
       */
     ~KDTree3d();
 
     /**
      * @brief Search for the nearest neighbors of a given point
-     * @param query Query point 
-     * @param[out] index Index of the nearest point 
-     * @param[out] dist Distance between query and nearest point 
-     * @retval true if search is done without any problem 
-     * @retval false if there was an error suring search 
+     * @param query Query point
+     * @param[out] index Index of the nearest point
+     * @param[out] dist Distance between query and nearest point
+     * @retval true if search is done without any problem
+     * @retval false if there was an error suring search
      */
     bool Search( const Vec3 &query, int &index, DistanceType &dist ) const;
 
     /**
-     * @brief Search for the nearest neighbor of a list of points 
-     * @param query list of query points (one per row) 
-     * @param[out] indices Index of the nearest point 
-     * @param[out] dist Distance between query and it's nearest point  
-     * @retval true if search is done without any problem 
-     * @retval false if there was an error suring search 
+     * @brief Search for the nearest neighbor of a list of points
+     * @param query list of query points (one per row)
+     * @param[out] indices Index of the nearest point
+     * @param[out] dist Distance between query and it's nearest point
+     * @retval true if search is done without any problem
+     * @retval false if there was an error suring search
      */
     bool Search( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &query,
                  std::vector<int> &indices,
                  std::vector<DistanceType> &dists ) const;
 
     /**
-     * @brief Search for the N nearest neighbors of a given point 
+     * @brief Search for the N nearest neighbors of a given point
      * @param query Query point
-     * @param Nb number of point to search  
-     * @param[out] indices Index of the nearest points 
-     * @param[out] dist Distance between query and nearest points 
-     * @retval true if search is done without any problem 
-     * @retval false if there was an error suring search 
+     * @param Nb number of point to search
+     * @param[out] indices Index of the nearest points
+     * @param[out] dist Distance between query and nearest points
+     * @retval true if search is done without any problem
+     * @retval false if there was an error suring search
      */
     bool Search( const Vec3 &query, const int Nb, std::vector<int> &indices, std::vector<DistanceType> &dist ) const;
 
     /**
-    * @brief Search for the N nearest neighbors of a list of point 
-    * @param query List of query point (one per row) 
-    * @param Nb Number of neighbors to search 
+    * @brief Search for the N nearest neighbors of a list of point
+    * @param query List of query point (one per row)
+    * @param Nb Number of neighbors to search
     * @param[out] indices of the nearest points (One row per query point, Nb columns)
     * @param[out] dists of the nearest points (One row per query point, Nb columns)
-    * @retval true if search is done without any problem 
-    * @retval false if there was an error suring search 
+    * @retval true if search is done without any problem
+    * @retval false if there was an error suring search
     */
     bool Search( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &query,
                  const int Nb,
@@ -86,133 +87,133 @@ namespace geometry
     std::unique_ptr<flann::Matrix<Scalar>> target_set_;
     /// The kdtree in flann format
     std::unique_ptr<flann::Index<Metric>> target_index_;
-  };
+};
 
-  /**
-   * @brief Efficient data structure for searching neighbors in a 3d point cloud 
-   * @TODO : find a better class name 
-   * @tparam Scalar Scalar type used to define points coordinates 
+/**
+ * @brief Efficient data structure for searching neighbors in a 3d point cloud
+ * @TODO : find a better class name
+ * @tparam Scalar Scalar type used to define points coordinates
+ */
+template <typename Scalar, typename Metric>
+KDTree3d<Scalar, Metric>::KDTree3d( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &set )
+{
+  // Build the index
+  target_set_.reset( new flann::Matrix<Scalar>( ( Scalar * )set.data(), set.rows(), 3 ) );
+  // Use 100% precision (an exact Kd Tree)
+  target_index_.reset( new flann::Index<Metric>( *target_set_, flann::KDTreeSingleIndexParams( 8 ) ) ) ;
+  target_index_->buildIndex();
+}
+
+/**
+ * @brief Destructor
+ */
+template <typename Scalar, typename Metric>
+KDTree3d<Scalar, Metric>::~KDTree3d()
+{
+  target_set_.reset();
+  target_index_.reset();
+}
+
+/**
+ * @brief Search for the nearest neighbors
+ * @param query Query point
+ * @param[out] index Index of the nearest point
+ * @param[out] dist Distance between query and nearest point
+ */
+template <typename Scalar, typename Metric>
+bool KDTree3d<Scalar, Metric>::Search( const Vec3 &query, int &index, DistanceType &dist ) const
+{
+  // Prepare data
+  int *indexPtr   = &index;
+  Scalar *distPtr = &dist;
+  flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), 1, 3 );
+  flann::Matrix<int> indices( indexPtr, 1, 1 );
+  flann::Matrix<DistanceType> dists( distPtr, 1, 1 );
+
+  // Perform search
+  return target_index_->knnSearch( queries, indices, dists, 1, flann::SearchParams( flann::FLANN_CHECKS_UNLIMITED ) ) > 0;
+}
+
+/**
+   * @brief Search for the nearest neighbor of a list of points
+   * @param query list of query points (one per row)
+   * @param[out] indices Index of the nearest point
+   * @param[out] dist Distance between query and it's nearest point
+   * @retval true if search is done without any problem
+   * @retval false if there was an error suring search
    */
-  template <typename Scalar, typename Metric>
-  KDTree3d<Scalar, Metric>::KDTree3d( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &set )
-  {
-    // Build the index
-    target_set_.reset( new flann::Matrix<Scalar>( (Scalar *)set.data(), set.rows(), 3 ) );
-    // Use 100% precision (an exact Kd Tree)
-    target_index_.reset( new flann::Index<Metric>( *target_set_, flann::AutotunedIndexParams( 1.0 ) ) );
-    target_index_->buildIndex();
-  }
+template <typename Scalar, typename Metric>
+bool KDTree3d<Scalar, Metric>::Search( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &query,
+                                       std::vector<int> &indices,
+                                       std::vector<DistanceType> &dists ) const
+{
+  // Prepare data
+  indices.resize( query.rows() );
+  dists.resize( query.rows() );
 
-  /**
-   * @brief Destructor 
-   */
-  template <typename Scalar, typename Metric>
-  KDTree3d<Scalar, Metric>::~KDTree3d()
-  {
-    target_set_.reset();
-    target_index_.reset();
-  }
+  int *indexPtr   = &( indices[ 0 ] );
+  Scalar *distPtr = &( dists[ 0 ] );
+  flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), query.rows(), 3 );
+  flann::Matrix<int> findices( indexPtr, query.rows(), 1 );
+  flann::Matrix<DistanceType> fdists( distPtr, query.rows(), 1 );
 
-  /**
-   * @brief Search for the nearest neighbors
-   * @param query Query point 
-   * @param[out] index Index of the nearest point 
-   * @param[out] dist Distance between query and nearest point 
-   */
-  template <typename Scalar, typename Metric>
-  bool KDTree3d<Scalar, Metric>::Search( const Vec3 &query, int &index, DistanceType &dist ) const
-  {
-    // Prepare data
-    int *indexPtr   = &index;
-    Scalar *distPtr = &dist;
-    flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), 1, 3 );
-    flann::Matrix<int> indices( indexPtr, 1, 1 );
-    flann::Matrix<DistanceType> dists( distPtr, 1, 1 );
+  // Perform search
+  return target_index_->knnSearch( queries, findices, fdists, 1, flann::SearchParams( flann::FLANN_CHECKS_UNLIMITED ) ) > 0;
+}
 
-    // Perform search
-    return target_index_->knnSearch( queries, indices, dists, 1, flann::SearchParams( flann::FLANN_CHECKS_AUTOTUNED ) ) > 0;
-  }
+/**
+ * @brief Search for the N nearest neighbors
+ * @param query Query point
+ * @param Nb number of point to search
+ * @param[out] indices Index of the nearest points
+ * @param[out] dist Distance between query and nearest points
+ */
+template <typename Scalar, typename Metric>
+bool KDTree3d<Scalar, Metric>::Search( const Vec3 &query, const int Nb, std::vector<int> &indices, std::vector<DistanceType> &dist ) const
+{
+  indices.resize( Nb );
+  dist.resize( Nb );
 
-  /**
-     * @brief Search for the nearest neighbor of a list of points 
-     * @param query list of query points (one per row) 
-     * @param[out] indices Index of the nearest point 
-     * @param[out] dist Distance between query and it's nearest point  
-     * @retval true if search is done without any problem 
-     * @retval false if there was an error suring search 
-     */
-  template <typename Scalar, typename Metric>
-  bool KDTree3d<Scalar, Metric>::Search( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &query,
-                                         std::vector<int> &indices,
-                                         std::vector<DistanceType> &dists ) const
-  {
-    // Prepare data
-    indices.resize( query.rows() );
-    dists.resize( query.rows() );
+  // Perform search
+  // Prepare data
+  int *indexPtr   = &( indices[ 0 ] );
+  Scalar *distPtr = &( dist[ 0 ] );
+  flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), 1, 3 );
+  flann::Matrix<int> findices( indexPtr, 1, Nb );
+  flann::Matrix<DistanceType> dists( distPtr, 1, Nb );
 
-    int *indexPtr   = &( indices[ 0 ] );
-    Scalar *distPtr = &( dists[ 0 ] );
-    flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), query.rows(), 3 );
-    flann::Matrix<int> findices( indexPtr, query.rows(), 1 );
-    flann::Matrix<DistanceType> fdists( distPtr, query.rows(), 1 );
+  // Perform search
+  return target_index_->knnSearch( queries, findices, dists, Nb, flann::SearchParams( flann::FLANN_CHECKS_UNLIMITED ) ) > 0;
+}
 
-    // Perform search
-    return target_index_->knnSearch( queries, findices, fdists, 1, flann::SearchParams( flann::FLANN_CHECKS_AUTOTUNED ) ) > 0;
-  }
+/**
+  * @brief Search for the N nearest neighbors of a list of point
+  * @param query List of query point (one per row)
+  * @param Nb Number of neighbors to search
+  * @param[out] indices of the nearest points (One row per query point, Nb columns)
+  * @param[out] dists of the nearest points (One row per query point, Nb columns)
+  * @retval true if search is done without any problem
+  * @retval false if there was an error suring search
+  */
+template <typename Scalar, typename Metric>
+bool KDTree3d<Scalar, Metric>::Search( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &query,
+                                       const int Nb,
+                                       Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &indices,
+                                       Eigen::Matrix<DistanceType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &dists ) const
+{
+  indices.resize( query.rows(), Nb );
+  dists.resize( query.rows(), Nb );
 
-  /**
-   * @brief Search for the N nearest neighbors 
-   * @param query Query point
-   * @param Nb number of point to search  
-   * @param[out] indices Index of the nearest points 
-   * @param[out] dist Distance between query and nearest points 
-   */
-  template <typename Scalar, typename Metric>
-  bool KDTree3d<Scalar, Metric>::Search( const Vec3 &query, const int Nb, std::vector<int> &indices, std::vector<DistanceType> &dist ) const
-  {
-    indices.resize( Nb );
-    dist.resize( Nb );
+  // Prepare data
+  int *indexPtr   = indices.data();
+  Scalar *distPtr = dists.data();
+  flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), query.rows(), 3 );
+  flann::Matrix<int> findices( indexPtr, query.rows(), Nb );
+  flann::Matrix<DistanceType> fdists( distPtr, query.rows(), Nb );
 
-    // Perform search
-    // Prepare data
-    int *indexPtr   = &( indices[ 0 ] );
-    Scalar *distPtr = &( dist[ 0 ] );
-    flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), 1, 3 );
-    flann::Matrix<int> findices( indexPtr, 1, Nb );
-    flann::Matrix<DistanceType> dists( distPtr, 1, Nb );
-
-    // Perform search
-    return target_index_->knnSearch( queries, findices, dists, Nb, flann::SearchParams( flann::FLANN_CHECKS_AUTOTUNED ) ) > 0;
-  }
-
-  /**
-    * @brief Search for the N nearest neighbors of a list of point 
-    * @param query List of query point (one per row) 
-    * @param Nb Number of neighbors to search 
-    * @param[out] indices of the nearest points (One row per query point, Nb columns)
-    * @param[out] dists of the nearest points (One row per query point, Nb columns)
-    * @retval true if search is done without any problem 
-    * @retval false if there was an error suring search 
-    */
-  template <typename Scalar, typename Metric>
-  bool KDTree3d<Scalar, Metric>::Search( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &query,
-                                         const int Nb,
-                                         Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &indices,
-                                         Eigen::Matrix<DistanceType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &dists ) const
-  {
-    indices.resize( query.rows(), Nb );
-    dists.resize( query.rows(), Nb );
-
-    // Prepare data
-    int *indexPtr   = indices.data();
-    Scalar *distPtr = dists.data();
-    flann::Matrix<Scalar> queries( const_cast<Scalar *>( query.data() ), query.rows(), 3 );
-    flann::Matrix<int> findices( indexPtr, query.rows(), Nb );
-    flann::Matrix<DistanceType> fdists( distPtr, query.rows(), Nb );
-
-    // Perform search
-    return target_index_->knnSearch( queries, findices, fdists, Nb, flann::SearchParams( flann::FLANN_CHECKS_AUTOTUNED ) ) > 0;
-  }
+  // Perform search
+  return target_index_->knnSearch( queries, findices, fdists, Nb, flann::SearchParams( flann::FLANN_CHECKS_UNLIMITED ) ) > 0;
+}
 
 } // namespace geometry
 } // namespace openMVG

--- a/src/openMVG/geometry/kd_tree_3d.hpp
+++ b/src/openMVG/geometry/kd_tree_3d.hpp
@@ -1,3 +1,11 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2017 Romuald Perrot.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 #ifndef OPENMVG_GEOMETRY_KDTREE3D_HPP
 #define OPENMVG_GEOMETRY_KDTREE3D_HPP
 
@@ -11,7 +19,7 @@ namespace openMVG
 {
 namespace geometry
 {
-  
+
 /**
  * @brief Efficient data structure for searching neighbors in a 3d point cloud
  * @TODO : find a better class name

--- a/src/openMVG/geometry/kd_tree_3d.hpp
+++ b/src/openMVG/geometry/kd_tree_3d.hpp
@@ -108,7 +108,7 @@ KDTree3d<Scalar, Metric>::KDTree3d( const Eigen::Matrix<Scalar, Eigen::Dynamic, 
   // Build the index
   target_set_.reset( new flann::Matrix<Scalar>( ( Scalar * )set.data(), set.rows(), 3 ) );
   // Use 100% precision (an exact Kd Tree)
-  target_index_.reset( new flann::Index<Metric>( *target_set_, flann::KDTreeSingleIndexParams( 15 ) ) ) ;
+  target_index_.reset( new flann::Index<Metric>( *target_set_, flann::KDTreeSingleIndexParams( 16 ) ) ) ;
   target_index_->buildIndex();
 }
 
@@ -139,7 +139,10 @@ bool KDTree3d<Scalar, Metric>::Search( const Vec3 &query, int &index, DistanceTy
   flann::Matrix<DistanceType> dists( distPtr, 1, 1 );
 
   // Perform search
-  return target_index_->knnSearch( queries, indices, dists, 1, flann::SearchParams( 0 , true , 32 ) ) > 0;
+  flann::SearchParams params( 0 , true , 32 ) ;
+  params.cores = 0 ;
+
+  return target_index_->knnSearch( queries, indices, dists, 1, params ) > 0;
 }
 
 /**
@@ -166,7 +169,10 @@ bool KDTree3d<Scalar, Metric>::Search( const Eigen::Matrix<Scalar, Eigen::Dynami
   flann::Matrix<DistanceType> fdists( distPtr, query.rows(), 1 );
 
   // Perform search
-  return target_index_->knnSearch( queries, findices, fdists, 1, flann::SearchParams( 0 , true , 32 ) ) > 0;
+  flann::SearchParams params( 0 , true , 32 ) ;
+  params.cores = 0 ;
+
+  return target_index_->knnSearch( queries, findices, fdists, 1, params ) > 0;
 }
 
 /**
@@ -191,7 +197,9 @@ bool KDTree3d<Scalar, Metric>::Search( const Vec3 &query, const int Nb, std::vec
   flann::Matrix<DistanceType> dists( distPtr, 1, Nb );
 
   // Perform search
-  return target_index_->knnSearch( queries, findices, dists, Nb, flann::SearchParams( 0 , true , 32 ) ) > 0;
+  flann::SearchParams params( 0 , true , 32 ) ;
+  params.cores = 0 ;
+  return target_index_->knnSearch( queries, findices, dists, Nb, params ) > 0;
 }
 
 /**
@@ -220,7 +228,10 @@ bool KDTree3d<Scalar, Metric>::Search( const Eigen::Matrix<Scalar, Eigen::Dynami
   flann::Matrix<DistanceType> fdists( distPtr, query.rows(), Nb );
 
   // Perform search
-  return target_index_->knnSearch( queries, findices, fdists, Nb, flann::SearchParams( 0 , true , 32 ) ) > 0;
+  flann::SearchParams params( 0 , true , 32 ) ;
+  params.cores = 0 ;
+
+  return target_index_->knnSearch( queries, findices, fdists, Nb, params ) > 0;
 }
 
 } // namespace geometry

--- a/src/openMVG/geometry/kd_tree_3d.hpp
+++ b/src/openMVG/geometry/kd_tree_3d.hpp
@@ -108,7 +108,7 @@ KDTree3d<Scalar, Metric>::KDTree3d( const Eigen::Matrix<Scalar, Eigen::Dynamic, 
   // Build the index
   target_set_.reset( new flann::Matrix<Scalar>( ( Scalar * )set.data(), set.rows(), 3 ) );
   // Use 100% precision (an exact Kd Tree)
-  target_index_.reset( new flann::Index<Metric>( *target_set_, flann::KDTreeSingleIndexParams( 8 ) ) ) ;
+  target_index_.reset( new flann::Index<Metric>( *target_set_, flann::KDTreeSingleIndexParams( 15 ) ) ) ;
   target_index_->buildIndex();
 }
 
@@ -139,7 +139,7 @@ bool KDTree3d<Scalar, Metric>::Search( const Vec3 &query, int &index, DistanceTy
   flann::Matrix<DistanceType> dists( distPtr, 1, 1 );
 
   // Perform search
-  return target_index_->knnSearch( queries, indices, dists, 1, flann::SearchParams( flann::FLANN_CHECKS_UNLIMITED ) ) > 0;
+  return target_index_->knnSearch( queries, indices, dists, 1, flann::SearchParams( 0 , true , 32 ) ) > 0;
 }
 
 /**
@@ -166,7 +166,7 @@ bool KDTree3d<Scalar, Metric>::Search( const Eigen::Matrix<Scalar, Eigen::Dynami
   flann::Matrix<DistanceType> fdists( distPtr, query.rows(), 1 );
 
   // Perform search
-  return target_index_->knnSearch( queries, findices, fdists, 1, flann::SearchParams( flann::FLANN_CHECKS_UNLIMITED ) ) > 0;
+  return target_index_->knnSearch( queries, findices, fdists, 1, flann::SearchParams( 0 , true , 32 ) ) > 0;
 }
 
 /**
@@ -191,7 +191,7 @@ bool KDTree3d<Scalar, Metric>::Search( const Vec3 &query, const int Nb, std::vec
   flann::Matrix<DistanceType> dists( distPtr, 1, Nb );
 
   // Perform search
-  return target_index_->knnSearch( queries, findices, dists, Nb, flann::SearchParams( flann::FLANN_CHECKS_UNLIMITED ) ) > 0;
+  return target_index_->knnSearch( queries, findices, dists, Nb, flann::SearchParams( 0 , true , 32 ) ) > 0;
 }
 
 /**
@@ -220,7 +220,7 @@ bool KDTree3d<Scalar, Metric>::Search( const Eigen::Matrix<Scalar, Eigen::Dynami
   flann::Matrix<DistanceType> fdists( distPtr, query.rows(), Nb );
 
   // Perform search
-  return target_index_->knnSearch( queries, findices, fdists, Nb, flann::SearchParams( flann::FLANN_CHECKS_UNLIMITED ) ) > 0;
+  return target_index_->knnSearch( queries, findices, fdists, Nb, flann::SearchParams( 0 , true , 32 ) ) > 0;
 }
 
 } // namespace geometry

--- a/src/openMVG/geometry/kd_tree_3d_test.cpp
+++ b/src/openMVG/geometry/kd_tree_3d_test.cpp
@@ -1,3 +1,11 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2017 Romuald Perrot.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 #include "openMVG/geometry/kd_tree_3d.hpp"
 
 #include "CppUnitLite/TestHarness.h"

--- a/src/openMVG/geometry/kd_tree_3d_test.cpp
+++ b/src/openMVG/geometry/kd_tree_3d_test.cpp
@@ -1,0 +1,243 @@
+#include "openMVG/geometry/kd_tree_3d.hpp"
+
+#include "CppUnitLite/TestHarness.h"
+#include "testing/testing.h"
+
+#include <iostream>
+
+using namespace openMVG;
+using namespace openMVG::geometry;
+
+TEST( kd_tree_3d, nothing )
+{
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  KDTree3d<double> tree( data );
+
+  Vec3 pt;
+  int index;
+  KDTree3d<double>::DistanceType dist;
+
+  EXPECT_FALSE( tree.Search( pt, index, dist ) );
+}
+
+TEST( Kd_tree_3d, onePointOnePoint )
+{
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  data.resize( 1, 3 );
+  data( 0, 0 ) = 0.0;
+  data( 0, 1 ) = 1.0;
+  data( 0, 2 ) = 2.0;
+
+  KDTree3d<double> tree( data );
+
+  Vec3 pt( 0.0, 0.0, 0.0 );
+  int index;
+  KDTree3d<double>::DistanceType dist;
+
+  EXPECT_TRUE( tree.Search( pt , index , dist ) ) ;
+
+  EXPECT_EQ( index , 0 ) ;
+
+  // squared distance 
+  EXPECT_EQ( dist , 5.0 ) ;
+}
+
+TEST( Kd_tree_3d , ThreePointsOnePoint )
+{
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  data.resize( 3, 3 );
+  data( 0, 0 ) = 0.0;
+  data( 0, 1 ) = 1.0;
+  data( 0, 2 ) = 2.0;
+
+  data( 1 , 0 ) = -10.0 ;
+  data( 1 , 1 ) = -11.0 ;
+  data( 1 , 2 ) = -3.0 ;
+
+  data( 2 , 0 ) = 2.0 ;
+  data( 2 , 1 ) = 3.0 ;
+  data( 2 , 2 ) = 3.0 ; 
+
+  KDTree3d<double> tree( data );
+
+  Vec3 pt( 0.0, 0.0, 0.0 );
+  int index;
+  KDTree3d<double>::DistanceType dist;
+
+  EXPECT_TRUE( tree.Search( pt , index , dist ) ) ;
+
+  EXPECT_EQ( index , 0 ) ;
+
+  // squared distance 
+  EXPECT_EQ( dist , 5.0 ) ;
+
+
+  pt = Vec3( 3.0 , 3.0 , 3.0 ) ;
+
+  EXPECT_TRUE( tree.Search( pt , index , dist ) ) ;
+
+  EXPECT_EQ( index , 2 ) ;
+
+  // squared distance 
+  EXPECT_EQ( dist , 1.0 ) ;
+
+
+  pt = Vec3( -10.0 , -11.0 , 0.0 ) ;
+
+
+  EXPECT_TRUE( tree.Search( pt , index , dist ) ) ;
+
+  EXPECT_EQ( index , 1 ) ;
+
+  // squared distance 
+  EXPECT_EQ( dist , 9.0 ) ;
+}
+
+
+TEST( Kd_tree_3d , ThreePointsOnePointTwoNN )
+{
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  data.resize( 3, 3 );
+  data( 0, 0 ) = 0.0;
+  data( 0, 1 ) = 1.0;
+  data( 0, 2 ) = 2.0;
+
+  data( 1 , 0 ) = -10.0 ;
+  data( 1 , 1 ) = -11.0 ;
+  data( 1 , 2 ) = -3.0 ;
+
+  data( 2 , 0 ) = 2.0 ;
+  data( 2 , 1 ) = 3.0 ;
+  data( 2 , 2 ) = 3.0 ; 
+
+  KDTree3d<double> tree( data );
+
+  Vec3 pt( 0.0, 0.0, 0.0 );
+  std::vector<int> index;
+  std::vector<KDTree3d<double>::DistanceType> dist;
+
+  index.resize(2) ;
+  dist.resize(2) ;
+
+  EXPECT_TRUE( tree.Search( pt , 2 , index , dist ) ) ;
+
+  EXPECT_EQ( index[0] , 0 ) ;
+
+  // squared distance 
+  EXPECT_EQ( dist[0] , 5.0 ) ;
+
+  EXPECT_EQ( index[1] , 2 ) ;
+
+  EXPECT_EQ( dist[1] , 22.0 ) ;
+}
+
+TEST( Kd_tree_3d , ThreePointsTwoPoints )
+{
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  data.resize( 3, 3 );
+  data( 0, 0 ) = 0.0;
+  data( 0, 1 ) = 1.0;
+  data( 0, 2 ) = 2.0;
+
+  data( 1 , 0 ) = -10.0 ;
+  data( 1 , 1 ) = -11.0 ;
+  data( 1 , 2 ) = -3.0 ;
+
+  data( 2 , 0 ) = 2.0 ;
+  data( 2 , 1 ) = 3.0 ;
+  data( 2 , 2 ) = 3.0 ; 
+
+  KDTree3d<double> tree( data );
+
+  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> pts ;
+
+  pts.resize( 2 , 3 ) ;
+
+  pts( 0 , 0 ) = 0.0 ;
+  pts( 0 , 1 ) = 0.0 ; 
+  pts( 0 , 2 ) = 0.0 ; 
+
+  pts( 1 , 0 ) = -10.0 ;
+  pts( 1 , 1 ) = -11.0 ;
+  pts( 1 , 2 ) = 0.0 ; 
+
+//  Eigen::Matrix<int,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> indices ; 
+//  Eigen::Matrix<KDTree3d<double>::DistanceType,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> dists ; 
+
+  std::vector< int > indices ; 
+  std::vector< KDTree3d<double>::DistanceType > dists ; 
+
+  EXPECT_TRUE( tree.Search( pts , indices , dists ) ) ;
+
+  // First pt 
+  EXPECT_EQ( indices[0] , 0 ) ;
+  EXPECT_EQ( dists[0] , 5.0 ) ;
+
+  // Second pt 
+  EXPECT_EQ( indices[1] , 1 ) ;
+  EXPECT_EQ( dists[1] , 9.0 ) ;  
+}
+
+TEST( Kd_tree_3d , ThreePointsTwoPointsTwoQueries )
+{
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  data.resize( 3, 3 );
+  data( 0, 0 ) = 0.0;
+  data( 0, 1 ) = 1.0;
+  data( 0, 2 ) = 2.0;
+
+  data( 1 , 0 ) = -10.0 ;
+  data( 1 , 1 ) = -11.0 ;
+  data( 1 , 2 ) = -3.0 ;
+
+  data( 2 , 0 ) = 2.0 ;
+  data( 2 , 1 ) = 3.0 ;
+  data( 2 , 2 ) = 3.0 ; 
+
+  KDTree3d<double> tree( data );
+
+  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> pts ;
+
+  pts.resize( 2 , 3 ) ;
+
+  pts( 0 , 0 ) = 0.0 ;
+  pts( 0 , 1 ) = 0.0 ; 
+  pts( 0 , 2 ) = 0.0 ; 
+
+  pts( 1 , 0 ) = -10.0 ;
+  pts( 1 , 1 ) = -11.0 ;
+  pts( 1 , 2 ) = 0.0 ; 
+
+  Eigen::Matrix<int,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> indices ; 
+  Eigen::Matrix<KDTree3d<double>::DistanceType,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> dists ; 
+
+  EXPECT_TRUE( tree.Search( pts , 2 , indices , dists ) ) ;
+
+  // First pt 
+  EXPECT_EQ( indices(0,0) , 0 ) ;
+  EXPECT_EQ( dists(0,0) , 5.0 ) ;
+  EXPECT_EQ( indices(0,1) , 2 ) ;
+  EXPECT_EQ( dists(0,1) , 22.0 ) ; 
+
+  // Second pt 
+  EXPECT_EQ( indices(1,0) , 1 ) ;
+  EXPECT_EQ( dists(1,0) , 9.0 ) ;  
+  EXPECT_EQ( indices(1,1) , 0 ) ;
+  EXPECT_EQ( dists(1,1) , 248.0 )
+  
+}
+
+
+/* ************************************************************************* */
+int main()
+{
+  TestResult tr;
+  return TestRegistry::runAllTests( tr );
+}
+/* ************************************************************************* */

--- a/src/openMVG/geometry/registration/CMakeLists.txt
+++ b/src/openMVG/geometry/registration/CMakeLists.txt
@@ -1,1 +1,1 @@
-UNIT_TEST(openMVG icp "openMVG_numeric;${CERES_LIBRARIES}")
+UNIT_TEST(openMVG icp "openMVG_numeric;libnabo;${CERES_LIBRARIES}")

--- a/src/openMVG/geometry/registration/CMakeLists.txt
+++ b/src/openMVG/geometry/registration/CMakeLists.txt
@@ -1,0 +1,1 @@
+UNIT_TEST(openMVG icp "openMVG_numeric;${CERES_LIBRARIES}")

--- a/src/openMVG/geometry/registration/icp.hpp
+++ b/src/openMVG/geometry/registration/icp.hpp
@@ -168,8 +168,8 @@ Mat4 EstimateTransformation( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eige
     std::pair< Eigen::Quaternion<Scalar> , Eigen::Matrix<Scalar, 3, 1> > tra = estimator( target , data , corresp ) ;
 
     Mat4 tmp = Mat4::Identity() ;
-    tmp.block( 0 , 0 , 3 , 3 ) = tra.first.toRotationMatrix() ;
-    tmp.block( 0 , 3 , 3 , 1 ) = tra.second ;
+    tmp.block( 0 , 0 , 3 , 3 ) = tra.first.toRotationMatrix().template cast<double>() ;
+    tmp.block( 0 , 3 , 3 , 1 ) = tra.second.template cast<double>() ;
 
     return tmp ;
   }
@@ -206,7 +206,9 @@ Mat4 EstimateTransformation( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eige
         ++id_out ;
       }
     }
-    return Eigen::umeyama( tmp_data , tmp_target , false ) ;
+    
+    const Eigen::Matrix<Scalar,4,4> res = Eigen::umeyama( tmp_data , tmp_target , false ) ;
+    return res.template cast<double>() ; 
   }
 }
 

--- a/src/openMVG/geometry/registration/icp.hpp
+++ b/src/openMVG/geometry/registration/icp.hpp
@@ -238,8 +238,6 @@ namespace geometry
         // Update final transformation and data point set
         final_tra = tmp * final_tra ;
 
-        std::cout << final_tra << std::endl ; 
-
         ++id_iteration;
       }
 

--- a/src/openMVG/geometry/registration/icp.hpp
+++ b/src/openMVG/geometry/registration/icp.hpp
@@ -1,3 +1,11 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2017 Romuald Perrot.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 #ifndef OPENMVG_GEOMETRY_REGISTRATION_ICP_HPP
 #define OPENMVG_GEOMETRY_REGISTRATION_ICP_HPP
 
@@ -32,10 +40,9 @@ static inline void Transform( Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::Ro
 {
   for( int id_pt = 0 ; id_pt < data.rows() ; ++id_pt )
   {
-    Eigen::Matrix<Scalar, 3, 1> cur_pt;
-    cur_pt << data( id_pt , 0 ) , data( id_pt , 1 ) , data( id_pt , 2 ) ;
-    const Eigen::Matrix<Scalar, 3, 1> tra_pt = ( q * cur_pt ) + t ;
-    data.row( id_pt ) = tra_pt.transpose() ;
+    //    const Eigen::Matrix<Scalar, 3, 1> cur_pt = data.row( id_pt ).transpose() ;
+    //    cur_pt << data( id_pt , 0 ) , data( id_pt , 1 ) , data( id_pt , 2 ) ;
+    data.row( id_pt ) = ( ( q * data.row( id_pt ).transpose() ) + t ).transpose() ;
   }
 }
 
@@ -97,22 +104,22 @@ static inline void RandomSubset( const size_t highest_value , // included
 }
 
 /**
-* @brief Compute standard deviation of a given set
+* @brief Compute standard deviation of a given vector
 * @param v a vector
 * @return standard deviation of the vector
 * @todo : move to numeric ?
-* @note : this assume that at least one value is in the set
+* @note : this assume that at least one value is in the vector
 */
 template< typename Scalar >
 static inline Scalar StdDev( const std::vector< Scalar > & v )
 {
-  double sum = std::accumulate( v.begin(), v.end(), Scalar( 0 ) );
-  double mean = sum / v.size();
+  const double sum = std::accumulate( v.begin(), v.end(), Scalar( 0 ) );
+  const double mean = sum / v.size();
 
   std::vector<double> diff( v.size() );
   std::transform( v.begin(), v.end(), diff.begin(),
                   std::bind2nd( std::minus<double>(), mean ) );
-  double sq_sum = std::inner_product( diff.begin(), diff.end(), diff.begin(), Scalar( 0 ) );
+  const double sq_sum = std::inner_product( diff.begin(), diff.end(), diff.begin(), Scalar( 0 ) );
   return std::sqrt( sq_sum / v.size() );
 }
 
@@ -145,8 +152,7 @@ void ICP( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &targe
   // Working sample
   Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> data = data_;
 
-  Mat4 final_tra;
-  final_tra.setIdentity();
+  Mat4 final_tra = Mat4::Identity() ;
 
   std::vector<int> corresp( data.rows() );
   std::vector<Scalar> distance( data.rows() );
@@ -192,6 +198,7 @@ void ICP( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &targe
         ++id_dist ;
       }
     }
+    compact_dist.resize( id_dist ) ;
 
     // 3 - Filter points based on 3 * stddev
     const Scalar t = 3.0 * StdDev( compact_dist ) ;
@@ -263,7 +270,6 @@ void ICP( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &targe
           openMVG::Vec3 &t,
           openMVG::Mat3 &R )
 {
-
   // Build Kd-Tree
   KDTree3d<Scalar> tree( target );
 
@@ -273,10 +279,8 @@ void ICP( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &targe
   // Working sample
   Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> data = data_;
 
-  Mat4 final_tra;
-  final_tra.setIdentity();
+  Mat4 final_tra = Mat4::Identity() ;
 
-  //  std::vector<bool> already_used( target.rows() );
   std::vector<int> corresp( data.rows() );
   std::vector<Scalar> distance( data.rows() );
 
@@ -322,6 +326,7 @@ void ICP( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &targe
         ++id_dist ;
       }
     }
+    compact_dist.resize( id_dist ) ;
 
     // 3 - Filter points based on 3 * stddev
     const Scalar t = 3.0 * StdDev( compact_dist ) ;

--- a/src/openMVG/geometry/registration/icp.hpp
+++ b/src/openMVG/geometry/registration/icp.hpp
@@ -1,0 +1,269 @@
+#ifndef OPENMVG_GEOMETRY_REGISTRATION_ICP_HPP
+#define OPENMVG_GEOMETRY_REGISTRATION_ICP_HPP
+
+#include "openMVG/geometry/kd_tree_3d.hpp"
+#include "openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp"
+#include "openMVG/numeric/numeric.h"
+
+#include <flann/flann.hpp>
+
+#include <memory>
+
+namespace openMVG
+{
+namespace geometry
+{
+  namespace registration
+  {
+
+    /**
+    * @brief Compute centroid of a point cloud 
+    * @TODO : look for an existing function or an eigen shortcut 
+    */
+    template <typename Scalar>
+    Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> PCCentroid( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3 , Eigen::RowMajor> &data )
+    {
+      Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> center;
+      center.fill( Scalar( 0 ) );
+      for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
+      {
+        center[ 0 ] += data( id_pt, 0 );
+        center[ 1 ] += data( id_pt, 1 );
+        center[ 2 ] += data( id_pt, 2 );
+      }
+
+      return center / data.rows();
+    }
+
+    /**
+    * @brief Compute distance between two points 
+    * @TODO : look for an existing function or an eigen shortcut 
+    */
+    template <typename Scalar>
+    Scalar PDistance( const Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> &p1, const Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> &p2 )
+    {
+      const Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> d = p1 - p2;
+
+      return d[ 0 ] * d[ 0 ] + d[ 1 ] * d[ 1 ] + d[ 2 ] * d[ 2 ];
+    }
+
+    /**
+    * @brief Compute threshold value as defined in BC-ICP method 
+    */
+    template <typename Scalar>
+    Scalar Threshold( const int Nmc,
+                      const Scalar lambda,
+                      const Scalar lambda_c,
+                      const Scalar s,
+                      const Scalar c,
+                      const Scalar meanSD )
+    {
+      if ( lambda > lambda_c )
+      {
+        return std::pow( Nmc, lambda ) * meanSD + s * c * c;
+      }
+      else
+      {
+        return meanSD;
+      }
+    }
+
+    /**
+    * @brief Transform data set using a specified transformation 
+    */
+    template <typename Scalar>
+    void Transform( Eigen::Matrix<Scalar, Eigen::Dynamic, 3 , Eigen::RowMajor> &data, const Mat4 &tra )
+    {
+      for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
+      {
+        const Scalar x = data( id_pt, 0 );
+        const Scalar y = data( id_pt, 1 );
+        const Scalar z = data( id_pt, 2 );
+        
+        Vec3 pt_tra( x * tra( 0, 0 ) + y * tra( 0, 1 ) + z * tra( 0, 2 ) + tra( 0, 3 ),
+                     x * tra( 1, 0 ) + y * tra( 1, 1 ) + z * tra( 1, 2 ) + tra( 1, 3 ),
+                     x * tra( 2, 0 ) + y * tra( 2, 1 ) + z * tra( 2, 2 ) + tra( 2, 3 ) );
+        const Scalar w = x * tra( 3 , 0 ) + y * tra( 3 , 1 ) + z * tra( 3 , 2 ) + tra( 3 , 3 ) ;  
+
+        data( id_pt, 0 ) = pt_tra[ 0 ] / w ;
+        data( id_pt, 1 ) = pt_tra[ 1 ] / w ;
+        data( id_pt, 2 ) = pt_tra[ 2 ] / w ;
+      }
+    }
+
+    /**
+  * @brief Given two sets of points: target and data 
+  * This function computes rigid transformation that maps model on target minimizing MSE distance 
+  * @param target Target shape : a matrix of 3d points (one point per row)
+  * @param data data shape : a matrix of 3d points (one point per row)
+  * @param nb_iteration Maximum number of iteration 
+  * @param mse_threshold Threshold use to stop computation 
+  * @param[out] t Translation transformation (3d vector) 
+  * @param[out] R Rotation transformation (3x3 rotation matrix)
+  * @note This is an implementation based on the BC-ICP algorithm 
+  */
+    template <typename Scalar>
+    void ICP( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3 , Eigen::RowMajor> &target,
+              const Eigen::Matrix<Scalar, Eigen::Dynamic, 3 , Eigen::RowMajor> &data_,
+              const unsigned long max_nb_iteration,
+              const double mse_threshold,
+              openMVG::Vec3 &t,
+              openMVG::Mat3 &R )
+    {
+      // Build Kd-Tree
+      KDTree3d<Scalar> tree( target );
+
+      unsigned long id_iteration = 0;
+      double cur_mse             = std::numeric_limits<Scalar>::max();
+      int Nmc                    = 10;
+
+      // Working sample
+      Eigen::Matrix<Scalar, Eigen::Dynamic, 3 , Eigen::RowMajor> data = data_;
+      Mat4 final_tra;
+      final_tra.setIdentity();
+
+      std::vector<bool> already_used( target.rows() );
+      std::vector<int> biunique_corresp( data.rows() );
+      std::vector<double> biunique_distance( data.rows() );
+
+      Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> indices;
+      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> dists;
+
+      while ( id_iteration < max_nb_iteration && cur_mse > mse_threshold )
+      {
+        std::fill( already_used.begin(), already_used.end(), false );
+        std::fill( biunique_corresp.begin(), biunique_corresp.end(), -1 );
+        std::fill( biunique_distance.begin(), biunique_distance.end(), -1.0 );
+
+        // Find Nmc nearest neighbors
+        tree.Search( data, Nmc, indices, dists );
+
+        // Compute binunique correspondance for each points
+        for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
+        {
+          for ( int id_n = 0; id_n < Nmc; ++id_n )
+          {
+            const int id_point = indices( id_pt, id_n );
+            if ( !already_used[ id_point ] )
+            {
+              // We've found one !
+              biunique_distance[ id_pt ] = dists( id_pt, id_n );
+              biunique_corresp[ id_pt ]  = id_point;
+              already_used[ id_point ]   = true;
+            }
+          }
+        }
+
+        // Compute outliers threshold
+        Scalar meanSD = Scalar( 0 );
+        int NbIn      = 0;
+        for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
+        {
+          if ( biunique_corresp[ id_pt ] >= 0 )
+          {
+            meanSD += biunique_distance[ id_pt ];
+            ++NbIn;
+          }
+        }
+        meanSD /= static_cast<Scalar>( NbIn );
+        const Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> pc1 = PCCentroid( target );
+        const Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> pc2 = PCCentroid( data );
+        const Scalar c        = PDistance( pc1, pc2 );
+        const Scalar s        = 1.0;
+        const Scalar lambda   = static_cast<Scalar>( data.rows() - NbIn ) / static_cast<Scalar>( data.rows() );
+        const Scalar lambda_c = 0.1;
+        const Scalar t        = Threshold( Nmc, lambda, lambda_c, s, c, meanSD );
+
+        // Filter points based on threshold
+        for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
+        {
+          if ( biunique_corresp[ id_pt ] >= 0 )
+          {
+            if ( biunique_distance[ id_pt ] > t )
+            {
+              biunique_corresp[ id_pt ]  = -1;
+              biunique_distance[ id_pt ] = -1.0;
+            }
+          }
+        }
+
+        // Compute rigid transformation using only pairs of biunique
+        // 1 - Build residual fonctor
+        // 2 - Run optimisation
+        RigidMotion3d3dEstimation<Scalar> estimator;
+        // Compute MSE error
+        std::pair<Mat3, Vec3> tra = estimator( target, data );
+        Mat4 tmp;
+        tmp( 0, 0 ) = tra.first( 0, 0 );
+        tmp( 0, 1 ) = tra.first( 0, 1 );
+        tmp( 0, 2 ) = tra.first( 0, 2 );
+        tmp( 0, 3 ) = tra.second[ 0 ];
+
+        tmp( 1, 0 ) = tra.first( 1, 0 );
+        tmp( 1, 1 ) = tra.first( 1, 1 );
+        tmp( 1, 2 ) = tra.first( 1, 2 );
+        tmp( 1, 3 ) = tra.second[ 1 ];
+
+        tmp( 2, 0 ) = tra.first( 2, 0 );
+        tmp( 2, 1 ) = tra.first( 2, 1 );
+        tmp( 2, 2 ) = tra.first( 2, 2 );
+        tmp( 2, 3 ) = tra.second[ 2 ];
+
+        tmp( 3 , 0 ) = 0.0 ;
+        tmp( 3 , 1 ) = 0.0 ;
+        tmp( 3 , 2 ) = 0.0 ; 
+        tmp( 3 , 3 ) = 1.0 ; 
+
+        // Update data points
+        Transform( data, tmp );
+        // Compute MSE between pairs of biunique
+        cur_mse = 0.0;
+        int nb_valid = 0 ; 
+        for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
+        {
+          const int corresp = biunique_corresp[ id_pt ];
+          if ( corresp >= 0 )
+          {
+            const double d[] = {data( id_pt, 0 ) - target( corresp, 0 ),
+                                data( id_pt, 1 ) - target( corresp, 1 ),
+                                data( id_pt, 2 ) - target( corresp, 2 )};
+
+            // Add distance between the two points
+            cur_mse += d[0] * d[0] + d[1] * d[1] + d[2] * d[2] ; 
+            ++nb_valid ; 
+          }
+        }
+        cur_mse /= static_cast<double>( nb_valid ) ;
+
+        // Update final transformation and data point set
+        final_tra = tmp * final_tra ;
+
+        std::cout << final_tra << std::endl ; 
+
+        ++id_iteration;
+      }
+
+      // Compute final transformation
+      R( 0, 0 ) = final_tra( 0, 0 );
+      R( 0, 1 ) = final_tra( 0, 1 );
+      R( 0, 2 ) = final_tra( 0, 2 );
+
+      R( 1, 0 ) = final_tra( 1, 0 );
+      R( 1, 1 ) = final_tra( 1, 1 );
+      R( 1, 2 ) = final_tra( 1, 2 );
+
+      R( 2, 0 ) = final_tra( 2, 0 );
+      R( 2, 1 ) = final_tra( 2, 1 );
+      R( 2, 2 ) = final_tra( 2, 2 );
+
+      t[ 0 ] = final_tra( 0, 3 );
+      t[ 1 ] = final_tra( 1, 3 );
+      t[ 2 ] = final_tra( 2, 3 );
+
+    }
+
+  } // namespace registration
+} // namespace geometry
+} // namespace openMVG
+
+#endif

--- a/src/openMVG/geometry/registration/icp.hpp
+++ b/src/openMVG/geometry/registration/icp.hpp
@@ -8,355 +8,388 @@
 #include <flann/flann.hpp>
 
 #include <memory>
+#include <numeric>
+#include <random>
 
 namespace openMVG
 {
 namespace geometry
 {
-  namespace registration
+namespace registration
+{
+
+
+template<typename Scalar>
+void Transform( Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> & data , const Eigen::Quaternion<Scalar> & q , Eigen::Vector3d & t )
+{
+  for( int id_pt = 0 ; id_pt < data.rows() ; ++id_pt )
   {
+    Eigen::Matrix<Scalar, 3, 1> cur_pt;
+    cur_pt << data( id_pt , 0 ) , data( id_pt , 1 ) , data( id_pt , 2 ) ;
+    const Eigen::Matrix<Scalar, 3, 1> tra_pt = ( q * cur_pt ) + t ;
+    data( id_pt , 0 ) = tra_pt[0] ;
+    data( id_pt , 1 ) = tra_pt[1] ;
+    data( id_pt , 2 ) = tra_pt[2] ;
+  }
+}
 
-    /**
-    * @brief Compute centroid of a point cloud 
-    * @TODO : look for an existing function or an eigen shortcut 
-    */
-    template <typename Scalar>
-    Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> PCCentroid( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &data )
+/**
+* @brief Compute mean square error between two set of points
+* @param target target point list
+* @param data source point list
+* @param corresp pair (index, corresp[index]) for error computation
+* @retval mse if number of pair is > 0
+* @retval +inf if number of pair == 0
+*/
+template< typename Scalar>
+Scalar ComputeMSE( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &target,
+                   const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &data ,
+                   const std::vector<int> & corresp )
+{
+  int nb_valid = 0 ;
+  Scalar mse = 0 ;
+  for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
+  {
+    const int corr = corresp[ id_pt ];
+    if ( corr >= 0 )
     {
-      Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> center;
-      center.fill( Scalar( 0 ) );
-      for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
-      {
-        center[ 0 ] += data( id_pt, 0 );
-        center[ 1 ] += data( id_pt, 1 );
-        center[ 2 ] += data( id_pt, 2 );
-      }
+      const Scalar d[] = {data( id_pt, 0 ) - target( corr, 0 ),
+                          data( id_pt, 1 ) - target( corr, 1 ),
+                          data( id_pt, 2 ) - target( corr, 2 )
+                         };
 
-      return center / static_cast<Scalar>( data.rows() );
+      // Add distance between the two points
+      mse += ( d[ 0 ] * d[ 0 ] +
+               d[ 1 ] * d[ 1 ] +
+               d[ 2 ] * d[ 2 ] );
+      ++nb_valid;
+    }
+  }
+  if( nb_valid > 0 )
+  {
+    return mse / static_cast<Scalar>( nb_valid );
+  }
+  else
+  {
+    return std::numeric_limits<Scalar>::max() ;
+  }
+}
+
+/**
+* @brief Compute a random subset of a list
+* @param highest_value Maximum index for the output
+* @param percentage Percentage of value to keep in the set [0;highest_value]
+* @param[out] samples Output samples
+* @param rng Random number generator
+* @todo : move to numeric ?
+*/
+static inline void RandomSubset( const size_t highest_value , // included
+                                 const double percentage , // between 0 and 1
+                                 std::vector< int > & samples , // selected samples
+                                 std::mt19937_64 & rng ) // random generator
+{
+  std::vector< int > res( highest_value ) ;
+  std::iota( res.begin() , res.end() , 0 ) ;
+  std::shuffle( res.begin() , res.end() , rng ) ;
+
+  const int nb_values = std::min( static_cast<int>( highest_value ) , static_cast<int>( std::ceil( static_cast<double>( highest_value ) * percentage ) ) ) ;
+  samples.resize( nb_values ) ;
+  std::copy( res.begin() , res.begin() + nb_values , samples.begin() ) ;
+}
+
+/**
+* @brief Compute standard deviation of a given set
+* @param v a vector
+* @return standard deviation of the vector
+* @todo : move to numeric ?
+* @note : this assume that at least one value is in the set
+*/
+template< typename Scalar >
+static inline Scalar StdDev( const std::vector< Scalar > & v )
+{
+  double sum = std::accumulate( v.begin(), v.end(), Scalar( 0 ) );
+  double mean = sum / v.size();
+
+  std::vector<double> diff( v.size() );
+  std::transform( v.begin(), v.end(), diff.begin(),
+                  std::bind2nd( std::minus<double>(), mean ) );
+  double sq_sum = std::inner_product( diff.begin(), diff.end(), diff.begin(), Scalar( 0 ) );
+  return std::sqrt( sq_sum / v.size() );
+}
+
+
+/**
+* @brief Given two sets of points: target and data
+* This function computes rigid transformation that maps model on target minimizing MSE distance
+* @param target Target shape : a matrix of 3d points (one point per row)
+* @param data data shape : a matrix of 3d points (one point per row)
+* @param nb_iteration Maximum number of iteration
+* @param mse_threshold Threshold use to stop computation
+* @param[out] t Translation transformation (3d vector)
+* @param[out] R Rotation transformation (3x3 rotation matrix)
+*/
+template <typename Scalar>
+void ICP( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &target,
+          const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &data_,
+          const unsigned long max_nb_iteration,
+          const Scalar mse_threshold,
+          openMVG::Vec3 &t,
+          openMVG::Mat3 &R )
+{
+
+  // Build Kd-Tree
+  KDTree3d<Scalar> tree( target );
+
+  unsigned long id_iteration = 0;
+  Scalar cur_mse             = std::numeric_limits<Scalar>::max();
+
+  // Working sample
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> data = data_;
+
+  Mat4 final_tra;
+  final_tra.setIdentity();
+
+  std::vector<int> corresp( data.rows() );
+  std::vector<Scalar> distance( data.rows() );
+
+  Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> indices;
+  Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> dists;
+
+  std::vector< int > subset_indice ;
+  const double percentage = 0.10 ; // only sample 10% of the subset
+  std::mt19937_64 rng ;
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> subset_data ;
+
+  while ( id_iteration < max_nb_iteration && cur_mse > mse_threshold )
+  {
+    std::fill( corresp.begin(), corresp.end(), -1 );
+    std::fill( distance.begin(), distance.end(), Scalar( -1.0 ) );
+
+    // 1 - Pick a random subset
+    RandomSubset( data.rows() - 1 , percentage , subset_indice , rng ) ;
+    const int nb_subset_elts = std::min( static_cast<int>( data.rows() ) - 1 , static_cast<int>( subset_indice.size() ) ) ;
+    subset_data.resize( nb_subset_elts , 3 ) ;
+    for( size_t id_sample = 0 ; id_sample < subset_indice.size() ; ++id_sample )
+    {
+      const int indice = subset_indice[ id_sample ] ;
+      subset_data( id_sample , 0 ) = data( indice , 0 ) ;
+      subset_data( id_sample , 1 ) = data( indice , 1 ) ;
+      subset_data( id_sample , 2 ) = data( indice , 2 ) ;
     }
 
-    // compute centers of target and data (restricted to pairs of bc)
-    template <typename Scalar>
-    std::pair<Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor>, Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor>> PCCentroid(
-        const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &target,
-        const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &data,
-        const std::vector<int> &biunique_corresp )
+    // 2 - Establish pairs based on nearest neighbor search
+    tree.Search( subset_data , 1 , indices, dists );
+    std::vector< Scalar > compact_dist( subset_data.rows() ) ;
+    int id_dist = 0 ;
+    for ( int id_pt = 0; id_pt < subset_data.rows(); ++id_pt )
     {
-      Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> tgt_center;
-      Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> dtd_center;
+      const int id_point = indices( id_pt, 0 );
 
-      tgt_center.fill( Scalar( 0 ) );
-      dtd_center.fill( Scalar( 0 ) );
-
-      int nb_valid = 0;
-      for ( int id_pt = 0; id_pt < biunique_corresp.size(); ++id_pt )
+      if ( ( id_point >= 0 ) &&
+           ( id_point < target.rows() ) )
       {
-        const int id_data   = id_pt;
-        const int id_target = biunique_corresp[ id_data ];
-        if ( id_target >= 0 )
-        {
-          tgt_center[ 0 ] += target( id_target, 0 );
-          tgt_center[ 1 ] += target( id_target, 1 );
-          tgt_center[ 2 ] += target( id_target, 2 );
+        distance[ id_pt ] = dists( id_pt, 0 );
+        corresp[ id_pt ]  = id_point;
+        compact_dist[ id_dist ] = dists( id_pt, 0 );
 
-          dtd_center[ 0 ] += data( id_data, 0 );
-          dtd_center[ 1 ] += data( id_data, 1 );
-          dtd_center[ 2 ] += data( id_data, 2 );
-          ++nb_valid;
-        }
-      }
-
-      tgt_center /= static_cast<Scalar>( nb_valid );
-      dtd_center /= static_cast<Scalar>( nb_valid );
-
-      return std::make_pair( tgt_center, dtd_center );
-    }
-
-    /**
-    * @brief Compute distance between two points 
-    * @TODO : look for an existing function or an eigen shortcut 
-    */
-    template <typename Scalar>
-    Scalar PDistance( const Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> &p1, const Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> &p2 )
-    {
-      const Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> d = p1 - p2;
-
-      return d[ 0 ] * d[ 0 ] +
-             d[ 1 ] * d[ 1 ] +
-             d[ 2 ] * d[ 2 ];
-    }
-
-    /**
-    * @brief Compute threshold value as defined in BC-ICP method 
-    */
-    template <typename Scalar>
-    Scalar Threshold( const int Nmc,
-                      const Scalar lambda,
-                      const Scalar lambda_c,
-                      const Scalar s,
-                      const Scalar c,
-                      const Scalar meanSD )
-    {
-      if ( lambda > lambda_c )
-      {
-        return std::pow( Nmc, lambda ) * meanSD + s * c * c;
-      }
-      else
-      {
-        return meanSD;
+        ++id_dist ;
       }
     }
 
-    /**
-    * @brief Transform data set using a specified transformation 
-    */
-    template <typename Scalar>
-    void Transform( Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &data, const Mat4 &tra )
+    // 3 - Filter points based on 3 * stddev
+    const Scalar t = 3.0 * StdDev( compact_dist ) ;
+    for ( int id_pt = 0; id_pt < subset_data.rows(); ++id_pt )
     {
-      for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
+      if ( corresp[ id_pt ] >= 0 )
       {
-        const Scalar x = data( id_pt, 0 );
-        const Scalar y = data( id_pt, 1 );
-        const Scalar z = data( id_pt, 2 );
+        if ( distance[ id_pt ] > t )
+        {
+          corresp[ id_pt ]  = -1;
+          distance[ id_pt ] = -1.0;
+        }
+      }
+    }
+    const double mse_before = ComputeMSE( target , subset_data , corresp ) ;
+    if( id_iteration == 0 )
+    {
+      cur_mse = mse_before ;
+    }
 
-        Vec3 pt_tra( x * tra( 0, 0 ) + y * tra( 0, 1 ) + z * tra( 0, 2 ) + tra( 0, 3 ),
-                     x * tra( 1, 0 ) + y * tra( 1, 1 ) + z * tra( 1, 2 ) + tra( 1, 3 ),
-                     x * tra( 2, 0 ) + y * tra( 2, 1 ) + z * tra( 2, 2 ) + tra( 2, 3 ) );
-        //        const Scalar w = x * tra( 3, 0 ) + y * tra( 3, 1 ) + z * tra( 3, 2 ) + tra( 3, 3 );
+    // 4 - Compute best rigid transformation based on pairs
+    RigidMotion3d3dEstimation<Scalar> estimator ;
+    std::pair< Eigen::Quaternion<Scalar> , Eigen::Matrix<Scalar, 3, 1> > tra = estimator( target , subset_data , corresp ) ;
 
-        data( id_pt, 0 ) = pt_tra[ 0 ]; // / w;
-        data( id_pt, 1 ) = pt_tra[ 1 ]; // / w;
-        data( id_pt, 2 ) = pt_tra[ 2 ]; // / w;
+    // 5 - Update data points and final transformation
+    Transform( subset_data , tra.first , tra.second );
+    const double mse_after = ComputeMSE( target , subset_data , corresp ) ;
+    if( mse_after < mse_before )
+    {
+      // Update the whole set
+      Transform( data , tra.first , tra.second );
+
+      // Update global transformation
+      Mat4 tmp = Mat4::Identity() ;
+      tmp.block( 0 , 0 , 3 , 3 ) = tra.first.toRotationMatrix() ;
+      tmp( 0 , 3 ) = tra.second[0] ;
+      tmp( 1 , 3 ) = tra.second[1] ;
+      tmp( 2 , 3 ) = tra.second[2] ;
+      final_tra = tmp * final_tra ;
+      // Update mse
+      cur_mse = mse_after ;
+    }
+
+    ++id_iteration;
+  }
+
+  // Compute final transformation
+  R = final_tra.block( 0 , 0 , 3 , 3 ) ;
+
+  t[ 0 ] = final_tra( 0, 3 );
+  t[ 1 ] = final_tra( 1, 3 );
+  t[ 2 ] = final_tra( 2, 3 );
+}
+
+
+/**
+* @brief Given two sets of points: target and data
+* This function computes rigid transformation that maps model on target minimizing MSE distance
+* This use the point to normal distance for computation
+* @param target Target shape : a matrix of 3d points (one point per row)
+* @param target_n Target shape normals : a matrix of 3d vectors (one vector per row)
+* @param data data shape : a matrix of 3d points (one point per row)
+* @param nb_iteration Maximum number of iteration
+* @param mse_threshold Threshold use to stop computation
+* @param[out] t Translation transformation (3d vector)
+* @param[out] R Rotation transformation (3x3 rotation matrix)
+*/
+template <typename Scalar>
+void ICP( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &target,
+          const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &target_n,
+          const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &data_,
+          const unsigned long max_nb_iteration,
+          const Scalar mse_threshold,
+          openMVG::Vec3 &t,
+          openMVG::Mat3 &R )
+{
+
+  // Build Kd-Tree
+  KDTree3d<Scalar> tree( target );
+
+  unsigned long id_iteration = 0;
+  Scalar cur_mse             = std::numeric_limits<Scalar>::max();
+
+  // Working sample
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> data = data_;
+
+  Mat4 final_tra;
+  final_tra.setIdentity();
+
+  //  std::vector<bool> already_used( target.rows() );
+  std::vector<int> corresp( data.rows() );
+  std::vector<Scalar> distance( data.rows() );
+
+  Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> indices;
+  Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> dists;
+
+
+  std::vector< int > subset_indice ;
+  const double percentage = 0.10 ; // only sample 10% of the subset
+  std::mt19937_64 rng ;
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> subset_data ;
+
+  while ( id_iteration < max_nb_iteration && cur_mse > mse_threshold )
+  {
+    std::fill( corresp.begin(), corresp.end(), -1 );
+    std::fill( distance.begin(), distance.end(), Scalar( -1.0 ) );
+
+    // 1 - Pick a random subset
+    RandomSubset( data.rows() - 1 , percentage , subset_indice , rng ) ;
+    const int nb_subset_elts = std::min( static_cast<int>( data.rows() ) - 1 , static_cast<int>( subset_indice.size() ) ) ;
+    subset_data.resize( nb_subset_elts , 3 ) ;
+    for( size_t id_sample = 0 ; id_sample < subset_indice.size() ; ++id_sample )
+    {
+      const int indice = subset_indice[ id_sample ] ;
+      subset_data( id_sample , 0 ) = data( indice , 0 ) ;
+      subset_data( id_sample , 1 ) = data( indice , 1 ) ;
+      subset_data( id_sample , 2 ) = data( indice , 2 ) ;
+    }
+
+    // 2 - Establish pairs based on nearest neighbor search
+    tree.Search( subset_data , 1 , indices, dists );
+    std::vector< Scalar > compact_dist( subset_data.rows() ) ;
+    int id_dist = 0 ;
+    for ( int id_pt = 0; id_pt < subset_data.rows(); ++id_pt )
+    {
+      const int id_point = indices( id_pt, 0 );
+
+      if ( ( id_point >= 0 ) &&
+           ( id_point < target.rows() ) )
+      {
+        distance[ id_pt ] = dists( id_pt, 0 );
+        corresp[ id_pt ]  = id_point;
+        compact_dist[ id_dist ] = dists( id_pt, 0 );
+
+        ++id_dist ;
       }
     }
 
-    template <typename Scalar>
-    void ComputeMinimumDistance( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &target,
-                                 const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &data,
-                                 std::vector<int> &index,
-                                 std::vector<Scalar> &distance )
+    // 3 - Filter points based on 3 * stddev
+    const Scalar t = 3.0 * StdDev( compact_dist ) ;
+    for ( int id_pt = 0; id_pt < subset_data.rows(); ++id_pt )
     {
-      index.resize( data.rows() );
-      distance.resize( data.rows() );
-
-      for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
+      if ( corresp[ id_pt ] >= 0 )
       {
-        Scalar minimum_distance = std::numeric_limits<Scalar>::max();
-        int id                  = -1;
-
-        for ( int id_ref = 0; id_ref < target.rows(); ++id_ref )
+        if ( distance[ id_pt ] > t )
         {
-          const Scalar delta[] = {target( id_ref, 0 ) - data( id_pt, 0 ),
-                                  target( id_ref, 1 ) - data( id_pt, 1 ),
-                                  target( id_ref, 2 ) - data( id_pt, 2 )};
-          const Scalar dist = delta[ 0 ] * delta[ 0 ] + delta[ 1 ] * delta[ 1 ] + delta[ 2 ] * delta[ 2 ];
-          if( dist < minimum_distance )
-          {
-            minimum_distance = dist ; 
-            id = id_ref ; 
-          }
+          corresp[ id_pt ]  = -1;
+          distance[ id_pt ] = -1.0;
         }
-
-        distance[ id_pt ] = minimum_distance;
-        index[ id_pt ]    = id;
       }
     }
-
-    /**
-  * @brief Given two sets of points: target and data 
-  * This function computes rigid transformation that maps model on target minimizing MSE distance 
-  * @param target Target shape : a matrix of 3d points (one point per row)
-  * @param data data shape : a matrix of 3d points (one point per row)
-  * @param nb_iteration Maximum number of iteration 
-  * @param mse_threshold Threshold use to stop computation 
-  * @param[out] t Translation transformation (3d vector) 
-  * @param[out] R Rotation transformation (3x3 rotation matrix)
-  * @note This is an implementation based on the BC-ICP algorithm 
-  */
-    template <typename Scalar>
-    void ICP( const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &target,
-              const Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> &data_,
-              const unsigned long max_nb_iteration,
-              const Scalar mse_threshold,
-              openMVG::Vec3 &t,
-              openMVG::Mat3 &R )
+    const double mse_before = ComputeMSE( target , subset_data , corresp ) ;
+    if( id_iteration == 0 )
     {
-
-      // Build Kd-Tree
-      KDTree3d<Scalar> tree( target );
-
-      unsigned long id_iteration = 0;
-      Scalar cur_mse             = std::numeric_limits<Scalar>::max();
-      int Nmc                    = 10 ;
-
-      // Working sample
-      Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor> data = data_;
-
-      Mat4 final_tra;
-      final_tra.setIdentity();
-
-      std::vector<bool> already_used( target.rows() );
-      std::vector<int> biunique_corresp( data.rows() );
-      std::vector<Scalar> biunique_distance( data.rows() );
-
-      Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> indices;
-      Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> dists;
-
-      double old_inliner_ratio = 0.0;
-
-      while ( id_iteration < max_nb_iteration && cur_mse > mse_threshold )
-      {
-        std::fill( already_used.begin(), already_used.end(), false );
-        std::fill( biunique_corresp.begin(), biunique_corresp.end(), -1 );
-        std::fill( biunique_distance.begin(), biunique_distance.end(), Scalar(-1.0) );
-
-        // Find Nmc nearest neighbors
-        tree.Search( data, Nmc, indices, dists );
-
-        // Compute binunique correspondance for each points
-        for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
-        {
-          for ( int id_n = 0; id_n < Nmc; ++id_n )
-          {
-            const int id_point = indices( id_pt, id_n );
-
-            if ( ( id_point >= 0 ) && ( id_point < target.rows() ) && ( !already_used[ id_point ] ) )
-            {
-              // We've found one !
-              biunique_distance[ id_pt ] = dists( id_pt, id_n );
-              biunique_corresp[ id_pt ]  = id_point;
-              already_used[ id_point ]   = true;
-              break;
-            }
-          }
-        }
-
-        // Mean squared distance (and nb inliers)
-        Scalar meanSD = Scalar( 0 );
-        int NbIn      = 0;
-        for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
-        {
-          if ( biunique_corresp[ id_pt ] >= 0 )
-          {
-            meanSD += biunique_distance[ id_pt ];
-            ++NbIn;
-          }
-        }
-        meanSD /= static_cast<Scalar>( NbIn );
-
-        const std::pair<Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor>,
-                        Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor>>
-            centers = PCCentroid( target, data, biunique_corresp );
-
-        const Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> pc1 = centers.first;
-        const Eigen::Matrix<Scalar, 1, 3, Eigen::RowMajor> pc2 = centers.second;
-
-        const Scalar c        = PDistance( pc1, pc2 );
-        const Scalar s        = 1.0;
-        const int nb_outliers = data.rows() - NbIn;
-        const Scalar lambda   = static_cast<Scalar>( nb_outliers ) / static_cast<Scalar>( data.rows() );
-        const Scalar lambda_c = 0.1;
-        const Scalar t        = Threshold( Nmc, lambda, lambda_c, s, c, meanSD );
-
-        // Filter points based on threshold
-        int nb_in_prev = NbIn ; 
-        for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
-        {
-          if ( biunique_corresp[ id_pt ] >= 0 )
-          {
-            if ( biunique_distance[ id_pt ] > t )
-            {
-              biunique_corresp[ id_pt ]  = -1;
-              biunique_distance[ id_pt ] = -1.0;
-            }
-            else 
-            {
-              ++nb_in_prev ; 
-            }
-          }
-        }
-
-        // Compute rigid transformation using only pairs of biunique
-        // 1 - Build residual fonctor
-        // 2 - Run optimisation
-        RigidMotion3d3dEstimation<Scalar> estimator;
-        // Compute MSE error
-        std::pair<Mat3, Vec3> tra = estimator( target, data, biunique_corresp );
-        Mat4 tmp;
-        tmp( 0, 0 ) = tra.first( 0, 0 );
-        tmp( 0, 1 ) = tra.first( 0, 1 );
-        tmp( 0, 2 ) = tra.first( 0, 2 );
-        tmp( 0, 3 ) = tra.second[ 0 ];
-
-        tmp( 1, 0 ) = tra.first( 1, 0 );
-        tmp( 1, 1 ) = tra.first( 1, 1 );
-        tmp( 1, 2 ) = tra.first( 1, 2 );
-        tmp( 1, 3 ) = tra.second[ 1 ];
-
-        tmp( 2, 0 ) = tra.first( 2, 0 );
-        tmp( 2, 1 ) = tra.first( 2, 1 );
-        tmp( 2, 2 ) = tra.first( 2, 2 );
-        tmp( 2, 3 ) = tra.second[ 2 ];
-
-        tmp( 3, 0 ) = 0.0;
-        tmp( 3, 1 ) = 0.0;
-        tmp( 3, 2 ) = 0.0;
-        tmp( 3, 3 ) = 1.0;
-
-        // Update data points
-        Transform( data, tmp );
-        // Compute MSE between pairs of biunique
-        cur_mse      = 0.0;
-        int nb_valid = 0;
-        for ( int id_pt = 0; id_pt < data.rows(); ++id_pt )
-        {
-          const int corresp = biunique_corresp[ id_pt ];
-          if ( corresp >= 0 )
-          {
-            const Scalar d[] = {data( id_pt, 0 ) - target( corresp, 0 ),
-                                data( id_pt, 1 ) - target( corresp, 1 ),
-                                data( id_pt, 2 ) - target( corresp, 2 )};
-
-            // Add distance between the two points
-            cur_mse += d[ 0 ] * d[ 0 ] + d[ 1 ] * d[ 1 ] + d[ 2 ] * d[ 2 ];
-            ++nb_valid;
-          }
-        }
-        cur_mse /= static_cast<Scalar>( nb_valid );
-        std::cout << "Mse after transformation : " << cur_mse << std::endl;
-
-        // Update final transformation and data point set
-        final_tra = tmp * final_tra;
-
-        const double cur_inlier_ratio = NbIn / data.rows();
-        const double delta_ratio      = cur_inlier_ratio - old_inliner_ratio;
-        if ( delta_ratio > 0.1 && Nmc > 1 )
-        {
-          --Nmc;
-        }
-
-        ++id_iteration;
-      }
-
-      // Compute final transformation
-      R( 0, 0 ) = final_tra( 0, 0 );
-      R( 0, 1 ) = final_tra( 0, 1 );
-      R( 0, 2 ) = final_tra( 0, 2 );
-
-      R( 1, 0 ) = final_tra( 1, 0 );
-      R( 1, 1 ) = final_tra( 1, 1 );
-      R( 1, 2 ) = final_tra( 1, 2 );
-
-      R( 2, 0 ) = final_tra( 2, 0 );
-      R( 2, 1 ) = final_tra( 2, 1 );
-      R( 2, 2 ) = final_tra( 2, 2 );
-
-      t[ 0 ] = final_tra( 0, 3 );
-      t[ 1 ] = final_tra( 1, 3 );
-      t[ 2 ] = final_tra( 2, 3 );
+      cur_mse = mse_before ;
     }
 
-  } // namespace registration
+    // 4 - Compute best rigid transformation based on pairs
+    RigidMotion3d3dEstimation<Scalar> estimator ;
+    std::pair< Eigen::Quaternion<Scalar> , Eigen::Matrix<Scalar, 3, 1> > tra = estimator( target , target_n , subset_data , corresp ) ;
+
+    // 5 - Update data points and final transformation
+    Transform( subset_data , tra.first , tra.second );
+    const double mse_after = ComputeMSE( target , subset_data , corresp ) ;
+    if( mse_after < mse_before )
+    {
+      // Update whole set
+      Transform( data , tra.first , tra.second );
+
+      // Update global transformation
+      Mat4 tmp = Mat4::Identity() ;
+      tmp.block( 0 , 0 , 3 , 3 ) = tra.first.toRotationMatrix() ;
+      tmp( 0 , 3 ) = tra.second[0] ;
+      tmp( 1 , 3 ) = tra.second[1] ;
+      tmp( 2 , 3 ) = tra.second[2] ;
+      final_tra = tmp * final_tra ;
+
+      // Update mse
+      cur_mse = mse_after ;
+    }
+
+    ++id_iteration;
+  }
+
+  // Compute final transformation
+  R = final_tra.block( 0 , 0 , 3 , 3 ) ;
+
+  t[ 0 ] = final_tra( 0, 3 );
+  t[ 1 ] = final_tra( 1, 3 );
+  t[ 2 ] = final_tra( 2, 3 );
+}
+
+
+
+} // namespace registration
 } // namespace geometry
 } // namespace openMVG
 

--- a/src/openMVG/geometry/registration/icp_test.cpp
+++ b/src/openMVG/geometry/registration/icp_test.cpp
@@ -1,0 +1,324 @@
+#include "testing/testing.h"
+
+#include "openMVG/geometry/registration/icp.hpp"
+
+#include <cmath>
+
+TEST( icp , icp_no_transfo )
+{
+  // Generate point set 
+  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> target ;
+  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> data ; 
+
+  // A sphere 
+  const double pi = 3.14159265358979 ;
+  const int nb_theta = 32 ;
+  const int nb_phi   = 16 ;
+  const double delta_theta = ( 2.0 * pi ) / nb_theta ;
+  const double delta_phi = ( pi ) / nb_phi ;
+  const double rad = 2.0 ;
+
+  int nb_pt = 0 ;
+  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  {
+    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    {
+      ++nb_pt ; 
+    }
+  }
+  
+  target.resize( nb_pt , 3 ) ;
+  data.resize( nb_pt , 3 ) ; 
+
+  int id_pt = 0 ; 
+  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  {
+    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    {
+      const double x = rad * std::cos( phi ) * std::cos( theta ) ;
+      const double y = rad * std::cos( phi ) * std::sin( theta ) ;
+      const double z = rad * std::sin( phi ) ;
+    
+      target( id_pt , 0 ) = x ;
+      target( id_pt , 1 ) = y ;
+      target( id_pt , 2 ) = z ; 
+
+      data( id_pt , 0 ) = x ; 
+      data( id_pt , 1 ) = y ;
+      data( id_pt , 2 ) = z ; 
+
+      ++id_pt ;   
+    }
+  }
+
+  openMVG::Mat3 R ;
+  openMVG::Vec3 t ; 
+
+  openMVG::geometry::registration::ICP( target , data , 200 , 0.0 , t , R ) ; 
+
+  EXPECT_EQ( t[0] , 0.0 ) ;
+  EXPECT_EQ( t[1] , 0.0 ) ;
+  EXPECT_EQ( t[2] , 0.0 ) ; 
+
+  EXPECT_EQ( R(0,0) , 1.0 ) ;
+  EXPECT_EQ( R(0,1) , 0.0 ) ;
+  EXPECT_EQ( R(0,2) , 0.0 ) ;
+
+  EXPECT_EQ( R(1,0) , 0.0 ) ;
+  EXPECT_EQ( R(1,1) , 1.0 ) ;
+  EXPECT_EQ( R(1,2) , 0.0 ) ;
+
+  EXPECT_EQ( R(2,0) , 0.0 ) ;
+  EXPECT_EQ( R(2,1) , 0.0 ) ;
+  EXPECT_EQ( R(2,2) , 1.0 ) ; 
+}
+
+
+TEST( icp , icp_rotate )
+{
+  // Generate point set 
+  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> target ;
+  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> data ; 
+
+  // A sphere 
+  const double pi = 3.14159265358979 ;
+  const int nb_theta = 32 ;
+  const int nb_phi   = 16 ;
+  const double delta_theta = ( 2.0 * pi ) / nb_theta ;
+  const double delta_phi = ( pi ) / nb_phi ;
+  const double rad = 2.0 ;
+
+  int nb_pt = 0 ;
+  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  {
+    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    {
+      ++nb_pt ; 
+    }
+  }
+  
+  target.resize( nb_pt , 3 ) ;
+  data.resize( nb_pt , 3 ) ; 
+
+  openMVG::Mat3 r ;
+  r = Eigen::AngleAxis<double>( pi / 3.0 , openMVG::Vec3( 1 , 1 , 1 ).normalized() ) ;
+
+
+  int id_pt = 0 ; 
+  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  {
+    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    {
+      const double x = rad * std::cos( phi ) * std::cos( theta ) ;
+      const double y = rad * std::cos( phi ) * std::sin( theta ) ;
+      const double z = rad * std::sin( phi ) ;
+    
+      target( id_pt , 0 ) = x ;
+      target( id_pt , 1 ) = y ;
+      target( id_pt , 2 ) = z ; 
+
+
+      const openMVG::Vec3 orig( x , y , z ) ;
+      const openMVG::Vec3 tra = r * orig ; 
+      
+      data( id_pt , 0 ) = tra[0] ; 
+      data( id_pt , 1 ) = tra[1] ;
+      data( id_pt , 2 ) = tra[2] ; 
+
+      ++id_pt ;   
+    }
+  }
+
+  // Inverse here 
+  r = r.inverse().eval() ; 
+
+  openMVG::Mat3 R ;
+  openMVG::Vec3 t ; 
+
+  openMVG::geometry::registration::ICP( target , data , 1000 , 0.0 , t , R ) ; 
+
+  EXPECT_NEAR( t[0] , 0 , 0.00001 ) ;
+  EXPECT_NEAR( t[1] , 0 , 0.00001 ) ;
+  EXPECT_NEAR( t[2] , 0 , 0.00001 ) ; 
+
+  EXPECT_NEAR( R(0,0) , r(0,0) , 0.00001 ) ;
+  EXPECT_NEAR( R(0,1) , r(0,1) , 0.00001 ) ;
+  EXPECT_NEAR( R(0,2) , r(0,2) , 0.00001 ) ;
+
+  EXPECT_NEAR( R(1,0) , r(1,0) , 0.00001 ) ;
+  EXPECT_NEAR( R(1,1) , r(1,1) , 0.00001 ) ;
+  EXPECT_NEAR( R(1,2) , r(1,2) , 0.00001 ) ;
+
+  EXPECT_NEAR( R(2,0) , r(2,0) , 0.00001 ) ;
+  EXPECT_NEAR( R(2,1) , r(2,1) , 0.00001 ) ;
+  EXPECT_NEAR( R(2,2) , r(2,2) , 0.00001 ) ; 
+}
+
+TEST( icp , icp_translate )
+{
+  // Generate point set 
+  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> target ;
+  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> data ; 
+
+  // A sphere 
+  const double pi = 3.14159265358979 ;
+  const int nb_theta = 32 ;
+  const int nb_phi   = 16 ;
+  const double delta_theta = ( 2.0 * pi ) / nb_theta ;
+  const double delta_phi = ( pi ) / nb_phi ;
+  const double rad = 2.0 ;
+
+  int nb_pt = 0 ;
+  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  {
+    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    {
+      ++nb_pt ; 
+    }
+  }
+  
+  target.resize( nb_pt , 3 ) ;
+  data.resize( nb_pt , 3 ) ; 
+
+  const double tx = 10.0 ;
+  const double ty = 20.0 ;
+  const double tz = 10.0 ; 
+
+  int id_pt = 0 ; 
+  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  {
+    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    {
+      const double x = rad * std::cos( phi ) * std::cos( theta ) ;
+      const double y = rad * std::cos( phi ) * std::sin( theta ) ;
+      const double z = rad * std::sin( phi ) ;
+    
+      target( id_pt , 0 ) = x ;
+      target( id_pt , 1 ) = y ;
+      target( id_pt , 2 ) = z ; 
+
+      data( id_pt , 0 ) = x + tx ; 
+      data( id_pt , 1 ) = y + ty ;
+      data( id_pt , 2 ) = z + tz ; 
+
+      ++id_pt ;   
+    }
+  }
+
+  openMVG::Mat3 R ;
+  openMVG::Vec3 t ; 
+
+  openMVG::geometry::registration::ICP( target , data , 1000 , 0.0 , t , R ) ; 
+
+  EXPECT_NEAR( t[0] , -tx , 0.00001 ) ;
+  EXPECT_NEAR( t[1] , -ty , 0.00001 ) ;
+  EXPECT_NEAR( t[2] , -tz , 0.00001 ) ; 
+
+  EXPECT_NEAR( R(0,0) , 1.0 , 0.00001 ) ;
+  EXPECT_NEAR( R(0,1) , 0.0 , 0.00001 ) ;
+  EXPECT_NEAR( R(0,2) , 0.0 , 0.00001 ) ;
+
+  EXPECT_NEAR( R(1,0) , 0.0 , 0.00001 ) ;
+  EXPECT_NEAR( R(1,1) , 1.0 , 0.00001 ) ;
+  EXPECT_NEAR( R(1,2) , 0.0 , 0.00001 ) ;
+
+  EXPECT_NEAR( R(2,0) , 0.0 , 0.00001 ) ;
+  EXPECT_NEAR( R(2,1) , 0.0 , 0.00001 ) ;
+  EXPECT_NEAR( R(2,2) , 1.0 , 0.00001 ) ; 
+}
+
+
+TEST( icp , icp_rot_translate )
+{
+  // Generate point set 
+  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> target ;
+  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> data ; 
+
+  // A sphere 
+  const double pi = 3.14159265358979 ;
+  const int nb_theta = 32 ;
+  const int nb_phi   = 16 ;
+  const double delta_theta = ( 2.0 * pi ) / nb_theta ;
+  const double delta_phi = ( pi ) / nb_phi ;
+  const double rad = 2.0 ;
+
+  int nb_pt = 0 ;
+  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  {
+    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    {
+      ++nb_pt ; 
+    }
+  }
+  
+  target.resize( nb_pt , 3 ) ;
+  data.resize( nb_pt , 3 ) ; 
+
+  openMVG::Mat3 r ;
+  r = Eigen::AngleAxis<double>( pi / 3.0 , openMVG::Vec3( 1 , 1 , 1 ).normalized() ) ;
+
+  const double tx = 10.0 ;
+  const double ty = 12.0 ;
+  const double tz = 3.0 ; 
+
+  int id_pt = 0 ; 
+  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  {
+    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    {
+      const double x = rad * std::cos( phi ) * std::cos( theta ) ;
+      const double y = rad * std::cos( phi ) * std::sin( theta ) ;
+      const double z = rad * std::sin( phi ) ;
+    
+      target( id_pt , 0 ) = x ;
+      target( id_pt , 1 ) = y ;
+      target( id_pt , 2 ) = z ; 
+
+
+      const openMVG::Vec3 orig( x , y , z ) ;
+      const openMVG::Vec3 tra = r * orig ; 
+      
+      data( id_pt , 0 ) = tra[0] + tx ; 
+      data( id_pt , 1 ) = tra[1] + ty ;
+      data( id_pt , 2 ) = tra[2] + tz ;  
+
+      ++id_pt ;   
+    }
+  }
+
+  // Inverse here 
+  r = r.inverse().eval() ; 
+
+  openMVG::Mat3 R ;
+  openMVG::Vec3 t ; 
+
+  openMVG::geometry::registration::ICP( target , data , 1000 , 0.0001 , t , R ) ; 
+
+  std::cout << "Computed" << std::endl ; 
+  std::cout << t << std::endl ; 
+  std::cout << R << std::endl ; 
+
+  std::cout << "Expected" << std::endl ; 
+  std::cout << -tx << " - " << -ty << " - " << -tz << std::endl ; 
+  std::cout << r << std::endl ; 
+
+  EXPECT_NEAR( t[0] , -tx , 0.00001 ) ;
+  EXPECT_NEAR( t[1] , -ty , 0.00001 ) ;
+  EXPECT_NEAR( t[2] , -tz , 0.00001 ) ; 
+
+  EXPECT_NEAR( R(0,0) , r(0,0) , 0.00001 ) ;
+  EXPECT_NEAR( R(0,1) , r(0,1) , 0.00001 ) ;
+  EXPECT_NEAR( R(0,2) , r(0,2) , 0.00001 ) ;
+
+  EXPECT_NEAR( R(1,0) , r(1,0) , 0.00001 ) ;
+  EXPECT_NEAR( R(1,1) , r(1,1) , 0.00001 ) ;
+  EXPECT_NEAR( R(1,2) , r(1,2) , 0.00001 ) ;
+
+  EXPECT_NEAR( R(2,0) , r(2,0) , 0.00001 ) ;
+  EXPECT_NEAR( R(2,1) , r(2,1) , 0.00001 ) ;
+  EXPECT_NEAR( R(2,2) , r(2,2) , 0.00001 ) ; 
+}
+
+/* ************************************************************************* */
+int main() { TestResult tr; return TestRegistry::runAllTests(tr);}
+/* ************************************************************************* */

--- a/src/openMVG/geometry/registration/icp_test.cpp
+++ b/src/openMVG/geometry/registration/icp_test.cpp
@@ -12,6 +12,90 @@
 
 #include <cmath>
 
+TEST( icp , icp_no_transfo_f )
+{
+  // Generate point set
+  Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor> target;
+  Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  // A sphere
+  const double pi          = 3.14159265358979;
+  const int nb_x = 64 ;
+  const int nb_y = 64 ;
+
+  const double x_min = -10 ;
+  const double x_max = 10 ;
+  const double y_min = -10 ;
+  const double y_max = 10 ;
+
+  const double x_range = x_max - x_min ;
+  const double y_range = y_max - y_min ;
+  const double delta_x = x_range / static_cast<double>( nb_x ) ;
+  const double delta_y = y_range / static_cast<double>( nb_y ) ;
+
+  target.resize( nb_x * nb_y , 3 );
+  data.resize( nb_x * nb_y , 3 );
+
+  int id_pt = 0;
+  for( int id_y = 0 ; id_y < nb_y ; ++id_y )
+  {
+    for( int id_x = 0 ; id_x < nb_x ; ++id_x )
+    {
+      const double x = x_min + id_x * delta_x ;
+      const double y = y_min + id_y * delta_y ;
+
+      const double rad = std::sqrt( x * x + y * y ) ;
+      const double z = std::max( 0.0 , x ) + std::max( 0.0 , y ) + std::cos( 2.0 * rad ) ;
+
+      target( id_pt, 0 ) = x;
+      target( id_pt, 1 ) = y;
+      target( id_pt, 2 ) = z;
+
+      data( id_pt, 0 ) = x ;
+      data( id_pt, 1 ) = y ;
+      data( id_pt, 2 ) = z ;
+
+      ++id_pt;
+    }
+  }
+
+  openMVG::Mat3 R;
+  openMVG::Vec3 t;
+
+  openMVG::geometry::registration::ICP( target, data, 200, 0.0001f , t, R );
+  const openMVG::Vec3 invT = R.transpose() * t ;
+
+  std::cout << "Computed" << std::endl;
+  std::cout << invT << std::endl;
+  std::cout << R << std::endl;
+
+  const double tx = 0.0 ;
+  const double ty = 0.0 ;
+  const double tz = 0.0 ;
+
+  openMVG::Mat3 r ;
+  r.setIdentity() ;
+  std::cout << "Expected" << std::endl;
+  std::cout << -tx << " - " << -ty << " - " << -tz << std::endl;
+  std::cout << r << std::endl ;
+
+  EXPECT_NEAR( invT[ 0 ], -tx, 0.00001 );
+  EXPECT_NEAR( invT[ 1 ], -ty, 0.00001 );
+  EXPECT_NEAR( invT[ 2 ], -tz, 0.00001 );
+
+  EXPECT_NEAR( R( 0, 0 ), r( 0, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 1 ), r( 0, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 2 ), r( 0, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 1, 0 ), r( 1, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 1 ), r( 1, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 2 ), r( 1, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 2, 0 ), r( 2, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 1 ), r( 2, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 2 ), r( 2, 2 ), 0.00001 );
+}
+
 TEST( icp, icp_no_transfo )
 {
   // Generate point set

--- a/src/openMVG/geometry/registration/icp_test.cpp
+++ b/src/openMVG/geometry/registration/icp_test.cpp
@@ -1,3 +1,11 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2017 Romuald Perrot.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 #include "testing/testing.h"
 
 #include "openMVG/geometry/registration/icp.hpp"

--- a/src/openMVG/geometry/registration/icp_test.cpp
+++ b/src/openMVG/geometry/registration/icp_test.cpp
@@ -12,40 +12,40 @@ TEST( icp, icp_no_transfo )
 
   // A sphere
   const double pi          = 3.14159265358979;
-  const int nb_theta       = 32;
-  const int nb_phi         = 16;
-  const double delta_theta = ( 2.0 * pi ) / nb_theta;
-  const double delta_phi   = ( pi ) / nb_phi;
-  const double rad         = 2.0;
+  const int nb_x = 64 ;
+  const int nb_y = 64 ;
 
-  int nb_pt = 0;
-  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
-  {
-    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
-    {
-      ++nb_pt;
-    }
-  }
+  const double x_min = -10 ;
+  const double x_max = 10 ;
+  const double y_min = -10 ;
+  const double y_max = 10 ;
 
-  target.resize( nb_pt, 3 );
-  data.resize( nb_pt, 3 );
+  const double x_range = x_max - x_min ;
+  const double y_range = y_max - y_min ;
+  const double delta_x = x_range / static_cast<double>( nb_x ) ;
+  const double delta_y = y_range / static_cast<double>( nb_y ) ;
+
+  target.resize( nb_x * nb_y , 3 );
+  data.resize( nb_x * nb_y , 3 );
 
   int id_pt = 0;
-  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
+  for( int id_y = 0 ; id_y < nb_y ; ++id_y )
   {
-    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
+    for( int id_x = 0 ; id_x < nb_x ; ++id_x )
     {
-      const double x = rad * std::cos( phi ) * std::cos( theta );
-      const double y = rad * std::cos( phi ) * std::sin( theta );
-      const double z = rad * std::sin( phi );
+      const double x = x_min + id_x * delta_x ;
+      const double y = y_min + id_y * delta_y ;
+
+      const double rad = std::sqrt( x * x + y * y ) ;
+      const double z = std::max( 0.0 , x ) + std::max( 0.0 , y ) + std::cos( 2.0 * rad ) ;
 
       target( id_pt, 0 ) = x;
       target( id_pt, 1 ) = y;
       target( id_pt, 2 ) = z;
 
-      data( id_pt, 0 ) = x;
-      data( id_pt, 1 ) = y;
-      data( id_pt, 2 ) = z;
+      data( id_pt, 0 ) = x ;
+      data( id_pt, 1 ) = y ;
+      data( id_pt, 2 ) = z ;
 
       ++id_pt;
     }
@@ -55,22 +55,37 @@ TEST( icp, icp_no_transfo )
   openMVG::Vec3 t;
 
   openMVG::geometry::registration::ICP( target, data, 200, 0.0001, t, R );
+  const openMVG::Vec3 invT = R.transpose() * t ;
 
-  EXPECT_EQ( t[ 0 ], 0.0 );
-  EXPECT_EQ( t[ 1 ], 0.0 );
-  EXPECT_EQ( t[ 2 ], 0.0 );
+  std::cout << "Computed" << std::endl;
+  std::cout << invT << std::endl;
+  std::cout << R << std::endl;
 
-  EXPECT_EQ( R( 0, 0 ), 1.0 );
-  EXPECT_EQ( R( 0, 1 ), 0.0 );
-  EXPECT_EQ( R( 0, 2 ), 0.0 );
+  const double tx = 0.0 ;
+  const double ty = 0.0 ;
+  const double tz = 0.0 ;
 
-  EXPECT_EQ( R( 1, 0 ), 0.0 );
-  EXPECT_EQ( R( 1, 1 ), 1.0 );
-  EXPECT_EQ( R( 1, 2 ), 0.0 );
+  openMVG::Mat3 r ;
+  r.setIdentity() ;
+  std::cout << "Expected" << std::endl;
+  std::cout << -tx << " - " << -ty << " - " << -tz << std::endl;
+  std::cout << r << std::endl ;
 
-  EXPECT_EQ( R( 2, 0 ), 0.0 );
-  EXPECT_EQ( R( 2, 1 ), 0.0 );
-  EXPECT_EQ( R( 2, 2 ), 1.0 );
+  EXPECT_NEAR( invT[ 0 ], -tx, 0.00001 );
+  EXPECT_NEAR( invT[ 1 ], -ty, 0.00001 );
+  EXPECT_NEAR( invT[ 2 ], -tz, 0.00001 );
+
+  EXPECT_NEAR( R( 0, 0 ), r( 0, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 1 ), r( 0, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 2 ), r( 0, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 1, 0 ), r( 1, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 1 ), r( 1, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 2 ), r( 1, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 2, 0 ), r( 2, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 1 ), r( 2, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 2 ), r( 2, 2 ), 0.00001 );
 }
 
 TEST( icp, icp_rotate )
@@ -81,35 +96,35 @@ TEST( icp, icp_rotate )
 
   // A sphere
   const double pi          = 3.14159265358979;
-  const int nb_theta       = 32;
-  const int nb_phi         = 16;
-  const double delta_theta = ( 2.0 * pi ) / nb_theta;
-  const double delta_phi   = ( pi ) / nb_phi;
-  const double rad         = 2.0;
+  openMVG::Mat3 r ;
+  r = Eigen::AngleAxis<double>( pi / 10.0, openMVG::Vec3( 1, 1, 1 ).normalized() );
 
-  int nb_pt = 0;
-  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
-  {
-    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
-    {
-      ++nb_pt;
-    }
-  }
+  const int nb_x = 64 ;
+  const int nb_y = 64 ;
 
-  target.resize( nb_pt, 3 );
-  data.resize( nb_pt, 3 );
+  const double x_min = -10 ;
+  const double x_max = 10 ;
+  const double y_min = -10 ;
+  const double y_max = 10 ;
 
-  openMVG::Mat3 r;
-  r = Eigen::AngleAxis<double>( pi / 3.0, openMVG::Vec3( 1, 1, 1 ).normalized() );
+  const double x_range = x_max - x_min ;
+  const double y_range = y_max - y_min ;
+  const double delta_x = x_range / static_cast<double>( nb_x ) ;
+  const double delta_y = y_range / static_cast<double>( nb_y ) ;
+
+  target.resize( nb_x * nb_y , 3 );
+  data.resize( nb_x * nb_y , 3 );
 
   int id_pt = 0;
-  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
+  for( int id_y = 0 ; id_y < nb_y ; ++id_y )
   {
-    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
+    for( int id_x = 0 ; id_x < nb_x ; ++id_x )
     {
-      const double x = rad * std::cos( phi ) * std::cos( theta );
-      const double y = rad * std::cos( phi ) * std::sin( theta );
-      const double z = rad * std::sin( phi );
+      const double x = x_min + id_x * delta_x ;
+      const double y = y_min + id_y * delta_y ;
+
+      const double rad = std::sqrt( x * x + y * y ) ;
+      const double z = std::max( 0.0 , x ) + std::max( 0.0 , y ) + std::cos( 2.0 * rad ) ;
 
       target( id_pt, 0 ) = x;
       target( id_pt, 1 ) = y;
@@ -133,6 +148,15 @@ TEST( icp, icp_rotate )
   openMVG::Vec3 t;
 
   openMVG::geometry::registration::ICP( target, data, 200, 0.0001, t, R );
+  const openMVG::Vec3 invT = R.transpose() * t ;
+
+  std::cout << "Computed" << std::endl;
+  std::cout << invT << std::endl;
+  std::cout << R << std::endl;
+
+  std::cout << "Expected" << std::endl;
+  std::cout << r << std::endl;
+
 
   EXPECT_NEAR( t[ 0 ], 0, 0.00001 );
   EXPECT_NEAR( t[ 1 ], 0, 0.00001 );
@@ -157,38 +181,39 @@ TEST( icp, icp_translate )
   Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target;
   Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
 
-  // A sphere
+  const double tx = 10;
+  const double ty = 12;
+  const double tz = 10;
+
   const double pi          = 3.14159265358979;
-  const int nb_theta       = 32;
-  const int nb_phi         = 16;
-  const double delta_theta = ( 2.0 * pi ) / nb_theta;
-  const double delta_phi   = ( pi ) / nb_phi;
-  const double rad         = 2.0;
 
-  int nb_pt = 0;
-  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
-  {
-    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
-    {
-      ++nb_pt;
-    }
-  }
 
-  target.resize( nb_pt, 3 );
-  data.resize( nb_pt, 3 );
+  const int nb_x = 64 ;
+  const int nb_y = 64 ;
 
-  const double tx = 10.0;
-  const double ty = 20.0;
-  const double tz = 10.0;
+  const double x_min = -10 ;
+  const double x_max = 10 ;
+  const double y_min = -10 ;
+  const double y_max = 10 ;
+
+  const double x_range = x_max - x_min ;
+  const double y_range = y_max - y_min ;
+  const double delta_x = x_range / static_cast<double>( nb_x ) ;
+  const double delta_y = y_range / static_cast<double>( nb_y ) ;
+
+  target.resize( nb_x * nb_y , 3 );
+  data.resize( nb_x * nb_y , 3 );
 
   int id_pt = 0;
-  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
+  for( int id_y = 0 ; id_y < nb_y ; ++id_y )
   {
-    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
+    for( int id_x = 0 ; id_x < nb_x ; ++id_x )
     {
-      const double x = rad * std::cos( phi ) * std::cos( theta );
-      const double y = rad * std::cos( phi ) * std::sin( theta );
-      const double z = rad * std::sin( phi );
+      const double x = x_min + id_x * delta_x ;
+      const double y = y_min + id_y * delta_y ;
+
+      const double rad = std::sqrt( x * x + y * y ) ;
+      const double z = std::max( 0.0 , x ) + std::max( 0.0 , y ) + std::cos( 2.0 * rad ) ;
 
       target( id_pt, 0 ) = x;
       target( id_pt, 1 ) = y;
@@ -205,129 +230,22 @@ TEST( icp, icp_translate )
   openMVG::Mat3 R;
   openMVG::Vec3 t;
 
-  openMVG::geometry::registration::ICP( target, data, 200, 0.0001, t, R );
-
-  EXPECT_NEAR( t[ 0 ], -tx, 0.00001 );
-  EXPECT_NEAR( t[ 1 ], -ty, 0.00001 );
-  EXPECT_NEAR( t[ 2 ], -tz, 0.00001 );
-
-  EXPECT_NEAR( R( 0, 0 ), 1.0, 0.00001 );
-  EXPECT_NEAR( R( 0, 1 ), 0.0, 0.00001 );
-  EXPECT_NEAR( R( 0, 2 ), 0.0, 0.00001 );
-
-  EXPECT_NEAR( R( 1, 0 ), 0.0, 0.00001 );
-  EXPECT_NEAR( R( 1, 1 ), 1.0, 0.00001 );
-  EXPECT_NEAR( R( 1, 2 ), 0.0, 0.00001 );
-
-  EXPECT_NEAR( R( 2, 0 ), 0.0, 0.00001 );
-  EXPECT_NEAR( R( 2, 1 ), 0.0, 0.00001 );
-  EXPECT_NEAR( R( 2, 2 ), 1.0, 0.00001 );
-}
-
-TEST( icp, icp_rot_translate )
-{
-  // Generate point set
-  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target;
-  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
-
-  // A sphere
-  const double pi          = 3.14159265358979;
-  const int nb_theta       = 32;
-  const int nb_phi         = 16;
-  const double delta_theta = ( 2.0 * pi ) / nb_theta;
-  const double delta_phi   = ( pi ) / nb_phi;
-  const double rad         = 2.0;
-
-  int nb_pt = 0;
-  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
-  {
-    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
-    {
-      ++nb_pt;
-    }
-  }
-
-  target.resize( nb_pt, 3 );
-  data.resize( nb_pt, 3 );
-
-  openMVG::Mat3 r;
-  r = Eigen::AngleAxis<double>( pi / 3.0, openMVG::Vec3( 1, 1, 1 ).normalized() );
-
-  const double tx = 15.0;
-  const double ty = 12.0;
-  const double tz = 3.0;
-
-  int id_pt = 0;
-  for( int y = 0 ; y < 10 ; ++y )
-  {
-    for( int x = 0 ; x < 10 ; ++x )
-    {
-      const double dx = x - 10.0 / 2.0 ;
-      const double dy = y - 10.0 / 2.0 ; 
-      
-      const double dist = dx * dx + dy * dy ; 
-
-      const double z = sin( dist ) ; 
-
-      target( id_pt , 0 ) = x ; 
-      target( id_pt , 1 ) = y * 2.0 ; 
-      target( id_pt , 2 ) = z ; 
-
-      const openMVG::Vec3 orig( x, y, z );
-      const openMVG::Vec3 tra = r * orig;
-
-      data( id_pt, 0 ) = tra[ 0 ] + tx;
-      data( id_pt, 1 ) = tra[ 1 ] + ty;
-      data( id_pt, 2 ) = tra[ 2 ] + tz;
-
-      ++id_pt;      
-    }
-  }
-  
-  /*
-  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
-  {
-    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
-    {
-      const double x = rad * std::cos( phi ) * std::cos( theta );
-      const double y = rad * std::cos( phi ) * std::sin( theta );
-      const double z = rad * std::sin( phi );
-
-      target( id_pt, 0 ) = x;
-      target( id_pt, 1 ) = y;
-      target( id_pt, 2 ) = z;
-
-      const openMVG::Vec3 orig( x, y, z );
-      const openMVG::Vec3 tra = r * orig;
-
-      data( id_pt, 0 ) = tra[ 0 ] + tx;
-      data( id_pt, 1 ) = tra[ 1 ] + ty;
-      data( id_pt, 2 ) = tra[ 2 ] + tz;
-
-      ++id_pt;
-    }
-  }
-  */
-
-  // Inverse here
-  r = r.inverse().eval();
-
-  openMVG::Mat3 R;
-  openMVG::Vec3 t;
-
-  openMVG::geometry::registration::ICP( target, data, 200, 0.0, t, R );
+  openMVG::geometry::registration::ICP( target, data, 2000, 0.0001, t, R );
+  const openMVG::Vec3 invT = R.transpose() * t ;
 
   std::cout << "Computed" << std::endl;
-  std::cout << t << std::endl;
+  std::cout << invT << std::endl;
   std::cout << R << std::endl;
 
+  openMVG::Mat3 r ;
+  r.setIdentity() ;
   std::cout << "Expected" << std::endl;
   std::cout << -tx << " - " << -ty << " - " << -tz << std::endl;
-  std::cout << r << std::endl;
+  std::cout << r << std::endl ;
 
-  EXPECT_NEAR( t[ 0 ], -tx, 0.00001 );
-  EXPECT_NEAR( t[ 1 ], -ty, 0.00001 );
-  EXPECT_NEAR( t[ 2 ], -tz, 0.00001 );
+  EXPECT_NEAR( invT[ 0 ], -tx, 0.00001 );
+  EXPECT_NEAR( invT[ 1 ], -ty, 0.00001 );
+  EXPECT_NEAR( invT[ 2 ], -tz, 0.00001 );
 
   EXPECT_NEAR( R( 0, 0 ), r( 0, 0 ), 0.00001 );
   EXPECT_NEAR( R( 0, 1 ), r( 0, 1 ), 0.00001 );
@@ -341,6 +259,317 @@ TEST( icp, icp_rot_translate )
   EXPECT_NEAR( R( 2, 1 ), r( 2, 1 ), 0.00001 );
   EXPECT_NEAR( R( 2, 2 ), r( 2, 2 ), 0.00001 );
 }
+
+TEST( icp, icp_translate_normal )
+{
+  // Generate point set
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target_n;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  const double tx = 10;
+  const double ty = 12;
+  const double tz = 10;
+
+  const double pi          = 3.14159265358979;
+
+  const int nb_x = 64 ;
+  const int nb_y = 64 ;
+
+  const double x_min = -10 ;
+  const double x_max = 10 ;
+  const double y_min = -10 ;
+  const double y_max = 10 ;
+
+  const double x_range = x_max - x_min ;
+  const double y_range = y_max - y_min ;
+  const double delta_x = x_range / static_cast<double>( nb_x ) ;
+  const double delta_y = y_range / static_cast<double>( nb_y ) ;
+
+  target.resize( nb_x * nb_y , 3 );
+  target_n.resize( nb_x * nb_y , 3 ) ;
+  data.resize( nb_x * nb_y , 3 );
+
+  int id_pt = 0;
+  for( int id_y = 0 ; id_y < nb_y ; ++id_y )
+  {
+    for( int id_x = 0 ; id_x < nb_x ; ++id_x )
+    {
+      const double x = x_min + id_x * delta_x ;
+      const double y = y_min + id_y * delta_y ;
+
+      const double rad = std::sqrt( x * x + y * y ) ;
+      const double z = std::max( 0.0 , x ) + std::max( 0.0 , y ) + std::cos( 2.0 * rad ) ;
+
+      const double dx_x = 1.0 ;
+      const double dy_x = 0.0 ;
+      const double dz_x = std::max( 0.0 , x ) / x - 2.0 * std::sin( 2.0 * rad ) / rad ;
+
+      const double dx_y = 0.0 ;
+      const double dy_y = 1.0 ;
+      const double dz_y = std::max( 0.0 , y ) / y - 2.0 * std::sin( 2.0 * rad ) / rad ;
+
+      const openMVG::Vec3 vx( dx_x , dx_y , dz_x ) ;
+      const openMVG::Vec3 vy( dy_x , dy_y , dz_y ) ;
+
+      const openMVG::Vec3 n = ( vx.cross( vy ) ).normalized() ;
+
+      target( id_pt, 0 ) = x;
+      target( id_pt, 1 ) = y;
+      target( id_pt, 2 ) = z;
+
+      target_n( id_pt , 0 ) = n[0] ;
+      target_n( id_pt , 1 ) = n[1] ;
+      target_n( id_pt , 2 ) = n[2] ;
+
+      data( id_pt, 0 ) = x + tx;
+      data( id_pt, 1 ) = y + ty;
+      data( id_pt, 2 ) = z + tz;
+
+      ++id_pt;
+    }
+  }
+
+  openMVG::Mat3 R;
+  openMVG::Vec3 t;
+
+  openMVG::geometry::registration::ICP( target, data, 2000, 0.0001, t, R );
+  const openMVG::Vec3 invT = R.transpose() * t ;
+
+  std::cout << "Computed" << std::endl;
+  std::cout << invT << std::endl;
+  std::cout << R << std::endl;
+
+  openMVG::Mat3 r ;
+  r.setIdentity() ;
+  std::cout << "Expected" << std::endl;
+  std::cout << -tx << " - " << -ty << " - " << -tz << std::endl;
+  std::cout << r << std::endl ;
+
+
+  EXPECT_NEAR( invT[ 0 ], -tx, 0.00001 );
+  EXPECT_NEAR( invT[ 1 ], -ty, 0.00001 );
+  EXPECT_NEAR( invT[ 2 ], -tz, 0.00001 );
+
+  EXPECT_NEAR( R( 0, 0 ), r( 0, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 1 ), r( 0, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 2 ), r( 0, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 1, 0 ), r( 1, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 1 ), r( 1, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 2 ), r( 1, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 2, 0 ), r( 2, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 1 ), r( 2, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 2 ), r( 2, 2 ), 0.00001 );
+}
+
+TEST( icp, icp_rot_translate )
+{
+  // Generate point set
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  const double pi          = 3.14159265358979;
+  openMVG::Mat3 r ;
+  r = Eigen::AngleAxis<double>( pi / 10.0, openMVG::Vec3( 1, 1, 1 ).normalized() );
+
+  const double tx = 0.1;
+  const double ty = 0.2;
+  const double tz = 0.3;
+
+  const int nb_x = 64 ;
+  const int nb_y = 64 ;
+
+  const double x_min = -10 ;
+  const double x_max = 10 ;
+  const double y_min = -10 ;
+  const double y_max = 10 ;
+
+  const double x_range = x_max - x_min ;
+  const double y_range = y_max - y_min ;
+  const double delta_x = x_range / static_cast<double>( nb_x ) ;
+  const double delta_y = y_range / static_cast<double>( nb_y ) ;
+
+  target.resize( nb_x * nb_y , 3 );
+  data.resize( nb_x * nb_y , 3 );
+
+  int id_pt = 0;
+  for( int id_y = 0 ; id_y < nb_y ; ++id_y )
+  {
+    for( int id_x = 0 ; id_x < nb_x ; ++id_x )
+    {
+      const double x = x_min + id_x * delta_x ;
+      const double y = y_min + id_y * delta_y ;
+
+      const double rad = std::sqrt( x * x + y * y ) ;
+      const double z = std::max( 0.0 , x ) + std::max( 0.0 , y ) + std::cos( 2.0 * rad ) ;
+
+      target( id_pt, 0 ) = x;
+      target( id_pt, 1 ) = y;
+      target( id_pt, 2 ) = z;
+
+      const openMVG::Vec3 orig( x, y, z );
+      const openMVG::Vec3 tra = r * orig;
+
+      data( id_pt, 0 ) = tra[0] + tx;
+      data( id_pt, 1 ) = tra[1] + ty;
+      data( id_pt, 2 ) = tra[2] + tz;
+
+      ++id_pt;
+    }
+  }
+  std::cout << Eigen::umeyama( data.transpose() , target.transpose() ) ;
+
+  // Inverse here
+  r = r.inverse().eval();
+
+  std::cout << r * openMVG::Vec3( tx , ty , tz ) ;
+
+  openMVG::Mat3 R;
+  openMVG::Vec3 t;
+
+  openMVG::geometry::registration::ICP( target, data, 2000 , 0.00001 , t, R );
+
+  const openMVG::Vec3 invT = R.transpose() * t ;
+
+  std::cout << "Computed" << std::endl;
+  std::cout << invT << std::endl;
+  std::cout << R << std::endl;
+
+
+  std::cout << "Expected" << std::endl;
+  std::cout << -tx << " - " << -ty << " - " << -tz << std::endl;
+  std::cout << r << std::endl;
+
+  EXPECT_NEAR( invT[ 0 ], -tx, 0.00001 );
+  EXPECT_NEAR( invT[ 1 ], -ty, 0.00001 );
+  EXPECT_NEAR( invT[ 2 ], -tz, 0.00001 );
+
+  EXPECT_NEAR( R( 0, 0 ), r( 0, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 1 ), r( 0, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 2 ), r( 0, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 1, 0 ), r( 1, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 1 ), r( 1, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 2 ), r( 1, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 2, 0 ), r( 2, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 1 ), r( 2, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 2 ), r( 2, 2 ), 0.00001 );
+}
+
+
+TEST( icp, icp_rot_translate_normal )
+{
+  // Generate point set
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target_n;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  openMVG::Mat3 r;
+  const double pi          = 3.14159265358979;
+  r = Eigen::AngleAxis<double>( pi / 10.0, openMVG::Vec3( 1, 1, 1 ).normalized() );
+
+  const double tx = 0.1;
+  const double ty = 0.2;
+  const double tz = 0.3;
+
+  const int nb_x = 64 ;
+  const int nb_y = 64 ;
+
+  const double x_min = -10 ;
+  const double x_max = 10 ;
+  const double y_min = -10 ;
+  const double y_max = 10 ;
+
+  const double x_range = x_max - x_min ;
+  const double y_range = y_max - y_min ;
+  const double delta_x = x_range / static_cast<double>( nb_x ) ;
+  const double delta_y = y_range / static_cast<double>( nb_y ) ;
+
+  target.resize( nb_x * nb_y , 3 );
+  target_n.resize( nb_x * nb_y , 3 ) ;
+  data.resize( nb_x * nb_y , 3 );
+
+  int id_pt = 0;
+  for( int id_y = 0 ; id_y < nb_y ; ++id_y )
+  {
+    for( int id_x = 0 ; id_x < nb_x ; ++id_x )
+    {
+      const double x = x_min + id_x * delta_x ;
+      const double y = y_min + id_y * delta_y ;
+
+      const double rad = std::sqrt( x * x + y * y ) ;
+      const double z = std::max( 0.0 , x ) + std::max( 0.0 , y ) + std::cos( 2.0 * rad ) ;
+
+      const double dx_x = 1.0 ;
+      const double dy_x = 0.0 ;
+      const double dz_x = std::max( 0.0 , x ) / x - 2.0 * std::sin( 2.0 * rad ) / rad ;
+
+      const double dx_y = 0.0 ;
+      const double dy_y = 1.0 ;
+      const double dz_y = std::max( 0.0 , y ) / y - 2.0 * std::sin( 2.0 * rad ) / rad ;
+
+      const openMVG::Vec3 vx( dx_x , dx_y , dz_x ) ;
+      const openMVG::Vec3 vy( dy_x , dy_y , dz_y ) ;
+
+      const openMVG::Vec3 n = ( vx.cross( vy ) ).normalized() ;
+
+      target( id_pt, 0 ) = x;
+      target( id_pt, 1 ) = y;
+      target( id_pt, 2 ) = z;
+
+      target_n( id_pt , 0 ) = n[0] ;
+      target_n( id_pt , 1 ) = n[1] ;
+      target_n( id_pt , 2 ) = n[2] ;
+
+      const openMVG::Vec3 orig( x, y, z );
+      const openMVG::Vec3 tra = r * orig;
+
+      data( id_pt, 0 ) = tra[0] + tx;
+      data( id_pt, 1 ) = tra[1] + ty;
+      data( id_pt, 2 ) = tra[2] + tz;
+
+      ++id_pt;
+    }
+  }
+
+  // Inverse here
+  r = r.inverse().eval();
+
+  openMVG::Mat3 R;
+  openMVG::Vec3 t;
+
+  openMVG::geometry::registration::ICP( target, data, 2000 , 0.0001 , t, R );
+
+  const openMVG::Vec3 invT = R.transpose() * t ;
+
+  std::cout << "Computed" << std::endl;
+  std::cout << invT << std::endl;
+  std::cout << R << std::endl;
+
+  std::cout << "Expected" << std::endl;
+  std::cout << -tx << " - " << -ty << " - " << -tz << std::endl;
+  std::cout << r << std::endl;
+
+  EXPECT_NEAR( invT[ 0 ], -tx, 0.00001 );
+  EXPECT_NEAR( invT[ 1 ], -ty, 0.00001 );
+  EXPECT_NEAR( invT[ 2 ], -tz, 0.00001 );
+
+  EXPECT_NEAR( R( 0, 0 ), r( 0, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 1 ), r( 0, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 2 ), r( 0, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 1, 0 ), r( 1, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 1 ), r( 1, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 2 ), r( 1, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 2, 0 ), r( 2, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 1 ), r( 2, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 2 ), r( 2, 2 ), 0.00001 );
+}
+
 
 /* ************************************************************************* */
 int main()

--- a/src/openMVG/geometry/registration/icp_test.cpp
+++ b/src/openMVG/geometry/registration/icp_test.cpp
@@ -257,7 +257,7 @@ TEST( icp , icp_rot_translate )
   openMVG::Mat3 r ;
   r = Eigen::AngleAxis<double>( pi / 3.0 , openMVG::Vec3( 1 , 1 , 1 ).normalized() ) ;
 
-  const double tx = 10.0 ;
+  const double tx = 15.0 ;
   const double ty = 12.0 ;
   const double tz = 3.0 ; 
 

--- a/src/openMVG/geometry/registration/icp_test.cpp
+++ b/src/openMVG/geometry/registration/icp_test.cpp
@@ -4,321 +4,348 @@
 
 #include <cmath>
 
-TEST( icp , icp_no_transfo )
+TEST( icp, icp_no_transfo )
 {
-  // Generate point set 
-  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> target ;
-  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> data ; 
+  // Generate point set
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
 
-  // A sphere 
-  const double pi = 3.14159265358979 ;
-  const int nb_theta = 32 ;
-  const int nb_phi   = 16 ;
-  const double delta_theta = ( 2.0 * pi ) / nb_theta ;
-  const double delta_phi = ( pi ) / nb_phi ;
-  const double rad = 2.0 ;
+  // A sphere
+  const double pi          = 3.14159265358979;
+  const int nb_theta       = 32;
+  const int nb_phi         = 16;
+  const double delta_theta = ( 2.0 * pi ) / nb_theta;
+  const double delta_phi   = ( pi ) / nb_phi;
+  const double rad         = 2.0;
 
-  int nb_pt = 0 ;
-  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  int nb_pt = 0;
+  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
   {
-    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
     {
-      ++nb_pt ; 
-    }
-  }
-  
-  target.resize( nb_pt , 3 ) ;
-  data.resize( nb_pt , 3 ) ; 
-
-  int id_pt = 0 ; 
-  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
-  {
-    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
-    {
-      const double x = rad * std::cos( phi ) * std::cos( theta ) ;
-      const double y = rad * std::cos( phi ) * std::sin( theta ) ;
-      const double z = rad * std::sin( phi ) ;
-    
-      target( id_pt , 0 ) = x ;
-      target( id_pt , 1 ) = y ;
-      target( id_pt , 2 ) = z ; 
-
-      data( id_pt , 0 ) = x ; 
-      data( id_pt , 1 ) = y ;
-      data( id_pt , 2 ) = z ; 
-
-      ++id_pt ;   
+      ++nb_pt;
     }
   }
 
-  openMVG::Mat3 R ;
-  openMVG::Vec3 t ; 
+  target.resize( nb_pt, 3 );
+  data.resize( nb_pt, 3 );
 
-  openMVG::geometry::registration::ICP( target , data , 200 , 0.0 , t , R ) ; 
+  int id_pt = 0;
+  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
+  {
+    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
+    {
+      const double x = rad * std::cos( phi ) * std::cos( theta );
+      const double y = rad * std::cos( phi ) * std::sin( theta );
+      const double z = rad * std::sin( phi );
 
-  EXPECT_EQ( t[0] , 0.0 ) ;
-  EXPECT_EQ( t[1] , 0.0 ) ;
-  EXPECT_EQ( t[2] , 0.0 ) ; 
+      target( id_pt, 0 ) = x;
+      target( id_pt, 1 ) = y;
+      target( id_pt, 2 ) = z;
 
-  EXPECT_EQ( R(0,0) , 1.0 ) ;
-  EXPECT_EQ( R(0,1) , 0.0 ) ;
-  EXPECT_EQ( R(0,2) , 0.0 ) ;
+      data( id_pt, 0 ) = x;
+      data( id_pt, 1 ) = y;
+      data( id_pt, 2 ) = z;
 
-  EXPECT_EQ( R(1,0) , 0.0 ) ;
-  EXPECT_EQ( R(1,1) , 1.0 ) ;
-  EXPECT_EQ( R(1,2) , 0.0 ) ;
+      ++id_pt;
+    }
+  }
 
-  EXPECT_EQ( R(2,0) , 0.0 ) ;
-  EXPECT_EQ( R(2,1) , 0.0 ) ;
-  EXPECT_EQ( R(2,2) , 1.0 ) ; 
+  openMVG::Mat3 R;
+  openMVG::Vec3 t;
+
+  openMVG::geometry::registration::ICP( target, data, 200, 0.0001, t, R );
+
+  EXPECT_EQ( t[ 0 ], 0.0 );
+  EXPECT_EQ( t[ 1 ], 0.0 );
+  EXPECT_EQ( t[ 2 ], 0.0 );
+
+  EXPECT_EQ( R( 0, 0 ), 1.0 );
+  EXPECT_EQ( R( 0, 1 ), 0.0 );
+  EXPECT_EQ( R( 0, 2 ), 0.0 );
+
+  EXPECT_EQ( R( 1, 0 ), 0.0 );
+  EXPECT_EQ( R( 1, 1 ), 1.0 );
+  EXPECT_EQ( R( 1, 2 ), 0.0 );
+
+  EXPECT_EQ( R( 2, 0 ), 0.0 );
+  EXPECT_EQ( R( 2, 1 ), 0.0 );
+  EXPECT_EQ( R( 2, 2 ), 1.0 );
 }
 
-
-TEST( icp , icp_rotate )
+TEST( icp, icp_rotate )
 {
-  // Generate point set 
-  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> target ;
-  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> data ; 
+  // Generate point set
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
 
-  // A sphere 
-  const double pi = 3.14159265358979 ;
-  const int nb_theta = 32 ;
-  const int nb_phi   = 16 ;
-  const double delta_theta = ( 2.0 * pi ) / nb_theta ;
-  const double delta_phi = ( pi ) / nb_phi ;
-  const double rad = 2.0 ;
+  // A sphere
+  const double pi          = 3.14159265358979;
+  const int nb_theta       = 32;
+  const int nb_phi         = 16;
+  const double delta_theta = ( 2.0 * pi ) / nb_theta;
+  const double delta_phi   = ( pi ) / nb_phi;
+  const double rad         = 2.0;
 
-  int nb_pt = 0 ;
-  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  int nb_pt = 0;
+  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
   {
-    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
     {
-      ++nb_pt ; 
+      ++nb_pt;
     }
   }
-  
-  target.resize( nb_pt , 3 ) ;
-  data.resize( nb_pt , 3 ) ; 
 
-  openMVG::Mat3 r ;
-  r = Eigen::AngleAxis<double>( pi / 3.0 , openMVG::Vec3( 1 , 1 , 1 ).normalized() ) ;
+  target.resize( nb_pt, 3 );
+  data.resize( nb_pt, 3 );
 
+  openMVG::Mat3 r;
+  r = Eigen::AngleAxis<double>( pi / 3.0, openMVG::Vec3( 1, 1, 1 ).normalized() );
 
-  int id_pt = 0 ; 
-  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  int id_pt = 0;
+  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
   {
-    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
     {
-      const double x = rad * std::cos( phi ) * std::cos( theta ) ;
-      const double y = rad * std::cos( phi ) * std::sin( theta ) ;
-      const double z = rad * std::sin( phi ) ;
-    
-      target( id_pt , 0 ) = x ;
-      target( id_pt , 1 ) = y ;
-      target( id_pt , 2 ) = z ; 
+      const double x = rad * std::cos( phi ) * std::cos( theta );
+      const double y = rad * std::cos( phi ) * std::sin( theta );
+      const double z = rad * std::sin( phi );
 
+      target( id_pt, 0 ) = x;
+      target( id_pt, 1 ) = y;
+      target( id_pt, 2 ) = z;
 
-      const openMVG::Vec3 orig( x , y , z ) ;
-      const openMVG::Vec3 tra = r * orig ; 
+      const openMVG::Vec3 orig( x, y, z );
+      const openMVG::Vec3 tra = r * orig;
+
+      data( id_pt, 0 ) = tra[ 0 ];
+      data( id_pt, 1 ) = tra[ 1 ];
+      data( id_pt, 2 ) = tra[ 2 ];
+
+      ++id_pt;
+    }
+  }
+
+  // Inverse here
+  r = r.inverse().eval();
+
+  openMVG::Mat3 R;
+  openMVG::Vec3 t;
+
+  openMVG::geometry::registration::ICP( target, data, 200, 0.0001, t, R );
+
+  EXPECT_NEAR( t[ 0 ], 0, 0.00001 );
+  EXPECT_NEAR( t[ 1 ], 0, 0.00001 );
+  EXPECT_NEAR( t[ 2 ], 0, 0.00001 );
+
+  EXPECT_NEAR( R( 0, 0 ), r( 0, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 1 ), r( 0, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 2 ), r( 0, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 1, 0 ), r( 1, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 1 ), r( 1, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 2 ), r( 1, 2 ), 0.00001 );
+
+  EXPECT_NEAR( R( 2, 0 ), r( 2, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 1 ), r( 2, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 2 ), r( 2, 2 ), 0.00001 );
+}
+
+TEST( icp, icp_translate )
+{
+  // Generate point set
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  // A sphere
+  const double pi          = 3.14159265358979;
+  const int nb_theta       = 32;
+  const int nb_phi         = 16;
+  const double delta_theta = ( 2.0 * pi ) / nb_theta;
+  const double delta_phi   = ( pi ) / nb_phi;
+  const double rad         = 2.0;
+
+  int nb_pt = 0;
+  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
+  {
+    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
+    {
+      ++nb_pt;
+    }
+  }
+
+  target.resize( nb_pt, 3 );
+  data.resize( nb_pt, 3 );
+
+  const double tx = 10.0;
+  const double ty = 20.0;
+  const double tz = 10.0;
+
+  int id_pt = 0;
+  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
+  {
+    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
+    {
+      const double x = rad * std::cos( phi ) * std::cos( theta );
+      const double y = rad * std::cos( phi ) * std::sin( theta );
+      const double z = rad * std::sin( phi );
+
+      target( id_pt, 0 ) = x;
+      target( id_pt, 1 ) = y;
+      target( id_pt, 2 ) = z;
+
+      data( id_pt, 0 ) = x + tx;
+      data( id_pt, 1 ) = y + ty;
+      data( id_pt, 2 ) = z + tz;
+
+      ++id_pt;
+    }
+  }
+
+  openMVG::Mat3 R;
+  openMVG::Vec3 t;
+
+  openMVG::geometry::registration::ICP( target, data, 200, 0.0001, t, R );
+
+  EXPECT_NEAR( t[ 0 ], -tx, 0.00001 );
+  EXPECT_NEAR( t[ 1 ], -ty, 0.00001 );
+  EXPECT_NEAR( t[ 2 ], -tz, 0.00001 );
+
+  EXPECT_NEAR( R( 0, 0 ), 1.0, 0.00001 );
+  EXPECT_NEAR( R( 0, 1 ), 0.0, 0.00001 );
+  EXPECT_NEAR( R( 0, 2 ), 0.0, 0.00001 );
+
+  EXPECT_NEAR( R( 1, 0 ), 0.0, 0.00001 );
+  EXPECT_NEAR( R( 1, 1 ), 1.0, 0.00001 );
+  EXPECT_NEAR( R( 1, 2 ), 0.0, 0.00001 );
+
+  EXPECT_NEAR( R( 2, 0 ), 0.0, 0.00001 );
+  EXPECT_NEAR( R( 2, 1 ), 0.0, 0.00001 );
+  EXPECT_NEAR( R( 2, 2 ), 1.0, 0.00001 );
+}
+
+TEST( icp, icp_rot_translate )
+{
+  // Generate point set
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> target;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> data;
+
+  // A sphere
+  const double pi          = 3.14159265358979;
+  const int nb_theta       = 32;
+  const int nb_phi         = 16;
+  const double delta_theta = ( 2.0 * pi ) / nb_theta;
+  const double delta_phi   = ( pi ) / nb_phi;
+  const double rad         = 2.0;
+
+  int nb_pt = 0;
+  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
+  {
+    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
+    {
+      ++nb_pt;
+    }
+  }
+
+  target.resize( nb_pt, 3 );
+  data.resize( nb_pt, 3 );
+
+  openMVG::Mat3 r;
+  r = Eigen::AngleAxis<double>( pi / 3.0, openMVG::Vec3( 1, 1, 1 ).normalized() );
+
+  const double tx = 15.0;
+  const double ty = 12.0;
+  const double tz = 3.0;
+
+  int id_pt = 0;
+  for( int y = 0 ; y < 10 ; ++y )
+  {
+    for( int x = 0 ; x < 10 ; ++x )
+    {
+      const double dx = x - 10.0 / 2.0 ;
+      const double dy = y - 10.0 / 2.0 ; 
       
-      data( id_pt , 0 ) = tra[0] ; 
-      data( id_pt , 1 ) = tra[1] ;
-      data( id_pt , 2 ) = tra[2] ; 
+      const double dist = dx * dx + dy * dy ; 
 
-      ++id_pt ;   
-    }
-  }
+      const double z = sin( dist ) ; 
 
-  // Inverse here 
-  r = r.inverse().eval() ; 
+      target( id_pt , 0 ) = x ; 
+      target( id_pt , 1 ) = y * 2.0 ; 
+      target( id_pt , 2 ) = z ; 
 
-  openMVG::Mat3 R ;
-  openMVG::Vec3 t ; 
+      const openMVG::Vec3 orig( x, y, z );
+      const openMVG::Vec3 tra = r * orig;
 
-  openMVG::geometry::registration::ICP( target , data , 1000 , 0.0 , t , R ) ; 
+      data( id_pt, 0 ) = tra[ 0 ] + tx;
+      data( id_pt, 1 ) = tra[ 1 ] + ty;
+      data( id_pt, 2 ) = tra[ 2 ] + tz;
 
-  EXPECT_NEAR( t[0] , 0 , 0.00001 ) ;
-  EXPECT_NEAR( t[1] , 0 , 0.00001 ) ;
-  EXPECT_NEAR( t[2] , 0 , 0.00001 ) ; 
-
-  EXPECT_NEAR( R(0,0) , r(0,0) , 0.00001 ) ;
-  EXPECT_NEAR( R(0,1) , r(0,1) , 0.00001 ) ;
-  EXPECT_NEAR( R(0,2) , r(0,2) , 0.00001 ) ;
-
-  EXPECT_NEAR( R(1,0) , r(1,0) , 0.00001 ) ;
-  EXPECT_NEAR( R(1,1) , r(1,1) , 0.00001 ) ;
-  EXPECT_NEAR( R(1,2) , r(1,2) , 0.00001 ) ;
-
-  EXPECT_NEAR( R(2,0) , r(2,0) , 0.00001 ) ;
-  EXPECT_NEAR( R(2,1) , r(2,1) , 0.00001 ) ;
-  EXPECT_NEAR( R(2,2) , r(2,2) , 0.00001 ) ; 
-}
-
-TEST( icp , icp_translate )
-{
-  // Generate point set 
-  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> target ;
-  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> data ; 
-
-  // A sphere 
-  const double pi = 3.14159265358979 ;
-  const int nb_theta = 32 ;
-  const int nb_phi   = 16 ;
-  const double delta_theta = ( 2.0 * pi ) / nb_theta ;
-  const double delta_phi = ( pi ) / nb_phi ;
-  const double rad = 2.0 ;
-
-  int nb_pt = 0 ;
-  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
-  {
-    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
-    {
-      ++nb_pt ; 
+      ++id_pt;      
     }
   }
   
-  target.resize( nb_pt , 3 ) ;
-  data.resize( nb_pt , 3 ) ; 
-
-  const double tx = 10.0 ;
-  const double ty = 20.0 ;
-  const double tz = 10.0 ; 
-
-  int id_pt = 0 ; 
-  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
+  /*
+  for ( double theta = 0.0; theta < 2.0 * pi; theta += delta_theta )
   {
-    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
+    for ( double phi = -pi / 2.0; phi < pi / 2.0; phi += delta_phi )
     {
-      const double x = rad * std::cos( phi ) * std::cos( theta ) ;
-      const double y = rad * std::cos( phi ) * std::sin( theta ) ;
-      const double z = rad * std::sin( phi ) ;
-    
-      target( id_pt , 0 ) = x ;
-      target( id_pt , 1 ) = y ;
-      target( id_pt , 2 ) = z ; 
+      const double x = rad * std::cos( phi ) * std::cos( theta );
+      const double y = rad * std::cos( phi ) * std::sin( theta );
+      const double z = rad * std::sin( phi );
 
-      data( id_pt , 0 ) = x + tx ; 
-      data( id_pt , 1 ) = y + ty ;
-      data( id_pt , 2 ) = z + tz ; 
+      target( id_pt, 0 ) = x;
+      target( id_pt, 1 ) = y;
+      target( id_pt, 2 ) = z;
 
-      ++id_pt ;   
+      const openMVG::Vec3 orig( x, y, z );
+      const openMVG::Vec3 tra = r * orig;
+
+      data( id_pt, 0 ) = tra[ 0 ] + tx;
+      data( id_pt, 1 ) = tra[ 1 ] + ty;
+      data( id_pt, 2 ) = tra[ 2 ] + tz;
+
+      ++id_pt;
     }
   }
+  */
 
-  openMVG::Mat3 R ;
-  openMVG::Vec3 t ; 
+  // Inverse here
+  r = r.inverse().eval();
 
-  openMVG::geometry::registration::ICP( target , data , 1000 , 0.0 , t , R ) ; 
+  openMVG::Mat3 R;
+  openMVG::Vec3 t;
 
-  EXPECT_NEAR( t[0] , -tx , 0.00001 ) ;
-  EXPECT_NEAR( t[1] , -ty , 0.00001 ) ;
-  EXPECT_NEAR( t[2] , -tz , 0.00001 ) ; 
+  openMVG::geometry::registration::ICP( target, data, 200, 0.0, t, R );
 
-  EXPECT_NEAR( R(0,0) , 1.0 , 0.00001 ) ;
-  EXPECT_NEAR( R(0,1) , 0.0 , 0.00001 ) ;
-  EXPECT_NEAR( R(0,2) , 0.0 , 0.00001 ) ;
+  std::cout << "Computed" << std::endl;
+  std::cout << t << std::endl;
+  std::cout << R << std::endl;
 
-  EXPECT_NEAR( R(1,0) , 0.0 , 0.00001 ) ;
-  EXPECT_NEAR( R(1,1) , 1.0 , 0.00001 ) ;
-  EXPECT_NEAR( R(1,2) , 0.0 , 0.00001 ) ;
+  std::cout << "Expected" << std::endl;
+  std::cout << -tx << " - " << -ty << " - " << -tz << std::endl;
+  std::cout << r << std::endl;
 
-  EXPECT_NEAR( R(2,0) , 0.0 , 0.00001 ) ;
-  EXPECT_NEAR( R(2,1) , 0.0 , 0.00001 ) ;
-  EXPECT_NEAR( R(2,2) , 1.0 , 0.00001 ) ; 
-}
+  EXPECT_NEAR( t[ 0 ], -tx, 0.00001 );
+  EXPECT_NEAR( t[ 1 ], -ty, 0.00001 );
+  EXPECT_NEAR( t[ 2 ], -tz, 0.00001 );
 
+  EXPECT_NEAR( R( 0, 0 ), r( 0, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 1 ), r( 0, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 0, 2 ), r( 0, 2 ), 0.00001 );
 
-TEST( icp , icp_rot_translate )
-{
-  // Generate point set 
-  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> target ;
-  Eigen::Matrix<double,Eigen::Dynamic,3,Eigen::RowMajor> data ; 
+  EXPECT_NEAR( R( 1, 0 ), r( 1, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 1 ), r( 1, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 1, 2 ), r( 1, 2 ), 0.00001 );
 
-  // A sphere 
-  const double pi = 3.14159265358979 ;
-  const int nb_theta = 32 ;
-  const int nb_phi   = 16 ;
-  const double delta_theta = ( 2.0 * pi ) / nb_theta ;
-  const double delta_phi = ( pi ) / nb_phi ;
-  const double rad = 2.0 ;
-
-  int nb_pt = 0 ;
-  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
-  {
-    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
-    {
-      ++nb_pt ; 
-    }
-  }
-  
-  target.resize( nb_pt , 3 ) ;
-  data.resize( nb_pt , 3 ) ; 
-
-  openMVG::Mat3 r ;
-  r = Eigen::AngleAxis<double>( pi / 3.0 , openMVG::Vec3( 1 , 1 , 1 ).normalized() ) ;
-
-  const double tx = 15.0 ;
-  const double ty = 12.0 ;
-  const double tz = 3.0 ; 
-
-  int id_pt = 0 ; 
-  for( double theta = 0.0 ; theta < 2.0 * pi ; theta += delta_theta )
-  {
-    for( double phi = -pi/2.0 ; phi < pi/2.0 ; phi += delta_phi )
-    {
-      const double x = rad * std::cos( phi ) * std::cos( theta ) ;
-      const double y = rad * std::cos( phi ) * std::sin( theta ) ;
-      const double z = rad * std::sin( phi ) ;
-    
-      target( id_pt , 0 ) = x ;
-      target( id_pt , 1 ) = y ;
-      target( id_pt , 2 ) = z ; 
-
-
-      const openMVG::Vec3 orig( x , y , z ) ;
-      const openMVG::Vec3 tra = r * orig ; 
-      
-      data( id_pt , 0 ) = tra[0] + tx ; 
-      data( id_pt , 1 ) = tra[1] + ty ;
-      data( id_pt , 2 ) = tra[2] + tz ;  
-
-      ++id_pt ;   
-    }
-  }
-
-  // Inverse here 
-  r = r.inverse().eval() ; 
-
-  openMVG::Mat3 R ;
-  openMVG::Vec3 t ; 
-
-  openMVG::geometry::registration::ICP( target , data , 1000 , 0.0001 , t , R ) ; 
-
-  std::cout << "Computed" << std::endl ; 
-  std::cout << t << std::endl ; 
-  std::cout << R << std::endl ; 
-
-  std::cout << "Expected" << std::endl ; 
-  std::cout << -tx << " - " << -ty << " - " << -tz << std::endl ; 
-  std::cout << r << std::endl ; 
-
-  EXPECT_NEAR( t[0] , -tx , 0.00001 ) ;
-  EXPECT_NEAR( t[1] , -ty , 0.00001 ) ;
-  EXPECT_NEAR( t[2] , -tz , 0.00001 ) ; 
-
-  EXPECT_NEAR( R(0,0) , r(0,0) , 0.00001 ) ;
-  EXPECT_NEAR( R(0,1) , r(0,1) , 0.00001 ) ;
-  EXPECT_NEAR( R(0,2) , r(0,2) , 0.00001 ) ;
-
-  EXPECT_NEAR( R(1,0) , r(1,0) , 0.00001 ) ;
-  EXPECT_NEAR( R(1,1) , r(1,1) , 0.00001 ) ;
-  EXPECT_NEAR( R(1,2) , r(1,2) , 0.00001 ) ;
-
-  EXPECT_NEAR( R(2,0) , r(2,0) , 0.00001 ) ;
-  EXPECT_NEAR( R(2,1) , r(2,1) , 0.00001 ) ;
-  EXPECT_NEAR( R(2,2) , r(2,2) , 0.00001 ) ; 
+  EXPECT_NEAR( R( 2, 0 ), r( 2, 0 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 1 ), r( 2, 1 ), 0.00001 );
+  EXPECT_NEAR( R( 2, 2 ), r( 2, 2 ), 0.00001 );
 }
 
 /* ************************************************************************* */
-int main() { TestResult tr; return TestRegistry::runAllTests(tr);}
+int main()
+{
+  TestResult tr;
+  return TestRegistry::runAllTests( tr );
+}
 /* ************************************************************************* */

--- a/src/openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp
+++ b/src/openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp
@@ -197,8 +197,8 @@ std::pair<Eigen::Quaternion<Scalar>, Eigen::Matrix<Scalar, 3, 1>> RigidMotion3d3
   // 1 Add residuals functions
   ceres::Problem problem;
   // Initial value (no transformation)
-  Eigen::Quaternion<Scalar> q = Eigen::Quaternion<Scalar>::Identity();
-  Eigen::Matrix<Scalar, 3, 1> t( 0, 0, 0 );
+  Eigen::Quaterniond q = Eigen::Quaterniond::Identity();
+  Eigen::Matrix<double, 3, 1> t( 0, 0, 0 );
 
   for ( size_t id_data = 0; id_data < data.rows() ; ++id_data )
   {
@@ -234,7 +234,10 @@ std::pair<Eigen::Quaternion<Scalar>, Eigen::Matrix<Scalar, 3, 1>> RigidMotion3d3
   ceres::Solver::Summary summary;
   ceres::Solve( solverOptions, &problem, &summary );
 
-  return std::make_pair( q , t );
+  // Cast to destination type
+  const Eigen::Quaternion<Scalar> qres = q.cast<Scalar>() ;
+  const Eigen::Matrix<Scalar, 3, 1> tres = t.cast<Scalar>() ;
+  return std::make_pair( qres , tres );
 }
 
 /**

--- a/src/openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp
+++ b/src/openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp
@@ -1,0 +1,174 @@
+#ifndef OPENMVG_GEOMETRY_REGISTRATION_RIGID_MOTION_3D_3D_ESTIMATION_HPP
+#define OPENMVG_GEOMETRY_REGISTRATION_RIGID_MOTION_3D_3D_ESTIMATION_HPP
+
+#include "openMVG/numeric/numeric.h"
+
+#include <ceres/ceres.h>
+
+namespace openMVG
+{
+namespace geometry
+{
+  namespace registration
+  {
+
+    // Compute residual projection cost given two points
+    struct RigidMotion3d3dEstimationCost
+    {
+    public:
+      RigidMotion3d3dEstimationCost( const Vec3 &ref, const Vec3 &data )
+          : m_ref( ref ),
+            m_data( data )
+      {
+      }
+
+      template <typename T>
+      bool operator()( const T *const x, T *residual ) const
+      {
+        // x : (R[0;8] | t[0;2])
+        // 1 - compute projection using
+        const double sx = m_data[ 0 ];
+        const double sy = m_data[ 1 ];
+        const double sz = m_data[ 2 ];
+
+        const double tx = x[ 0 ] * sx + x[ 1 ] * sy + x[ 2 ] * sz + x[ 9 ] ;
+        const double ty = x[ 3 ] * sx + x[ 4 ] * sy + x[ 5 ] * sz + x[ 10 ] ;
+        const double tz = x[ 6 ] * sx + x[ 7 ] * sy + x[ 8 ] * sz + x[ 11 ] ;
+
+        const Vec3 tra( tx , ty , tz ) ; 
+
+        // 2 - compute distance between transformed and
+        const Vec3 delta = tra - m_ref ; 
+        residual[ 0 ] = delta[0] * delta[0] ;
+        residual[ 1 ] = delta[1] * delta[1] ;
+        residual[ 2 ] = delta[2] * delta[2] ;
+
+        return true;
+      }
+
+    private:
+      Vec3 m_ref;
+      Vec3 m_data;
+    };
+
+    template <typename Scalar>
+    class RigidMotion3d3dEstimation
+    {
+      using point_list_type = Eigen::Matrix<Scalar, Eigen::Dynamic, 3, Eigen::RowMajor>;
+
+    public:
+      RigidMotion3d3dEstimation();
+
+      /**
+      * @brief Computes ridig motion (R,t) : R * data + t that maps data on ref 
+      * @param ref Reference point cloud 
+      * @param data Data point cloud 
+      * @return R,t Rigid motion that minimise the MSE   
+      */
+      std::pair<Mat3, Vec3> operator()( const point_list_type &ref, const point_list_type &data );
+
+    private:
+    };
+
+    template <typename Scalar>
+    RigidMotion3d3dEstimation<Scalar>::RigidMotion3d3dEstimation()
+    {
+    }
+
+    /**
+      * @brief Computes ridig motion (R,t) : R * data + t that maps data on ref 
+      * @param ref Reference point cloud 
+      * @param data Data point cloud 
+      * @return R,t Rigid motion that minimise the MSE   
+      */
+    template <typename Scalar>
+    std::pair<Mat3, Vec3> RigidMotion3d3dEstimation<Scalar>::operator()( const RigidMotion3d3dEstimation<Scalar>::point_list_type &ref, const RigidMotion3d3dEstimation<Scalar>::point_list_type &data )
+    {
+      // 1 Add residuals functions
+      ceres::Problem problem;
+      // Initial value (no transformation)
+      Scalar x[ 12 ];
+      x[ 0 ] = 1.0;
+      x[ 1 ] = 0.0;
+      x[ 2 ] = 0.0;
+
+      x[ 3 ] = 0.0;
+      x[ 4 ] = 1.0;
+      x[ 5 ] = 0.0;
+
+      x[ 6 ] = 0.0;
+      x[ 7 ] = 0.0;
+      x[ 8 ] = 1.0;
+
+      x[ 9 ]  = 0.0;
+      x[ 10 ] = 0.0;
+      x[ 11 ] = 0.0;
+
+      for ( int id_obs = 0; id_obs < ref.rows(); ++id_obs )
+      {
+        Vec3 ref_pt( ref( id_obs, 0 ), ref( id_obs, 1 ), ref( id_obs, 2 ) );
+        Vec3 data_pt( data( id_obs, 0 ), data( id_obs, 1 ), data( id_obs, 2 ) );
+
+        ceres::CostFunction *cost_fun =
+            new ceres::NumericDiffCostFunction<RigidMotion3d3dEstimationCost, ceres::CENTRAL , 3, 12>( new RigidMotion3d3dEstimationCost( ref_pt, data_pt ) );
+        problem.AddResidualBlock( cost_fun, NULL, x );
+      }
+
+      ceres::Solver::Options solverOptions;
+      solverOptions.minimizer_progress_to_stdout = false;
+      solverOptions.logging_type                 = ceres::SILENT;
+      // Since the problem is sparse, use a sparse solver iff available
+      if ( ceres::IsSparseLinearAlgebraLibraryTypeAvailable( ceres::SUITE_SPARSE ) )
+      {
+        solverOptions.sparse_linear_algebra_library_type = ceres::SUITE_SPARSE;
+        solverOptions.linear_solver_type                 = ceres::SPARSE_NORMAL_CHOLESKY;
+      }
+      else if ( ceres::IsSparseLinearAlgebraLibraryTypeAvailable( ceres::CX_SPARSE ) )
+      {
+        solverOptions.sparse_linear_algebra_library_type = ceres::CX_SPARSE;
+        solverOptions.linear_solver_type                 = ceres::SPARSE_NORMAL_CHOLESKY;
+      }
+      else if ( ceres::IsSparseLinearAlgebraLibraryTypeAvailable( ceres::EIGEN_SPARSE ) )
+      {
+        solverOptions.sparse_linear_algebra_library_type = ceres::EIGEN_SPARSE;
+        solverOptions.linear_solver_type                 = ceres::SPARSE_NORMAL_CHOLESKY;
+      }
+      else
+      {
+        solverOptions.linear_solver_type = ceres::DENSE_NORMAL_CHOLESKY;
+      }
+#ifdef OPENMVG_USE_OPENMP
+      solverOptions.num_threads               = omp_get_max_threads();
+      solverOptions.num_linear_solver_threads = omp_get_max_threads();
+#endif // OPENMVG_USE_OPENMP
+
+      ceres::Solver::Summary summary;
+      ceres::Solve( solverOptions, &problem, &summary );
+
+      Mat3 r;
+
+      r( 0, 0 ) = x[ 0 ];
+      r( 0, 1 ) = x[ 1 ];
+      r( 0, 2 ) = x[ 2 ];
+
+      r( 1, 0 ) = x[ 3 ];
+      r( 1, 1 ) = x[ 4 ];
+      r( 1, 2 ) = x[ 5 ];
+
+      r( 2, 0 ) = x[ 6 ];
+      r( 2, 1 ) = x[ 7 ];
+      r( 2, 2 ) = x[ 8 ];
+
+      Vec3 t;
+      t[ 0 ] = x[ 9 ];
+      t[ 1 ] = x[ 10 ];
+      t[ 2 ] = x[ 11 ];
+
+      return std::make_pair( r, t );
+    }
+
+  } // namespace registration
+} // namespace geometry
+} // namespace openMVG
+
+#endif

--- a/src/openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp
+++ b/src/openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp
@@ -38,10 +38,10 @@ namespace geometry
         const Vec3 tra( tx , ty , tz ) ; 
 
         // 2 - compute distance between transformed and
-        const Vec3 delta = tra - m_ref ; 
-        residual[ 0 ] = delta[0] * delta[0] ;
-        residual[ 1 ] = delta[1] * delta[1] ;
-        residual[ 2 ] = delta[2] * delta[2] ;
+        const Vec3 delta = m_ref - tra ; 
+        residual[ 0 ] = delta[0] ;
+        residual[ 1 ] = delta[1] ;
+        residual[ 2 ] = delta[2] ;
 
         return true;
       }

--- a/src/openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp
+++ b/src/openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp
@@ -26,22 +26,23 @@ namespace geometry
       bool operator()( const T *const x, T *residual ) const
       {
         // x : (R[0;8] | t[0;2])
-        // 1 - compute projection using
-        const double sx = m_data[ 0 ];
-        const double sy = m_data[ 1 ];
-        const double sz = m_data[ 2 ];
+        Eigen::Matrix<T, 3, 1> src;
+        src << T( m_data[ 0 ] ), T( m_data[ 1 ] ), T( m_data[ 2 ] );
 
-        const double tx = x[ 0 ] * sx + x[ 1 ] * sy + x[ 2 ] * sz + x[ 9 ] ;
-        const double ty = x[ 3 ] * sx + x[ 4 ] * sy + x[ 5 ] * sz + x[ 10 ] ;
-        const double tz = x[ 6 ] * sx + x[ 7 ] * sy + x[ 8 ] * sz + x[ 11 ] ;
+        const T tx = x[ 0 ] * src[ 0 ] + x[ 1 ] * src[ 1 ] + x[ 2 ] * src[ 2 ] + x[ 9 ];
+        const T ty = x[ 3 ] * src[ 0 ] + x[ 4 ] * src[ 1 ] + x[ 5 ] * src[ 2 ] + x[ 10 ];
+        const T tz = x[ 6 ] * src[ 0 ] + x[ 7 ] * src[ 1 ] + x[ 8 ] * src[ 2 ] + x[ 11 ];
 
-        const Vec3 tra( tx , ty , tz ) ; 
+        Eigen::Matrix<T, 3, 1> tra;
+        tra << tx, ty, tz;
 
         // 2 - compute distance between transformed and
-        const Vec3 delta = m_ref - tra ; 
-        residual[ 0 ] = delta[0] ;
-        residual[ 1 ] = delta[1] ;
-        residual[ 2 ] = delta[2] ;
+        Eigen::Matrix<T, 3, 1> ref;
+        ref << T( m_ref[ 0 ] ), T( m_ref[ 1 ] ), T( m_ref[ 2 ] );
+
+        residual[ 0 ] = ref[ 0 ] - tra[ 0 ];
+        residual[ 1 ] = ref[ 1 ] - tra[ 1 ];
+        residual[ 2 ] = ref[ 2 ] - tra[ 2 ];
 
         return true;
       }
@@ -66,6 +67,15 @@ namespace geometry
       * @return R,t Rigid motion that minimise the MSE   
       */
       std::pair<Mat3, Vec3> operator()( const point_list_type &ref, const point_list_type &data );
+
+      /**
+      * @brief Computes ridig motion (R,t) : R * data + t that maps data on ref 
+      * @param ref Reference point cloud 
+      * @param data Data point cloud 
+      * @param corresps (id of the correspondances from data to ref, -1 if no corresp)
+      * @return R,t Rigid motion that minimise the MSE   
+      */
+      std::pair<Mat3, Vec3> operator()( const point_list_type &ref, const point_list_type &data, const std::vector<int> &corresps );
 
     private:
     };
@@ -110,8 +120,109 @@ namespace geometry
         Vec3 data_pt( data( id_obs, 0 ), data( id_obs, 1 ), data( id_obs, 2 ) );
 
         ceres::CostFunction *cost_fun =
-            new ceres::NumericDiffCostFunction<RigidMotion3d3dEstimationCost, ceres::CENTRAL , 3, 12>( new RigidMotion3d3dEstimationCost( ref_pt, data_pt ) );
+            new ceres::AutoDiffCostFunction<RigidMotion3d3dEstimationCost, 3, 12>( new RigidMotion3d3dEstimationCost( ref_pt, data_pt ) );
         problem.AddResidualBlock( cost_fun, NULL, x );
+      }
+
+      ceres::Solver::Options solverOptions;
+      solverOptions.minimizer_progress_to_stdout = false;
+      solverOptions.logging_type                 = ceres::SILENT;
+      // Since the problem is sparse, use a sparse solver iff available
+      if ( ceres::IsSparseLinearAlgebraLibraryTypeAvailable( ceres::SUITE_SPARSE ) )
+      {
+        solverOptions.sparse_linear_algebra_library_type = ceres::SUITE_SPARSE;
+        solverOptions.linear_solver_type                 = ceres::SPARSE_NORMAL_CHOLESKY;
+      }
+      else if ( ceres::IsSparseLinearAlgebraLibraryTypeAvailable( ceres::CX_SPARSE ) )
+      {
+        solverOptions.sparse_linear_algebra_library_type = ceres::CX_SPARSE;
+        solverOptions.linear_solver_type                 = ceres::SPARSE_NORMAL_CHOLESKY;
+      }
+      else if ( ceres::IsSparseLinearAlgebraLibraryTypeAvailable( ceres::EIGEN_SPARSE ) )
+      {
+        solverOptions.sparse_linear_algebra_library_type = ceres::EIGEN_SPARSE;
+        solverOptions.linear_solver_type                 = ceres::SPARSE_NORMAL_CHOLESKY;
+      }
+      else
+      {
+        solverOptions.linear_solver_type = ceres::DENSE_NORMAL_CHOLESKY;
+      }
+#ifdef OPENMVG_USE_OPENMP
+      solverOptions.num_threads               = omp_get_max_threads();
+      solverOptions.num_linear_solver_threads = omp_get_max_threads();
+#endif // OPENMVG_USE_OPENMP
+
+      ceres::Solver::Summary summary;
+      ceres::Solve( solverOptions, &problem, &summary );
+
+      Mat3 r;
+
+      r( 0, 0 ) = x[ 0 ];
+      r( 0, 1 ) = x[ 1 ];
+      r( 0, 2 ) = x[ 2 ];
+
+      r( 1, 0 ) = x[ 3 ];
+      r( 1, 1 ) = x[ 4 ];
+      r( 1, 2 ) = x[ 5 ];
+
+      r( 2, 0 ) = x[ 6 ];
+      r( 2, 1 ) = x[ 7 ];
+      r( 2, 2 ) = x[ 8 ];
+
+      Vec3 t;
+      t[ 0 ] = x[ 9 ];
+      t[ 1 ] = x[ 10 ];
+      t[ 2 ] = x[ 11 ];
+
+      return std::make_pair( r, t );
+    }
+
+    /**
+      * @brief Computes ridig motion (R,t) : R * data + t that maps data on ref 
+      * @param ref Reference point cloud 
+      * @param data Data point cloud 
+      * @param corresps (id of the correspondances from data to ref, -1 if no corresp)
+      * @return R,t Rigid motion that minimise the MSE   
+      */
+    template <typename Scalar>
+    std::pair<Mat3, Vec3> RigidMotion3d3dEstimation<Scalar>::operator()( const point_list_type &ref,
+                                                                         const point_list_type &data,
+                                                                         const std::vector<int> &corresps )
+    {
+      // 1 Add residuals functions
+      ceres::Problem problem;
+      // Initial value (no transformation)
+      Scalar x[ 12 ];
+      x[ 0 ] = 1.0;
+      x[ 1 ] = 0.0;
+      x[ 2 ] = 0.0;
+
+      x[ 3 ] = 0.0;
+      x[ 4 ] = 1.0;
+      x[ 5 ] = 0.0;
+
+      x[ 6 ] = 0.0;
+      x[ 7 ] = 0.0;
+      x[ 8 ] = 1.0;
+
+      x[ 9 ]  = 0.0;
+      x[ 10 ] = 0.0;
+      x[ 11 ] = 0.0;
+
+      for ( size_t id_corresp = 0; id_corresp < corresps.size(); ++id_corresp )
+      {
+        if ( corresps[ id_corresp ] >= 0 )
+        {
+          const int id_data = id_corresp;
+          const int id_ref  = corresps[ id_corresp ];
+
+          Vec3 ref_pt( ref( id_ref, 0 ), ref( id_ref, 1 ), ref( id_ref, 2 ) );
+          Vec3 data_pt( data( id_data, 0 ), data( id_data, 1 ), data( id_data, 2 ) );
+
+          ceres::CostFunction *cost_fun =
+              new ceres::AutoDiffCostFunction<RigidMotion3d3dEstimationCost, 3, 12>( new RigidMotion3d3dEstimationCost( ref_pt, data_pt ) );
+          problem.AddResidualBlock( cost_fun, NULL, x );
+        }
       }
 
       ceres::Solver::Options solverOptions;

--- a/src/openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp
+++ b/src/openMVG/geometry/registration/rigid_motion_3d_3d_estimation.hpp
@@ -1,3 +1,11 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2017 Romuald Perrot.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 #ifndef OPENMVG_GEOMETRY_REGISTRATION_RIGID_MOTION_3D_3D_ESTIMATION_HPP
 #define OPENMVG_GEOMETRY_REGISTRATION_RIGID_MOTION_3D_3D_ESTIMATION_HPP
 

--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -115,3 +115,5 @@ install(
   FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h"
 )
 endforeach(inDirectory)
+
+add_subdirectory( nabo )

--- a/src/third_party/nabo/CMakeLists.txt
+++ b/src/third_party/nabo/CMakeLists.txt
@@ -1,0 +1,11 @@
+set( NABO_SRCS nabo.cpp brute_force_cpu.cpp kdtree_cpu.cpp )
+set( NABO_HDRS nabo.h index_heap.h nabo_private.h )
+
+add_library( libnabo STATIC ${NABO_SRCS} )
+SET_PROPERTY(TARGET libnabo PROPERTY FOLDER OpenMVG/3rdParty)
+
+install(FILES ${NABO_HDRS}
+  DESTINATION ${INCLUDE_INSTALL_DIR} COMPONENT Devel
+)
+
+INSTALL(TARGETS libnabo DESTINATION lib EXPORT openMVG-targets)

--- a/src/third_party/nabo/brute_force_cpu.cpp
+++ b/src/third_party/nabo/brute_force_cpu.cpp
@@ -1,0 +1,111 @@
+/*
+
+Copyright (c) 2010--2011, Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the author at <stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "nabo_private.h"
+#include "index_heap.h"
+
+/*!	\file brute_force_cpu.cpp
+	\brief brute force search, cpu implementation
+	\ingroup private
+*/
+
+namespace Nabo
+{
+	using namespace std;
+	
+	template<typename T, typename CloudType>
+	BruteForceSearch<T, CloudType>::BruteForceSearch(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags):
+		NearestNeighbourSearch<T, CloudType>::NearestNeighbourSearch(cloud, dim, creationOptionFlags)
+	{
+#ifdef EIGEN3_API
+		const_cast<Vector&>(this->minBound) = cloud.topRows(this->dim).rowwise().minCoeff();
+		const_cast<Vector&>(this->maxBound) = cloud.topRows(this->dim).rowwise().maxCoeff();
+#else // EIGEN3_API
+		// compute bounds
+		for (int i = 0; i < cloud.cols(); ++i)
+		{
+			const Vector& v(cloud.block(0,i,this->dim,1));
+			const_cast<Vector&>(this->minBound) = this->minBound.cwise().min(v);
+			const_cast<Vector&>(this->maxBound) = this->maxBound.cwise().max(v);
+		}
+#endif // EIGEN3_API
+	}
+	
+
+	template<typename T, typename CloudType>
+	unsigned long BruteForceSearch<T, CloudType>::knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Index k, const T epsilon, const unsigned optionFlags, const T maxRadius) const
+	{
+		const Vector maxRadii(Vector::Constant(query.cols(), maxRadius));
+		return knn(query, indices, dists2, maxRadii, k, epsilon, optionFlags);
+	}
+	
+	template<typename T, typename CloudType>
+	unsigned long BruteForceSearch<T, CloudType>::knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Vector& maxRadii, const Index k, const T /*epsilon*/, const unsigned optionFlags) const
+	{
+		checkSizesKnn(query, indices, dists2, k, optionFlags, &maxRadii);
+		
+		const bool allowSelfMatch(optionFlags & NearestNeighbourSearch<T>::ALLOW_SELF_MATCH);
+		const bool sortResults(optionFlags & NearestNeighbourSearch<T>::SORT_RESULTS);
+		const bool collectStatistics(creationOptionFlags & NearestNeighbourSearch<T>::TOUCH_STATISTICS);
+		
+		IndexHeapSTL<Index, T> heap(k);
+		
+		for (int c = 0; c < query.cols(); ++c)
+		{
+			const T maxRadius(maxRadii[c]);
+			const T maxRadius2(maxRadius * maxRadius);
+			const Vector& q(query.block(0,c,dim,1));
+			heap.reset();
+			for (int i = 0; i < this->cloud.cols(); ++i)
+			{
+				const T dist(dist2<T>(this->cloud.block(0,i,dim,1), q));
+				if ((dist <= maxRadius2) &&
+					(dist < heap.headValue()) &&
+					(allowSelfMatch || (dist > numeric_limits<T>::epsilon())))
+					heap.replaceHead(i, dist);
+			}
+			if (sortResults)
+				heap.sort();	
+			heap.getData(indices.col(c), dists2.col(c));
+		}
+		if (collectStatistics)
+			return (unsigned long)query.cols() * (unsigned long)this->cloud.cols();
+		else
+			return 0;
+	}
+	
+	template struct BruteForceSearch<float>;
+	template struct BruteForceSearch<double>;
+	template struct BruteForceSearch<float, Eigen::Matrix3Xf>;
+	template struct BruteForceSearch<double, Eigen::Matrix3Xd>;
+	template struct BruteForceSearch<float, Eigen::Map<const Eigen::Matrix3Xf, Eigen::Aligned> >;
+	template struct BruteForceSearch<double, Eigen::Map<const Eigen::Matrix3Xd, Eigen::Aligned> >;
+}

--- a/src/third_party/nabo/index_heap.h
+++ b/src/third_party/nabo/index_heap.h
@@ -1,0 +1,372 @@
+/*
+
+Copyright (c) 2010--2011, Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the author at <stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef __INDEX_HEAP_H
+#define __INDEX_HEAP_H
+
+#include "nabo.h"
+#include <vector>
+#include <algorithm>
+#include <limits>
+#include <iostream>
+
+/*!	\file index_heap.h
+	\brief implementation of index heaps
+	\ingroup private
+*/
+
+namespace Nabo
+{
+	//! balanced-tree implementation of heap
+	/** It uses a binary heap, which provides replacement in O(log(n)),
+	 * 	however the constant overhead is significative. */
+	template<typename IT, typename VT>
+	struct IndexHeapSTL
+	{
+		//! type of an index
+		typedef IT Index;
+		//! type of a value
+		typedef VT Value;
+		
+		//! an entry of the heap tree
+		struct Entry
+		{
+			IT index; //!< index of point
+			VT value; //!< distance for this point
+			
+			//! create a new entry
+			Entry(const IT index, const VT value): index(index), value(value) {}
+			//! return true if e0 is of lower value than e1, false otherwise
+			friend bool operator<(const Entry& e0, const Entry& e1) { return e0.value < e1.value; }
+		};
+		//! vector of entry, type for the storage of the tree
+		typedef std::vector<Entry> Entries;
+		//! vector of indices
+		typedef typename Eigen::Matrix<Index, Eigen::Dynamic, 1> IndexVector;
+		//! vector of values
+		typedef typename Eigen::Matrix<Value, Eigen::Dynamic, 1> ValueVector;
+		
+		//! storage for the tree
+		Entries data;
+		//! number of neighbours requested
+		const size_t nbNeighbours;
+
+		
+		//! Constructor
+		/*! \param size number of elements in the heap */
+		IndexHeapSTL(const size_t size):
+			data(1, Entry(0, std::numeric_limits<VT>::infinity())),
+			nbNeighbours(size)
+		{
+			data.reserve(size);
+		}
+		
+		//! reset to the empty heap
+		inline void reset()
+		{
+			data.clear();
+			data.push_back(Entry(0, std::numeric_limits<VT>::infinity()));
+		}
+		
+		//! get the largest value of the heap
+		/** \return the largest value in the heap */
+		inline const VT& headValue() const { return data.front().value; }
+		
+		//! put value into heap, replace the largest value if full
+		/** \param index new point index
+		 * 	\param value new distance value */
+		inline void replaceHead(const Index index, const Value value)
+		{
+
+			if (data.size() == nbNeighbours)
+			{	// we have enough neighbours to discard largest
+				pop_heap(data.begin(), data.end());
+				data.back() = Entry(index, value);
+			}
+			else
+			{	// missing neighbours
+				data.push_back(Entry(index, value));
+			}
+			// ensure heap
+			push_heap(data.begin(), data.end());
+		}
+		
+		//! sort the entries, from the smallest to the largest
+		inline void sort()
+		{
+			sort_heap (data.begin(), data.end());
+		}
+		
+		//! get the data from the heap
+		/** \param indices index vector
+		 * 	\param values value vector */
+		template<typename DI, typename DV>
+		inline void getData(const Eigen::MatrixBase<DI>& indices, const Eigen::MatrixBase<DV> & values) const
+		{
+			// note: we must implement this hack because of problem with reference to temporary
+			// C++0x will solve this with rvalue
+			// see: http://eigen.tuxfamily.org/dox-devel/TopicFunctionTakingEigenTypes.html
+			// for more informations
+			size_t i = 0;
+			for (; i < data.size(); ++i)
+			{
+				const_cast<Eigen::MatrixBase<DI>&>(indices).coeffRef(i) = data[i].index;
+				const_cast<Eigen::MatrixBase<DV>&>(values).coeffRef(i) = data[i].value;
+			}
+			for (; i < nbNeighbours; ++i)
+			{
+				const_cast<Eigen::MatrixBase<DI>&>(indices).coeffRef(i) = 0;
+				const_cast<Eigen::MatrixBase<DV>&>(values).coeffRef(i) = std::numeric_limits<VT>::infinity();
+			}
+		}
+		
+#if 0
+		//! get the data-point indices from the heap
+		/** \return the indices */
+		inline IndexVector getIndexes() const
+		{
+			IndexVector indexes(data.capacity());
+			size_t i = 0;
+			for (; i < data.size(); ++i)
+				indexes.coeffRef(i) = data[i].index;
+			for (; i < data.capacity(); ++i)
+				indexes.coeffRef(i) = 0;
+			return indexes;
+		}
+#endif
+	};
+	
+#if 0
+	//! brute-force implementation of heap
+	/** It uses a vector and linear search, which provides replacement in O(n),
+	 * 	but with a very low constant overhead. */
+	template<typename IT, typename VT>
+	struct IndexHeapBruteForceVector
+	{
+		//! type of an index
+		typedef IT Index;
+		//! type of a value
+		typedef VT Value;
+		
+		//! an entry of the heap vector
+		struct Entry
+		{
+			IT index; //!< index of point
+			VT value;  //!< distance for this point
+			
+			//! create a new entry
+			Entry(const IT index, const VT value): index(index), value(value) {} 
+			//! return true if e0 is smaller than e1, false otherwise
+			friend bool operator<(const Entry& e0, const Entry& e1) { return e0.value < e1.value; }
+		};
+		//! vector of entry, type for the storage of the tree
+		typedef std::vector<Entry> Entries;
+		//! vector of indices
+		typedef typename Eigen::Matrix<Index, Eigen::Dynamic, 1> IndexVector;
+		
+		//! storage for the tree
+		Entries data;
+		//! reference to the largest value in the tree, to optimise access speed
+		const VT& headValueRef;
+		//! pre-competed size minus one, to optimise access speed
+		const size_t sizeMinusOne;
+		
+		//! Constructor
+		/*! \param size number of elements in the heap */
+		IndexHeapBruteForceVector(const size_t size):
+			data(size, Entry(0, std::numeric_limits<VT>::infinity())),
+			headValueRef((data.end() - 1)->value),
+			sizeMinusOne(data.size() - 1)
+		{
+		}
+		
+		//! reset to the empty heap
+		inline void reset()
+		{
+			for (typename Entries::iterator it(data.begin()); it != data.end(); ++it)
+			{
+				it->value = std::numeric_limits<VT>::infinity();
+				it->index = 0;
+			}
+		}
+		
+		//! get the largest value of the heap
+		/** \return the smallest value in the heap */
+		inline const VT& headValue() const { return data[0].value; }
+		
+		//! replace the largest value of the heap
+		/** \param index new point index
+		 * 	\param value new distance value */
+		inline void replaceHead(const Index index, const Value value)
+		{
+			register size_t i = 0;
+			for (; i < sizeMinusOne; ++i)
+			{
+				if (data[i + 1].value > value)
+					data[i] = data[i + 1];
+				else
+					break;
+			}
+			data[i].value = value;
+			data[i].index = index;
+		}
+		
+		//! sort the entries, from the smallest to the largest
+		inline void sort()
+		{
+			// no need to sort as data are already sorted
+		}
+		
+		//! get the data-point indices from the heap
+		/** \return the indices */
+		inline IndexVector getIndexes() const
+		{
+			IndexVector indexes(data.size());
+			for (size_t i = 0; i < data.size(); ++i)
+				indexes.coeffRef(i) = data[sizeMinusOne-i].index;
+			return indexes;
+		}
+	};
+#endif
+	
+	//! brute-force implementation of heap
+	/** It uses a vector and linear search, which provides replacement in O(n),
+	 * 	but with a very low constant overhead. */
+	template<typename IT, typename VT>
+	struct IndexHeapBruteForceVector
+	{
+		//! type of an index
+		typedef IT Index;
+		//! type of a value
+		typedef VT Value;
+		
+		//! an entry of the heap vector
+		struct Entry
+		{
+			IT index; //!< index of point
+			VT value;  //!< distance for this point
+			
+			//! create a new entry
+			Entry(const IT index, const VT value): index(index), value(value) {} 
+			//! return true if e0 is smaller than e1, false otherwise
+			friend bool operator<(const Entry& e0, const Entry& e1) { return e0.value < e1.value; }
+		};
+		//! vector of entry, type for the storage of the tree
+		typedef std::vector<Entry> Entries;
+		//! vector of indices
+		typedef typename Eigen::Matrix<Index, Eigen::Dynamic, 1> IndexVector;
+		//! vector of values
+		typedef typename Eigen::Matrix<Value, Eigen::Dynamic, 1> ValueVector;
+		
+		//! storage for the tree
+		Entries data;
+		//! reference to the largest value in the tree, to optimise access speed
+		const VT& headValueRef;
+		//! pre-competed size minus one, to optimise access speed
+		const size_t sizeMinusOne;
+		
+		//! Constructor
+		/*! \param size number of elements in the heap */
+		IndexHeapBruteForceVector(const size_t size):
+		data(size, Entry(0, std::numeric_limits<VT>::infinity())),
+		headValueRef((data.end() - 1)->value),
+		sizeMinusOne(data.size() - 1)
+		{
+		}
+		
+		//! reset to the empty heap
+		inline void reset()
+		{
+			for (typename Entries::iterator it(data.begin()); it != data.end(); ++it)
+			{
+				it->value = std::numeric_limits<VT>::infinity();
+				it->index = 0;
+			}
+		}
+		
+		//! get the largest value of the heap
+		/** \return the smallest value in the heap */
+		inline const VT& headValue() const { return headValueRef; }
+		
+		//! replace the largest value of the heap
+		/** \param index new point index
+		 * 	\param value new distance value */
+		inline void replaceHead(const Index index, const Value value)
+		{
+			register size_t i;
+			for (i = sizeMinusOne; i > 0; --i)
+			{
+				if (data[i-1].value > value)
+					data[i] = data[i-1];
+				else
+					break;
+			}
+			data[i].value = value;
+			data[i].index = index;
+		}
+		
+		//! sort the entries, from the smallest to the largest
+		inline void sort()
+		{
+			// no need to sort as data are already sorted
+		}
+		
+		//! get the data from the heap
+		/** \param indices index vector
+		 * 	\param values value vector */
+		template<typename DI, typename DV>
+		inline void getData(const Eigen::MatrixBase<DI>& indices, const Eigen::MatrixBase<DV> & values) const
+		{
+			// note: we must implement this hack because of problem with reference to temporary
+			// C++0x will solve this with rvalue
+			// see: http://eigen.tuxfamily.org/dox-devel/TopicFunctionTakingEigenTypes.html
+			// for more informations
+			for (size_t i = 0; i < data.size(); ++i)
+			{
+				const_cast<Eigen::MatrixBase<DI>&>(indices).coeffRef(i) = data[i].index;
+				const_cast<Eigen::MatrixBase<DV>&>(values).coeffRef(i) = data[i].value;
+			}
+		}
+#if 0
+		//! get the data-point indices from the heap
+		/** \return the indices */
+		inline IndexVector getIndexes() const
+		{
+			IndexVector indexes(data.size());
+			for (size_t i = 0; i < data.size(); ++i)
+				indexes.coeffRef(i) = data[i].index;
+			return indexes;
+		}
+#endif
+	};
+}
+
+#endif // __INDEX_HEAP_H

--- a/src/third_party/nabo/kdtree_cpu.cpp
+++ b/src/third_party/nabo/kdtree_cpu.cpp
@@ -1,0 +1,541 @@
+/*
+
+Copyright (c) 2010--2011, Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the author at <stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "nabo_private.h"
+#include "index_heap.h"
+#include <iostream>
+#include <stdexcept>
+#include <limits>
+#include <queue>
+#include <algorithm>
+#include <utility>
+/*
+#include <boost/numeric/conversion/bounds.hpp>
+#include <boost/limits.hpp>
+#include <boost/format.hpp>
+*/
+#ifdef HAVE_OPENMP
+  #include <omp.h>
+#endif
+
+/*! \file kdtree_cpu.cpp
+  \brief kd-tree search, cpu implementation
+  \ingroup private
+*/
+
+namespace Nabo
+{
+//! \ingroup private
+//@{
+
+using namespace std;
+
+//! Return the number of bit required to store a value
+/** \param v value to store
+ * \return number of bits required
+ */
+template<typename T>
+T getStorageBitCount( T v )
+{
+  for ( T i = 0; i < 64; ++i )
+  {
+    if ( v == 0 )
+    {
+      return i;
+    }
+    v >>= 1;
+  }
+  return 64;
+}
+
+//! Return the index of the maximum value of a vector of positive values
+/** \param v vector of positive values
+ * \return index of maximum value, 0 if the vector is empty
+ */
+template<typename T, typename CloudType>
+size_t argMax( const typename NearestNeighbourSearch<T, CloudType>::Vector& v )
+{
+  T maxVal( 0 );
+  size_t maxIdx( 0 );
+  for ( int i = 0; i < v.size(); ++i )
+  {
+    if ( v[i] > maxVal )
+    {
+      maxVal = v[i];
+      maxIdx = i;
+    }
+  }
+  return maxIdx;
+}
+
+// OPT
+template<typename T, typename Heap, typename CloudType>
+pair<T, T> KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, Heap, CloudType>::getBounds( const BuildPointsIt first, const BuildPointsIt last, const unsigned dim )
+{
+  T minVal( std::numeric_limits<T>::max() );
+  T maxVal( std::numeric_limits<T>::lowest() );
+
+  for ( BuildPointsCstIt it( first ); it != last; ++it )
+  {
+    const T val( cloud.coeff( dim, *it ) );
+    minVal = min( val, minVal );
+    maxVal = max( val, maxVal );
+  }
+
+  return make_pair( minVal, maxVal );
+}
+
+template<typename T, typename Heap, typename CloudType>
+unsigned KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, Heap, CloudType>::buildNodes( const BuildPointsIt first, const BuildPointsIt last, const Vector minValues, const Vector maxValues )
+{
+  const int count( last - first );
+  assert( count >= 1 );
+  const unsigned pos( nodes.size() );
+
+  //cerr << count << endl;
+  if ( count <= int( bucketSize ) )
+  {
+    const uint32_t initBucketsSize( buckets.size() );
+    //cerr << "creating bucket with " << count << " values" << endl;
+    for ( int i = 0; i < count; ++i )
+    {
+      const Index index( *( first + i ) );
+      assert( index < cloud.cols() );
+      buckets.push_back( BucketEntry( &cloud.coeff( 0, index ), index ) );
+      //cerr << "  " << &cloud.coeff(0, index) << ", " << index << endl;
+    }
+    //cerr << "at address " << bucketStart << endl;
+    nodes.push_back( Node( createDimChildBucketSize( dim, count ), initBucketsSize ) );
+    return pos;
+  }
+
+  // find the largest dimension of the box
+  const unsigned cutDim = argMax<T, CloudType>( maxValues - minValues );
+  const T idealCutVal( ( maxValues( cutDim ) + minValues( cutDim ) ) / 2 );
+
+  // get bounds from actual points
+  const pair<T, T> minMaxVals( getBounds( first, last, cutDim ) );
+
+  // correct cut following bounds
+  T cutVal;
+  if ( idealCutVal < minMaxVals.first )
+  {
+    cutVal = minMaxVals.first;
+  }
+  else if ( idealCutVal > minMaxVals.second )
+  {
+    cutVal = minMaxVals.second;
+  }
+  else
+  {
+    cutVal = idealCutVal;
+  }
+
+  int l( 0 );
+  int r( count - 1 );
+  // partition points around cutVal
+  while ( 1 )
+  {
+    while ( l < count && cloud.coeff( cutDim, *( first + l ) ) < cutVal )
+    {
+      ++l;
+    }
+    while ( r >= 0 && cloud.coeff( cutDim, *( first + r ) ) >= cutVal )
+    {
+      --r;
+    }
+    if ( l > r )
+    {
+      break;
+    }
+    swap( *( first + l ), *( first + r ) );
+    ++l;
+    --r;
+  }
+  const int br1 = l;  // now: points[0..br1-1] < cutVal <= points[br1..count-1]
+  r = count - 1;
+  // partition points[br1..count-1] around cutVal
+  while ( 1 )
+  {
+    while ( l < count && cloud.coeff( cutDim, *( first + l ) ) <= cutVal )
+    {
+      ++l;
+    }
+    while ( r >= br1 && cloud.coeff( cutDim, *( first + r ) ) > cutVal )
+    {
+      --r;
+    }
+    if ( l > r )
+    {
+      break;
+    }
+    swap( *( first + l ), *( first + r ) );
+    ++l;
+    --r;
+  }
+  const int br2 = l; // now: points[br1..br2-1] == cutVal < points[br2..count-1]
+
+  // find best split index
+  int leftCount;
+  if ( idealCutVal < minMaxVals.first )
+  {
+    leftCount = 1;
+  }
+  else if ( idealCutVal > minMaxVals.second )
+  {
+    leftCount = count - 1;
+  }
+  else if ( br1 > count / 2 )
+  {
+    leftCount = br1;
+  }
+  else if ( br2 < count / 2 )
+  {
+    leftCount = br2;
+  }
+  else
+  {
+    leftCount = count / 2;
+  }
+  assert( leftCount > 0 );
+  /*if (leftCount >= count)
+  {
+    cerr << "Error found in kdtree:" << endl;
+    cerr << "cloud size: " << cloud.cols() << endl;
+    cerr << "count:" << count << endl;
+    cerr << "leftCount: " << leftCount << endl;
+    cerr << "br1: " << br1 << endl;
+    cerr << "br2: " << br2 << endl;
+    cerr << "idealCutVal: " << idealCutVal << endl;
+    cerr << "cutVal: " << cutVal << endl;
+    cerr << "minMaxVals.first: " << minMaxVals.first << endl;
+    cerr << "minMaxVals.second: " << minMaxVals.second << endl;
+  }*/
+  assert( leftCount < count );
+
+  // update bounds for left
+  Vector leftMaxValues( maxValues );
+  leftMaxValues[cutDim] = cutVal;
+  // update bounds for right
+  Vector rightMinValues( minValues );
+  rightMinValues[cutDim] = cutVal;
+
+  // add this
+  nodes.push_back( Node( 0, cutVal ) );
+
+  // recurse
+  const unsigned _UNUSED leftChild = buildNodes( first, first + leftCount, minValues, leftMaxValues );
+  assert( leftChild == pos + 1 );
+  const unsigned rightChild = buildNodes( first + leftCount, last, rightMinValues, maxValues );
+
+  // write right child index and return
+  nodes[pos].dimChildBucketSize = createDimChildBucketSize( cutDim, rightChild );
+  return pos;
+}
+
+template<typename T, typename Heap, typename CloudType>
+KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, Heap, CloudType>::KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt( const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const Parameters& additionalParameters ):
+  NearestNeighbourSearch<T, CloudType>::NearestNeighbourSearch( cloud, dim, creationOptionFlags ),
+  bucketSize( additionalParameters.get<unsigned>( "bucketSize", 8 ) ),
+  dimBitCount( getStorageBitCount<uint32_t>( this->dim ) ),
+  dimMask( ( 1 << dimBitCount ) - 1 )
+{
+  if ( bucketSize < 2 )
+  {
+    std::stringstream str ;
+    str << "Requested bucket size " << bucketSize << ", but must be larger than 2" ;
+
+    throw runtime_error( str.str() );
+
+  }
+  if ( cloud.cols() <= bucketSize )
+  {
+    // make a single-bucket tree
+    for ( int i = 0; i < cloud.cols(); ++i )
+    {
+      buckets.push_back( BucketEntry( &cloud.coeff( 0, i ), i ) );
+    }
+    nodes.push_back( Node( createDimChildBucketSize( this->dim, cloud.cols() ), uint32_t( 0 ) ) );
+    return;
+  }
+
+  const uint64_t maxNodeCount( ( 0x1ULL << ( 32 - dimBitCount ) ) - 1 );
+  const uint64_t estimatedNodeCount( cloud.cols() / ( bucketSize / 2 ) );
+  if ( estimatedNodeCount > maxNodeCount )
+  {
+    std::stringstream str ;
+    str << "Cloud has a risk to have more nodes (" << estimatedNodeCount << ") than the kd-tree allows (" << maxNodeCount << "). The kd-tree has " << dimBitCount << " bits for dimensions and " << ( 32 - dimBitCount ) << " bits for node indices";
+
+    throw runtime_error( str.str() );
+  }
+
+  // build point vector and compute bounds
+  BuildPoints buildPoints;
+  buildPoints.reserve( cloud.cols() );
+  for ( int i = 0; i < cloud.cols(); ++i )
+  {
+    const Vector& v( cloud.block( 0, i, this->dim, 1 ) );
+    buildPoints.push_back( i );
+#ifdef EIGEN3_API
+    const_cast<Vector&>( minBound ) = minBound.array().min( v.array() );
+    const_cast<Vector&>( maxBound ) = maxBound.array().max( v.array() );
+#else // EIGEN3_API
+    const_cast<Vector&>( minBound ) = minBound.cwise().min( v );
+    const_cast<Vector&>( maxBound ) = maxBound.cwise().max( v );
+#endif // EIGEN3_API
+  }
+
+  // create nodes
+  buildNodes( buildPoints.begin(), buildPoints.end(), minBound, maxBound );
+  buildPoints.clear();
+}
+
+template<typename T, typename Heap, typename CloudType>
+unsigned long KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, Heap, CloudType>::knn( const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Index k, const T epsilon, const unsigned optionFlags, const T maxRadius ) const
+{
+  checkSizesKnn( query, indices, dists2, k, optionFlags );
+
+  const bool allowSelfMatch( optionFlags & NearestNeighbourSearch<T>::ALLOW_SELF_MATCH );
+  const bool sortResults( optionFlags & NearestNeighbourSearch<T>::SORT_RESULTS );
+  const bool collectStatistics( creationOptionFlags & NearestNeighbourSearch<T>::TOUCH_STATISTICS );
+  const T maxRadius2( maxRadius * maxRadius );
+  const T maxError2( ( 1 + epsilon ) * ( 1 + epsilon ) );
+  const int colCount( query.cols() );
+
+  assert( nodes.size() > 0 );
+
+  IndexMatrix result( k, query.cols() );
+  unsigned long leafTouchedCount( 0 );
+
+  #pragma omp parallel
+  {
+
+    Heap heap( k );
+    std::vector<T> off( dim, 0 );
+
+    #pragma omp for reduction(+:leafTouchedCount) schedule(guided,32)
+    for ( int i = 0; i < colCount; ++i )
+    {
+      leafTouchedCount += onePointKnn( query, indices, dists2, i, heap, off, maxError2, maxRadius2, allowSelfMatch, collectStatistics, sortResults );
+    }
+  }
+  return leafTouchedCount;
+}
+
+template<typename T, typename Heap, typename CloudType>
+unsigned long KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, Heap, CloudType>::knn( const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Vector& maxRadii, const Index k, const T epsilon, const unsigned optionFlags ) const
+{
+  checkSizesKnn( query, indices, dists2, k, optionFlags, &maxRadii );
+
+  const bool allowSelfMatch( optionFlags & NearestNeighbourSearch<T>::ALLOW_SELF_MATCH );
+  const bool sortResults( optionFlags & NearestNeighbourSearch<T>::SORT_RESULTS );
+  const bool collectStatistics( creationOptionFlags & NearestNeighbourSearch<T>::TOUCH_STATISTICS );
+  const T maxError2( ( 1 + epsilon ) * ( 1 + epsilon ) );
+  const int colCount( query.cols() );
+
+  assert( nodes.size() > 0 );
+  IndexMatrix result( k, query.cols() );
+  unsigned long leafTouchedCount( 0 );
+
+  #pragma omp parallel
+  {
+
+    Heap heap( k );
+    std::vector<T> off( dim, 0 );
+
+    #pragma omp for reduction(+:leafTouchedCount) schedule(guided,32)
+    for ( int i = 0; i < colCount; ++i )
+    {
+      const T maxRadius( maxRadii[i] );
+      const T maxRadius2( maxRadius * maxRadius );
+      leafTouchedCount += onePointKnn( query, indices, dists2, i, heap, off, maxError2, maxRadius2, allowSelfMatch, collectStatistics, sortResults );
+    }
+  }
+  return leafTouchedCount;
+}
+
+template<typename T, typename Heap, typename CloudType>
+unsigned long KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, Heap, CloudType>::onePointKnn( const Matrix& query, IndexMatrix& indices, Matrix& dists2, int i, Heap& heap, std::vector<T>& off, const T maxError2, const T maxRadius2, const bool allowSelfMatch, const bool collectStatistics, const bool sortResults ) const
+{
+  fill( off.begin(), off.end(), 0 );
+  heap.reset();
+  unsigned long leafTouchedCount( 0 );
+
+  if ( allowSelfMatch )
+  {
+    if ( collectStatistics )
+    {
+      leafTouchedCount += recurseKnn<true, true>( &query.coeff( 0, i ), 0, 0, heap, off, maxError2, maxRadius2 );
+    }
+    else
+    {
+      recurseKnn<true, false>( &query.coeff( 0, i ), 0, 0, heap, off, maxError2, maxRadius2 );
+    }
+  }
+  else
+  {
+    if ( collectStatistics )
+    {
+      leafTouchedCount += recurseKnn<false, true>( &query.coeff( 0, i ), 0, 0, heap, off, maxError2, maxRadius2 );
+    }
+    else
+    {
+      recurseKnn<false, false>( &query.coeff( 0, i ), 0, 0, heap, off, maxError2, maxRadius2 );
+    }
+  }
+
+  if ( sortResults )
+  {
+    heap.sort();
+  }
+
+  heap.getData( indices.col( i ), dists2.col( i ) );
+  return leafTouchedCount;
+}
+
+template<typename T, typename Heap, typename CloudType> template<bool allowSelfMatch, bool collectStatistics>
+unsigned long KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, Heap, CloudType>::recurseKnn( const T* query, const unsigned n, T rd, Heap& heap, std::vector<T>& off, const T maxError2, const T maxRadius2 ) const
+{
+  const Node& node( nodes[n] );
+  const uint32_t cd( getDim( node.dimChildBucketSize ) );
+
+  if ( cd == uint32_t( dim ) )
+  {
+    //cerr << "entering bucket " << node.bucket << endl;
+    const BucketEntry* bucket( &buckets[node.bucketIndex] );
+    const uint32_t bucketSize( getChildBucketSize( node.dimChildBucketSize ) );
+    for ( uint32_t i = 0; i < bucketSize; ++i )
+    {
+      //cerr << "  " << bucket-> pt << endl;
+      //const T dist(dist2<T>(query, cloud.col(index)));
+      //const T dist((query - cloud.col(index)).squaredNorm());
+      T dist( 0 );
+      const T* qPtr( query );
+      const T* dPtr( bucket->pt );
+      for ( int i = 0; i < this->dim; ++i )
+      {
+        const T diff( *qPtr - *dPtr );
+        dist += diff * diff;
+        qPtr++;
+        dPtr++;
+      }
+      if ( ( dist <= maxRadius2 ) &&
+           ( dist < heap.headValue() ) &&
+           ( allowSelfMatch || ( dist > numeric_limits<T>::epsilon() ) )
+         )
+      {
+        heap.replaceHead( bucket->index, dist );
+      }
+      ++bucket;
+    }
+    return ( unsigned long )( bucketSize );
+  }
+  else
+  {
+    const unsigned rightChild( getChildBucketSize( node.dimChildBucketSize ) );
+    unsigned long leafVisitedCount( 0 );
+    T& offcd( off[cd] );
+    //const T old_off(off.coeff(cd));
+    const T old_off( offcd );
+    const T new_off( query[cd] - node.cutVal );
+    if ( new_off > 0 )
+    {
+      if ( collectStatistics )
+      {
+        leafVisitedCount += recurseKnn<allowSelfMatch, true>( query, rightChild, rd, heap, off, maxError2, maxRadius2 );
+      }
+      else
+      {
+        recurseKnn<allowSelfMatch, false>( query, rightChild, rd, heap, off, maxError2, maxRadius2 );
+      }
+      rd += - old_off * old_off + new_off * new_off;
+      if ( ( rd <= maxRadius2 ) &&
+           ( rd * maxError2 < heap.headValue() ) )
+      {
+        offcd = new_off;
+        if ( collectStatistics )
+        {
+          leafVisitedCount += recurseKnn<allowSelfMatch, true>( query, n + 1, rd, heap, off, maxError2, maxRadius2 );
+        }
+        else
+        {
+          recurseKnn<allowSelfMatch, false>( query, n + 1, rd, heap, off, maxError2, maxRadius2 );
+        }
+        offcd = old_off;
+      }
+    }
+    else
+    {
+      if ( collectStatistics )
+      {
+        leafVisitedCount += recurseKnn<allowSelfMatch, true>( query, n + 1, rd, heap, off, maxError2, maxRadius2 );
+      }
+      else
+      {
+        recurseKnn<allowSelfMatch, false>( query, n + 1, rd, heap, off, maxError2, maxRadius2 );
+      }
+      rd += - old_off * old_off + new_off * new_off;
+      if ( ( rd <= maxRadius2 ) &&
+           ( rd * maxError2 < heap.headValue() ) )
+      {
+        offcd = new_off;
+        if ( collectStatistics )
+        {
+          leafVisitedCount += recurseKnn<allowSelfMatch, true>( query, rightChild, rd, heap, off, maxError2, maxRadius2 );
+        }
+        else
+        {
+          recurseKnn<allowSelfMatch, false>( query, rightChild, rd, heap, off, maxError2, maxRadius2 );
+        }
+        offcd = old_off;
+      }
+    }
+    return leafVisitedCount;
+  }
+}
+
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<float, IndexHeapSTL<int, float> >;
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<float, IndexHeapBruteForceVector<int, float> >;
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<double, IndexHeapSTL<int, double> >;
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<double, IndexHeapBruteForceVector<int, double> >;
+
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<float, IndexHeapSTL<int, float>, Eigen::Matrix3Xf>;
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<float, IndexHeapBruteForceVector<int, float>, Eigen::Matrix3Xf>;
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<double, IndexHeapSTL<int, double>, Eigen::Matrix3Xd>;
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<double, IndexHeapBruteForceVector<int, double>, Eigen::Matrix3Xd>;
+
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<float, IndexHeapSTL<int, float>, Eigen::Map<const Eigen::Matrix3Xf, Eigen::Aligned> >;
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<float, IndexHeapBruteForceVector<int, float>, Eigen::Map<const Eigen::Matrix3Xf, Eigen::Aligned> >;
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<double, IndexHeapSTL<int, double>, Eigen::Map<const Eigen::Matrix3Xd, Eigen::Aligned> >;
+template struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<double, IndexHeapBruteForceVector<int, double>, Eigen::Map<const Eigen::Matrix3Xd, Eigen::Aligned> >;
+
+//@}
+}

--- a/src/third_party/nabo/kdtree_opencl.cpp
+++ b/src/third_party/nabo/kdtree_opencl.cpp
@@ -1,0 +1,696 @@
+/*
+
+Copyright (c) 2010--2011, Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the author at <stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifdef HAVE_OPENCL
+
+#include "nabo_private.h"
+#include "index_heap.h"
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <stdexcept>
+#include <limits>
+#include <queue>
+#include <algorithm>
+// #include <map>
+#include <boost/numeric/conversion/bounds.hpp>
+#include <boost/limits.hpp>
+#include <boost/format.hpp>
+#include <boost/thread.hpp>
+
+
+/*!	\file kdtree_opencl.cpp
+ \ *brief kd-tree search, opencl implementation
+ \ingroup private
+ */
+
+namespace cl
+{
+	//! Vector of device
+	typedef std::vector<Device> Devices;
+}
+
+namespace Nabo
+{
+	//! Return the index of the maximum value of a vector of positive values
+	/** \param v vector of positive values
+	 * \return index of maximum value, 0 if the vector is empty
+	 */
+	template<typename T, typename CloudType>
+	size_t argMax(const typename NearestNeighbourSearch<T, CloudType>::Vector& v)
+	{
+		T maxVal(0);
+		size_t maxIdx(0);
+		for (int i = 0; i < v.size(); ++i)
+		{
+			if (v[i] > maxVal)
+			{
+				maxVal = v[i];
+				maxIdx = i;
+			}
+		}
+		return maxIdx;
+	}
+	
+	//! \ingroup private
+	//@{
+	
+	//! Maximum number of points acceptable in a query
+	#define MAX_K 32
+	
+	using namespace std;
+	
+	//! Template to retrieve type-specific code for CL support
+	template<typename T, typename CloudType>
+	struct EnableCLTypeSupport {};
+	
+	//! CL support code for float
+	template<typename CloudType>
+	struct EnableCLTypeSupport<float, CloudType>
+	{
+		//! Return CL code to enable float support and set it for use by our CL code
+		static string code(const cl::Device& device)
+		{
+			return "typedef float T;\n";
+		}
+	};
+	
+	//! CL support code for double
+	template<typename CloudType>
+	struct EnableCLTypeSupport<double, CloudType>
+	{
+		//! Return CL code to enable double support and set it for use by our CL code.
+		/** This is more complex than float as double is not supported by default. */
+		static string code(const cl::Device& device)
+		{
+			string s;
+			const string& exts(device.getInfo<CL_DEVICE_EXTENSIONS>());
+			//cerr << "extensions: " << exts << endl;
+			// first try generic 64-bits fp, otherwise try to fall back on vendor-specific extensions
+			if (exts.find("cl_khr_fp64") != string::npos)
+				s += "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n";
+			else if (exts.find("cl_amd_fp64") != string::npos)
+				s += "#pragma OPENCL EXTENSION cl_amd_fp64 : enable\n";
+			else
+				throw runtime_error("The OpenCL platform does not support 64 bits double-precision floating-points scalars.");
+			s += "typedef double T;\n";
+			return s;
+		}
+	};
+	
+	//! Cache CL source code (including defines and support code)
+	struct SourceCacher
+	{
+		//! Vector of devices
+		typedef std::vector<cl::Device> Devices;
+		//! Map of cached programmes
+		typedef std::map<std::string, cl::Program> ProgramCache;
+		
+		cl::Context context; //!< context in which programs are cached
+		Devices devices; //!< devices linked to the context
+		ProgramCache cachedPrograms; //!< cached programs
+		
+		//! Create a source cacher for a given device type, retrieves a list of devices
+		SourceCacher(const cl_device_type deviceType)
+		{
+			// looking for platforms, AMD drivers do not like the default for creating context
+			vector<cl::Platform> platforms;
+			cl::Platform::get(&platforms);
+			if (platforms.empty())
+				throw runtime_error("No OpenCL platform found");
+			//for(vector<cl::Platform>::iterator i = platforms.begin(); i != platforms.end(); ++i)
+			//	cerr << "platform " << i - platforms.begin() << " is " << (*i).getInfo<CL_PLATFORM_VENDOR>() << endl;
+			cl::Platform platform = platforms[0];
+			const char *userDefinedPlatform(getenv("NABO_OPENCL_USE_PLATFORM"));
+			if (userDefinedPlatform)
+			{
+				size_t userDefinedPlatformId = atoi(userDefinedPlatform);
+				if (userDefinedPlatformId < platforms.size())
+					platform = platforms[userDefinedPlatformId];
+			}
+			
+			// create OpenCL contexts
+			cl_context_properties properties[] = { CL_CONTEXT_PLATFORM, (cl_context_properties)platform(), 0 };
+			bool deviceFound = false;
+			try {
+				context = cl::Context(deviceType, properties);
+				deviceFound = true;
+			} catch (const cl::Error& e) {
+				cerr << "Cannot find device type " << deviceType << " for OpenCL, falling back to any device" << endl;
+			}
+			if (!deviceFound)
+				context = cl::Context(CL_DEVICE_TYPE_ALL, properties);
+			devices = context.getInfo<CL_CONTEXT_DEVICES>();
+			if (devices.empty())
+				throw runtime_error("No devices on OpenCL platform");
+		}
+		
+		//! Destroy the cache, programs will be released automatically
+		~SourceCacher()
+		{
+			cerr << "Destroying source cacher containing " << cachedPrograms.size() << " cached programs" << endl;
+		}
+		
+		//! Return whether program source is cached
+		bool contains(const std::string& source)
+		{
+			return cachedPrograms.find(source) != cachedPrograms.end();
+		}
+	};
+	
+	//! Create and manage CL contexts and corresponding source caches
+	class ContextManager
+	{
+	public:
+		//! A map from device to caches
+		typedef std::map<cl_device_type, SourceCacher*> Devices;
+		
+		//! Destroy the manager and all caches
+		~ContextManager()
+		{
+			cerr << "Destroying CL context manager, used " << devices.size() << " contexts" << endl;
+			for (Devices::iterator it(devices.begin()); it != devices.end(); ++it)
+				delete it->second;
+		}
+		//! Create a new contexc for a given type of device
+		cl::Context& createContext(const cl_device_type deviceType)
+		{
+			boost::mutex::scoped_lock lock(mutex);
+			Devices::iterator it(devices.find(deviceType));
+			if (it == devices.end())
+			{
+				it = devices.insert(
+					pair<cl_device_type, SourceCacher*>(deviceType, new SourceCacher(deviceType))
+					).first;
+			}
+			return it->second->context;
+		}
+		//! Return the cache for a given type of device
+		SourceCacher* getSourceCacher(const cl_device_type deviceType)
+		{
+			boost::mutex::scoped_lock lock(mutex);
+			Devices::iterator it(devices.find(deviceType));
+			if (it == devices.end())
+				throw runtime_error("Attempt to get source cacher before creating a context");
+			return it->second;
+		}
+		
+	protected:
+		Devices devices; //!< devices with caches
+		boost::mutex mutex; //!< mutex to protect concurrent accesses to devices
+	};
+	
+	//! Static instance of context manager
+	static ContextManager contextManager;
+	
+	template<typename T, typename CloudType>
+	OpenCLSearch<T, CloudType>::OpenCLSearch(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const cl_device_type deviceType):
+		NearestNeighbourSearch<T, CloudType>::NearestNeighbourSearch(cloud, dim, creationOptionFlags),
+		deviceType(deviceType),
+		context(contextManager.createContext(deviceType))
+	{
+	}
+	
+	template<typename T, typename CloudType>
+	void OpenCLSearch<T, CloudType>::initOpenCL(const char* clFileName, const char* kernelName, const std::string& additionalDefines)
+	{
+		const bool collectStatistics(creationOptionFlags & NearestNeighbourSearch<T, CloudType>::TOUCH_STATISTICS);
+		
+		SourceCacher* sourceCacher(contextManager.getSourceCacher(deviceType));
+		SourceCacher::Devices& devices(sourceCacher->devices);
+		
+		// build and load source files
+		cl::Program::Sources sources;
+		// build defines
+		ostringstream oss;
+		oss << EnableCLTypeSupport<T, CloudType>::code(devices.back());
+		oss << "#define EPSILON " << numeric_limits<T>::epsilon() << "\n";
+		oss << "#define DIM_COUNT " << dim << "\n";
+		//oss << "#define CLOUD_POINT_COUNT " << cloud.cols() << "\n";
+		oss << "#define POINT_STRIDE " << cloud.stride() << "\n";
+		oss << "#define MAX_K " << MAX_K << "\n";
+		if (collectStatistics)
+			oss << "#define TOUCH_STATISTICS\n";
+		oss << additionalDefines;
+		//cerr << "params:\n" << oss.str() << endl;
+		
+		const std::string& source(oss.str());
+		if (!sourceCacher->contains(source))
+		{
+			const size_t defLen(source.length());
+			char *defContent(new char[defLen+1]);
+			strcpy(defContent, source.c_str());
+			sources.push_back(std::make_pair(defContent, defLen));
+			string sourceFileName(OPENCL_SOURCE_DIR);
+			sourceFileName += clFileName;
+			// load files
+			const char* files[] = {
+				OPENCL_SOURCE_DIR "structure.cl",
+				OPENCL_SOURCE_DIR "heap.cl",
+				sourceFileName.c_str(),
+				NULL 
+			};
+			for (const char** file = files; *file != NULL; ++file)
+			{
+				std::ifstream stream(*file);
+				if (!stream.good())
+					throw runtime_error((string("cannot open file: ") + *file));
+				
+				stream.seekg(0, std::ios_base::end);
+				size_t size(stream.tellg());
+				stream.seekg(0, std::ios_base::beg);
+				
+				char* content(new char[size + 1]);
+				std::copy(std::istreambuf_iterator<char>(stream),
+							std::istreambuf_iterator<char>(), content);
+				content[size] = '\0';
+				
+				sources.push_back(std::make_pair(content, size));
+			}
+			sourceCacher->cachedPrograms[source] = cl::Program(context, sources);
+			cl::Program& program = sourceCacher->cachedPrograms[source];
+			
+			// build
+			cl::Error error(CL_SUCCESS);
+			try {
+				program.build(devices);
+			} catch (cl::Error e) {
+				error = e;
+			}
+			
+			// dump
+			for (cl::Devices::const_iterator it = devices.begin(); it != devices.end(); ++it)
+			{
+				cerr << "device : " << it->getInfo<CL_DEVICE_NAME>() << "\n";
+				cerr << "compilation log:\n" << program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(*it) << endl;
+			}
+			// cleanup sources
+			for (cl::Program::Sources::iterator it = sources.begin(); it != sources.end(); ++it)
+			{
+				delete[] it->first;
+			}
+			sources.clear();
+			
+			// make sure to stop if compilation failed
+			if (error.err() != CL_SUCCESS)
+				throw error;
+		}
+		cl::Program& program = sourceCacher->cachedPrograms[source];
+		
+		// build kernel and command queue
+		knnKernel = cl::Kernel(program, kernelName); 
+		queue = cl::CommandQueue(context, devices.back());
+		
+		// map cloud
+		if (!(cloud.Flags & Eigen::DirectAccessBit) || (cloud.Flags & Eigen::RowMajorBit))
+			throw runtime_error("wrong memory mapping in point cloud");
+		const size_t cloudCLSize(cloud.cols() * cloud.stride() * sizeof(T));
+		cloudCL = cl::Buffer(context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR, cloudCLSize, const_cast<T*>(&cloud.coeff(0,0)));
+		knnKernel.setArg(0, sizeof(cl_mem), &cloudCL);
+	}
+	
+	template<typename T, typename CloudType>
+	unsigned long OpenCLSearch<T, CloudType>::knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Index k, const T epsilon, const unsigned optionFlags, const T maxRadius) const
+	{
+		checkSizesKnn(query, indices, dists2, k, optionFlags);
+		const bool collectStatistics(creationOptionFlags & NearestNeighbourSearch<T, CloudType>::TOUCH_STATISTICS);
+		
+		// check K
+		if (k > MAX_K)
+			throw runtime_error("number of neighbors too large for OpenCL");
+		
+		// check consistency of query wrt cloud
+		if (query.stride() != cloud.stride() ||
+			query.rows() != cloud.rows())
+			throw runtime_error("query is not of the same dimensionality as the point cloud");
+		
+		// map query
+		if (!(query.Flags & Eigen::DirectAccessBit) || (query.Flags & Eigen::RowMajorBit))
+			throw runtime_error("wrong memory mapping in query data");
+		const size_t queryCLSize(query.cols() * query.stride() * sizeof(T));
+		cl::Buffer queryCL(context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR, queryCLSize, const_cast<T*>(&query.coeff(0,0)));
+		knnKernel.setArg(1, sizeof(cl_mem), &queryCL);
+		// map indices
+		assert((indices.Flags & Eigen::DirectAccessBit) && (!(indices.Flags & Eigen::RowMajorBit)));
+		const int indexStride(indices.stride());
+		const size_t indicesCLSize(indices.cols() * indexStride * sizeof(int));
+		cl::Buffer indicesCL(context, CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR, indicesCLSize, &indices.coeffRef(0,0));
+		knnKernel.setArg(2, sizeof(cl_mem), &indicesCL);
+		// map dists2
+		assert((dists2.Flags & Eigen::DirectAccessBit) && (!(dists2.Flags & Eigen::RowMajorBit)));
+		const int dists2Stride(dists2.stride());
+		const size_t dists2CLSize(dists2.cols() * dists2Stride * sizeof(T));
+		cl::Buffer dists2CL(context, CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR, dists2CLSize, &dists2.coeffRef(0,0));
+		knnKernel.setArg(3, sizeof(cl_mem), &dists2CL);
+		
+		// set resulting parameters
+		knnKernel.setArg(4, k);
+		knnKernel.setArg(5, (1 + epsilon)*(1 + epsilon));
+		knnKernel.setArg(6, maxRadius*maxRadius);
+		knnKernel.setArg(7, optionFlags);
+		knnKernel.setArg(8, indexStride);
+		knnKernel.setArg(9, dists2Stride);
+		knnKernel.setArg(10, cl_uint(cloud.cols()));
+		
+		// if required, map visit count
+		vector<cl_uint> visitCounts;
+		const size_t visitCountCLSize(query.cols() * sizeof(cl_uint));
+		cl::Buffer visitCountCL;
+		if (collectStatistics)
+		{
+			visitCounts.resize(query.cols());
+			visitCountCL = cl::Buffer(context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR, visitCountCLSize, &visitCounts[0]);
+			knnKernel.setArg(11, sizeof(cl_mem), &visitCountCL);
+		}
+		
+		// execute query
+		queue.enqueueNDRangeKernel(knnKernel, cl::NullRange, cl::NDRange(query.cols()), cl::NullRange);
+		queue.enqueueMapBuffer(indicesCL, true, CL_MAP_READ, 0, indicesCLSize, 0, 0);
+		queue.enqueueMapBuffer(dists2CL, true, CL_MAP_READ, 0, dists2CLSize, 0, 0);
+		if (collectStatistics)
+			queue.enqueueMapBuffer(visitCountCL, true, CL_MAP_READ, 0, visitCountCLSize, 0, 0);
+		queue.finish();
+		
+		// if required, collect statistics
+		if (collectStatistics)
+		{
+			unsigned long totalVisitCounts(0);
+			for (size_t i = 0; i < visitCounts.size(); ++i)
+				totalVisitCounts += (unsigned long)visitCounts[i];
+			return totalVisitCounts;
+		}
+		else
+			return 0;
+	}
+	
+	template<typename T, typename CloudType>
+	BruteForceSearchOpenCL<T, CloudType>::BruteForceSearchOpenCL(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const cl_device_type deviceType):
+	OpenCLSearch<T, CloudType>::OpenCLSearch(cloud, dim, creationOptionFlags, deviceType)
+	{
+#ifdef EIGEN3_API
+		const_cast<Vector&>(this->minBound) = cloud.topRows(this->dim).rowwise().minCoeff();
+		const_cast<Vector&>(this->maxBound) = cloud.topRows(this->dim).rowwise().maxCoeff();
+#else // EIGEN3_API
+		// compute bounds
+		for (int i = 0; i < cloud.cols(); ++i)
+		{
+			const Vector& v(cloud.block(0,i,this->dim,1));
+			const_cast<Vector&>(this->minBound) = this->minBound.cwise().min(v);
+			const_cast<Vector&>(this->maxBound) = this->maxBound.cwise().max(v);
+		}
+#endif // EIGEN3_API
+		// init openCL
+		initOpenCL("knn_bf.cl", "knnBruteForce");
+	}
+
+	template struct BruteForceSearchOpenCL<float>;
+	template struct BruteForceSearchOpenCL<double>;
+	template struct BruteForceSearchOpenCL<float, Eigen::Matrix3Xf>;
+	template struct BruteForceSearchOpenCL<double, Eigen::Matrix3Xd>;
+	template struct BruteForceSearchOpenCL<float, Eigen::Map<const Eigen::Matrix3Xf, Eigen::Aligned> >;
+	template struct BruteForceSearchOpenCL<double, Eigen::Map<const Eigen::Matrix3Xd, Eigen::Aligned> >;
+	
+	
+
+	template<typename T, typename CloudType>
+	size_t KDTreeBalancedPtInLeavesStackOpenCL<T, CloudType>::getTreeSize(size_t elCount) const
+	{
+		// FIXME: 64 bits safe stuff, only work for 2^32 elements right now
+		assert(elCount > 0);
+		elCount --;
+		size_t count = 0;
+		int i = 31;
+		for (; i >= 0; --i)
+		{
+			if (elCount & (1 << i))
+				break;
+		}
+		for (int j = 0; j <= i; ++j)
+			count |= (1 << j);
+		count <<= 1;
+		count |= 1;
+		return count;
+	}
+	
+	template<typename T, typename CloudType>
+	size_t KDTreeBalancedPtInLeavesStackOpenCL<T, CloudType>::getTreeDepth(size_t elCount) const
+	{
+		if (elCount <= 1)
+			return 0;
+		elCount --;
+		size_t i = 31;
+		for (; i >= 0; --i)
+		{
+			if (elCount & (1 << i))
+				break;
+		}
+		return i+1;
+	}
+
+	template<typename T, typename CloudType>
+	void KDTreeBalancedPtInLeavesStackOpenCL<T, CloudType>::buildNodes(const BuildPointsIt first, const BuildPointsIt last, const size_t pos, const Vector minValues, const Vector maxValues)
+	{
+		const size_t count(last - first);
+		//cerr << count << endl;
+		if (count == 1)
+		{
+			const int d = -2-(first->index);
+			assert(pos < nodes.size());
+			nodes[pos] = Node(d);
+			return;
+		}
+		
+		// find the largest dimension of the box
+		size_t cutDim = argMax<T, CloudType>(maxValues - minValues);
+		
+		// compute number of elements
+		const size_t rightCount(count/2);
+		const size_t leftCount(count - rightCount);
+		assert(last - rightCount == first + leftCount);
+		
+		// sort
+		nth_element(first, first + leftCount, last, CompareDim(cutDim));
+		
+		// set node
+		const T cutVal((first+leftCount)->pos.coeff(cutDim));
+		nodes[pos] = Node(cutDim, cutVal);
+		
+		//cerr << pos << " cutting on " << cutDim << " at " << (first+leftCount)->pos[cutDim] << endl;
+		
+		// update bounds for left
+		Vector leftMaxValues(maxValues);
+		leftMaxValues[cutDim] = cutVal;
+		// update bounds for right
+		Vector rightMinValues(minValues);
+		rightMinValues[cutDim] = cutVal;
+		
+		// recurse
+		buildNodes(first, first + leftCount, childLeft(pos), minValues, leftMaxValues);
+		buildNodes(first + leftCount, last, childRight(pos), rightMinValues, maxValues);
+	}
+	
+	template<typename T, typename CloudType>
+	KDTreeBalancedPtInLeavesStackOpenCL<T, CloudType>::KDTreeBalancedPtInLeavesStackOpenCL(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const cl_device_type deviceType):
+		OpenCLSearch<T, CloudType>::OpenCLSearch(cloud, dim, creationOptionFlags, deviceType)
+	{
+		const bool collectStatistics(creationOptionFlags & NearestNeighbourSearch<T>::TOUCH_STATISTICS);
+		
+		// build point vector and compute bounds
+		BuildPoints buildPoints;
+		buildPoints.reserve(cloud.cols());
+		for (int i = 0; i < cloud.cols(); ++i)
+		{
+			const Vector& v(cloud.block(0,i,this->dim,1));
+			buildPoints.push_back(BuildPoint(v, i));
+#ifdef EIGEN3_API
+			const_cast<Vector&>(minBound) = minBound.array().min(v.array());
+			const_cast<Vector&>(maxBound) = maxBound.array().max(v.array());
+#else // EIGEN3_API
+			const_cast<Vector&>(minBound) = minBound.cwise().min(v);
+			const_cast<Vector&>(maxBound) = maxBound.cwise().max(v);
+#endif // EIGEN3_API
+		}
+		
+		// create nodes
+		nodes.resize(getTreeSize(cloud.cols()));
+		buildNodes(buildPoints.begin(), buildPoints.end(), 0, minBound, maxBound);
+		const unsigned maxStackDepth(getTreeDepth(nodes.size()) + 1);
+		
+		// init openCL
+		initOpenCL("knn_kdtree_pt_in_leaves.cl", "knnKDTree", (boost::format("#define MAX_STACK_DEPTH %1%\n") % maxStackDepth).str());
+		
+		// map nodes, for info about alignment, see sect 6.1.5 
+		const size_t nodesCLSize(nodes.size() * sizeof(Node));
+		nodesCL = cl::Buffer(context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR, nodesCLSize, &nodes[0]);
+		if (collectStatistics)
+			knnKernel.setArg(12, sizeof(cl_mem), &nodesCL);
+		else
+			knnKernel.setArg(11, sizeof(cl_mem), &nodesCL);
+	}
+
+	template struct KDTreeBalancedPtInLeavesStackOpenCL<float>;
+	template struct KDTreeBalancedPtInLeavesStackOpenCL<double>;
+	template struct KDTreeBalancedPtInLeavesStackOpenCL<float, Eigen::Matrix3Xf>;
+	template struct KDTreeBalancedPtInLeavesStackOpenCL<double, Eigen::Matrix3Xd>;
+	template struct KDTreeBalancedPtInLeavesStackOpenCL<float, Eigen::Map<const Eigen::Matrix3Xf, Eigen::Aligned> >;
+	template struct KDTreeBalancedPtInLeavesStackOpenCL<double, Eigen::Map<const Eigen::Matrix3Xd, Eigen::Aligned> >;
+	
+	
+	template<typename T, typename CloudType>
+	size_t KDTreeBalancedPtInNodesStackOpenCL<T, CloudType>::getTreeSize(size_t elCount) const
+	{
+		// FIXME: 64 bits safe stuff, only work for 2^32 elements right now
+		size_t count = 0;
+		int i = 31;
+		for (; i >= 0; --i)
+		{
+			if (elCount & (1 << i))
+				break;
+		}
+		for (int j = 0; j <= i; ++j)
+			count |= (1 << j);
+		//cerr << "tree size " << count << " (" << elCount << " elements)\n";
+		return count;
+	}
+	
+	template<typename T, typename CloudType>
+	size_t KDTreeBalancedPtInNodesStackOpenCL<T, CloudType>::getTreeDepth(size_t elCount) const
+	{
+		// FIXME: 64 bits safe stuff, only work for 2^32 elements right now
+		int i = 31;
+		for (; i >= 0; --i)
+		{
+			if (elCount & (1 << i))
+				break;
+		}
+		return i + 1;
+	}
+	
+	template<typename T, typename CloudType>
+	void KDTreeBalancedPtInNodesStackOpenCL<T, CloudType>::buildNodes(const BuildPointsIt first, const BuildPointsIt last, const size_t pos, const Vector minValues, const Vector maxValues)
+	{
+		const size_t count(last - first);
+		//cerr << count << endl;
+		if (count == 1)
+		{
+			nodes[pos] = Node(-1, *first);
+			return;
+		}
+		
+		// find the largest dimension of the box
+		const size_t cutDim = argMax<T, CloudType>(maxValues - minValues);
+		
+		// compute number of elements
+		const size_t recurseCount(count-1);
+		const size_t rightCount(recurseCount/2);
+		const size_t leftCount(recurseCount-rightCount);
+		assert(last - rightCount == first + leftCount + 1);
+		
+		// sort
+		nth_element(first, first + leftCount, last, CompareDim(cloud, cutDim));
+		
+		// set node
+		const Index index(*(first+leftCount));
+		const T cutVal(cloud.coeff(cutDim, index));
+		nodes[pos] = Node(cutDim, index);
+		
+		//cerr << pos << " cutting on " << cutDim << " at " << (first+leftCount)->pos[cutDim] << endl;
+		
+		// update bounds for left
+		Vector leftMaxValues(maxValues);
+		leftMaxValues[cutDim] = cutVal;
+		// update bounds for right
+		Vector rightMinValues(minValues);
+		rightMinValues[cutDim] = cutVal;
+		
+		// recurse
+		if (count > 2)
+		{
+			buildNodes(first, first + leftCount, childLeft(pos), minValues, leftMaxValues);
+			buildNodes(first + leftCount + 1, last, childRight(pos), rightMinValues, maxValues);
+		}
+		else
+		{
+			nodes[childLeft(pos)] = Node(-1, *first);
+			nodes[childRight(pos)] = Node(-2, 0);
+		}
+	}
+	
+	template<typename T, typename CloudType>
+	KDTreeBalancedPtInNodesStackOpenCL<T, CloudType>::KDTreeBalancedPtInNodesStackOpenCL(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const cl_device_type deviceType):
+	OpenCLSearch<T, CloudType>::OpenCLSearch(cloud, dim, creationOptionFlags, deviceType)
+	{
+		const bool collectStatistics(creationOptionFlags & NearestNeighbourSearch<T, CloudType>::TOUCH_STATISTICS);
+		
+		// build point vector and compute bounds
+		BuildPoints buildPoints;
+		buildPoints.reserve(cloud.cols());
+		for (int i = 0; i < cloud.cols(); ++i)
+		{
+			buildPoints.push_back(i);
+			const Vector& v(cloud.block(0,i,this->dim,1));
+#ifdef EIGEN3_API
+			const_cast<Vector&>(minBound) = minBound.array().min(v.array());
+			const_cast<Vector&>(maxBound) = maxBound.array().max(v.array());
+#else // EIGEN3_API
+			const_cast<Vector&>(minBound) = minBound.cwise().min(v);
+			const_cast<Vector&>(maxBound) = maxBound.cwise().max(v);
+#endif // EIGEN3_API
+		}
+		
+		// create nodes
+		nodes.resize(getTreeSize(cloud.cols()));
+		buildNodes(buildPoints.begin(), buildPoints.end(), 0, minBound, maxBound);
+		const unsigned maxStackDepth(getTreeDepth(nodes.size()) + 1);
+		
+		// init openCL
+		initOpenCL("knn_kdtree_pt_in_nodes.cl", "knnKDTree", (boost::format("#define MAX_STACK_DEPTH %1%\n") % maxStackDepth).str());
+		
+		// map nodes, for info about alignment, see sect 6.1.5 
+		const size_t nodesCLSize(nodes.size() * sizeof(Node));
+		nodesCL = cl::Buffer(context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR, nodesCLSize, &nodes[0]);
+		if (collectStatistics)
+			knnKernel.setArg(12, sizeof(cl_mem), &nodesCL);
+		else
+			knnKernel.setArg(11, sizeof(cl_mem), &nodesCL);
+	}
+	
+	template struct KDTreeBalancedPtInNodesStackOpenCL<float>;
+	template struct KDTreeBalancedPtInNodesStackOpenCL<double>;
+	template struct KDTreeBalancedPtInNodesStackOpenCL<float, Eigen::Matrix3Xf>;
+	template struct KDTreeBalancedPtInNodesStackOpenCL<double, Eigen::Matrix3Xd>;
+	template struct KDTreeBalancedPtInNodesStackOpenCL<float, Eigen::Map<const Eigen::Matrix3Xf, Eigen::Aligned> >;
+	template struct KDTreeBalancedPtInNodesStackOpenCL<double, Eigen::Map<const Eigen::Matrix3Xd, Eigen::Aligned> >;
+	
+	//@}
+}
+
+#endif // HAVE_OPENCL

--- a/src/third_party/nabo/nabo.cpp
+++ b/src/third_party/nabo/nabo.cpp
@@ -1,0 +1,187 @@
+/*
+
+Copyright (c) 2010--2011, Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the author at <stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "nabo.h"
+#include "nabo_private.h"
+#include "index_heap.h"
+#include <limits>
+#include <algorithm>
+#include <stdexcept>
+#include <sstream>
+
+/*!	\file nabo.cpp
+	\brief implementation of public interface
+	\ingroup private
+*/
+
+namespace Nabo
+{
+	using namespace std;
+
+	// Custom exception class supporting stream-style message constructions.
+	struct runtime_error : std::runtime_error {
+		stringstream ss;
+
+		template<typename T> runtime_error& operator<<(const T& t) {
+			ss << t;
+
+			// Linux executor would not print correctly by overiding "virtual const char* what()".
+			// One solution is refreshing underlying std::runtime_error every time message is changed.
+			static_cast<std::runtime_error&>(*this) = std::runtime_error(ss.str());
+
+			return *this;
+		}
+
+		runtime_error(): std::runtime_error("") {}
+		runtime_error(const runtime_error& re): std::runtime_error(re.ss.str()), ss(re.ss.str()) {}
+		virtual ~runtime_error() throw () {}
+	};
+
+	template<typename T, typename CloudType>
+	NearestNeighbourSearch<T, CloudType>::NearestNeighbourSearch(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags):
+		cloud(cloud),
+		dim(min(dim, int(cloud.rows()))),
+		creationOptionFlags(creationOptionFlags),
+		minBound(Vector::Constant(this->dim, numeric_limits<T>::max())),
+		maxBound(Vector::Constant(this->dim, numeric_limits<T>::min()))
+	{
+		if (cloud.cols() == 0)
+			throw runtime_error() << "Cloud has no points";
+		if (cloud.rows() == 0)
+			throw runtime_error() << "Cloud has 0 dimensions";
+	}
+	
+	template<typename T, typename CloudType>
+	unsigned long NearestNeighbourSearch<T, CloudType>::knn(const Vector& query, IndexVector& indices, Vector& dists2, const Index k, const T epsilon, const unsigned optionFlags, const T maxRadius) const
+	{
+#ifdef EIGEN3_API
+		const Eigen::Map<const Matrix> queryMatrix(&query.coeff(0,0), dim, 1);
+#else // EIGEN3_API
+		const Eigen::Map<Matrix> queryMatrix(&query.coeff(0,0), dim, 1);
+#endif // EIGEN3_API
+		// note: this is inefficient, because we copy memory, due to the template-
+		// based abstraction of Eigen. High-performance implementation should
+		// take care of knnM and then implement knn on top of it.
+		// C++0x should solve this with rvalue
+		IndexMatrix indexMatrix(k, 1);
+		Matrix dists2Matrix(k, 1);
+		const unsigned long stats = knn(queryMatrix, indexMatrix, dists2Matrix, k, epsilon, optionFlags, maxRadius);
+		indices = indexMatrix.col(0);
+		dists2 = dists2Matrix.col(0);
+		return stats;
+	}
+
+	template<typename T, typename CloudType>
+	void NearestNeighbourSearch<T, CloudType>::checkSizesKnn(const Matrix& query, const IndexMatrix& indices, const Matrix& dists2, const Index k, const unsigned optionFlags, const Vector* maxRadii) const
+	{
+		const bool allowSelfMatch(optionFlags & NearestNeighbourSearch<T, CloudType>::ALLOW_SELF_MATCH);
+		if (allowSelfMatch)
+		{
+			if (k > cloud.cols())
+				throw runtime_error() << "Requesting more points (" << k << ") than available in cloud (" << cloud.cols() << ")";
+		}
+		else
+		{
+			if (k > cloud.cols()-1)
+				throw runtime_error() << "Requesting more points (" << k << ") than available in cloud minus 1 (" << cloud.cols()-1 << ") (as self match is forbidden)";
+		}
+		if (query.rows() < dim)
+			throw runtime_error() << "Query has less dimensions (" << query.rows() << ") than requested for cloud (" << dim << ")";
+		if (indices.rows() != k)
+			throw runtime_error() << "Index matrix has a different number of rows (" << indices.rows() << ") than k (" << k << ")";
+		if (indices.cols() != query.cols())
+			throw runtime_error() << "Index matrix has a different number of columns (" << indices.rows() << ") than query (" << query.cols() << ")";
+		if (dists2.rows() != k)
+			throw runtime_error() << "Distance matrix has a different number of rows (" << dists2.rows() << ") than k (" << k << ")";
+		if (dists2.cols() != query.cols())
+			throw runtime_error() << "Distance matrix has a different number of columns (" << dists2.rows() << ") than query (" << query.cols() << ")";
+		if (maxRadii && (maxRadii->size() != query.cols()))
+			throw runtime_error() << "Maximum radii vector has not the same length (" << maxRadii->size() << ") than query has columns (" << k << ")";
+		const unsigned maxOptionFlagsValue(ALLOW_SELF_MATCH|SORT_RESULTS);
+		if (optionFlags > maxOptionFlagsValue)
+			throw runtime_error() << "OR-ed value of option flags (" << optionFlags << ") is larger than maximal valid value (" << maxOptionFlagsValue << ")";
+	}
+	
+
+	template<typename T, typename CloudType>
+	NearestNeighbourSearch<T, CloudType>* NearestNeighbourSearch<T, CloudType>::create(const CloudType& cloud, const Index dim, const SearchType preferedType, const unsigned creationOptionFlags, const Parameters& additionalParameters)
+	{
+		if (dim <= 0)
+			throw runtime_error() << "Your space must have at least one dimension";
+		switch (preferedType)
+		{
+			case BRUTE_FORCE: return new BruteForceSearch<T, CloudType>(cloud, dim, creationOptionFlags);
+			case KDTREE_LINEAR_HEAP: return new KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, IndexHeapBruteForceVector<int,T>, CloudType>(cloud, dim, creationOptionFlags, additionalParameters);
+			case KDTREE_TREE_HEAP: return new KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, IndexHeapSTL<int,T>, CloudType>(cloud, dim, creationOptionFlags, additionalParameters);
+			#ifdef HAVE_OPENCL
+			case KDTREE_CL_PT_IN_NODES: return new KDTreeBalancedPtInNodesStackOpenCL<T, CloudType>(cloud, dim, creationOptionFlags, CL_DEVICE_TYPE_GPU);
+			case KDTREE_CL_PT_IN_LEAVES: return new KDTreeBalancedPtInLeavesStackOpenCL<T, CloudType>(cloud, dim, creationOptionFlags, CL_DEVICE_TYPE_GPU);
+			case BRUTE_FORCE_CL: return new BruteForceSearchOpenCL<T, CloudType>(cloud, dim, creationOptionFlags, CL_DEVICE_TYPE_GPU);
+			#else // HAVE_OPENCL
+			case KDTREE_CL_PT_IN_NODES: throw runtime_error() << "OpenCL not found during compilation";
+			case KDTREE_CL_PT_IN_LEAVES: throw runtime_error() << "OpenCL not found during compilation";
+			case BRUTE_FORCE_CL: throw runtime_error() << "OpenCL not found during compilation";
+			#endif // HAVE_OPENCL
+			default: throw runtime_error() << "Unknown search type";
+		}
+	}
+
+	template<typename T, typename CloudType>
+	NearestNeighbourSearch<T, CloudType>* NearestNeighbourSearch<T, CloudType>::createBruteForce(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags)
+	{
+		if (dim <= 0)
+			throw runtime_error() << "Your space must have at least one dimension";
+		return new BruteForceSearch<T, CloudType>(cloud, dim, creationOptionFlags);
+	}
+
+	template<typename T, typename CloudType>
+	NearestNeighbourSearch<T, CloudType>* NearestNeighbourSearch<T, CloudType>::createKDTreeLinearHeap(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const Parameters& additionalParameters)
+	{
+		if (dim <= 0)
+			throw runtime_error() << "Your space must have at least one dimension";
+		return new KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, IndexHeapBruteForceVector<int,T>, CloudType>(cloud, dim, creationOptionFlags, additionalParameters);
+	}
+
+	template<typename T, typename CloudType>
+	NearestNeighbourSearch<T, CloudType>* NearestNeighbourSearch<T, CloudType>::createKDTreeTreeHeap(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const Parameters& additionalParameters)
+	{
+		if (dim <= 0)
+			throw runtime_error() << "Your space must have at least one dimension";
+		return new KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, IndexHeapSTL<int,T>, CloudType>(cloud, dim, creationOptionFlags, additionalParameters);
+	}
+	
+	template struct NearestNeighbourSearch<float>;
+	template struct NearestNeighbourSearch<double>;
+	template struct NearestNeighbourSearch<float, Eigen::Matrix3Xf>;
+	template struct NearestNeighbourSearch<double, Eigen::Matrix3Xd>;
+	template struct NearestNeighbourSearch<float, Eigen::Map<const Eigen::Matrix3Xf, Eigen::Aligned> >;
+	template struct NearestNeighbourSearch<double, Eigen::Map<const Eigen::Matrix3Xd, Eigen::Aligned> >;
+}

--- a/src/third_party/nabo/nabo.h
+++ b/src/third_party/nabo/nabo.h
@@ -1,0 +1,437 @@
+/*
+
+Copyright (c) 2010--2011, Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the author at <stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef __NABO_H
+#define __NABO_H
+
+#include "Eigen/Core"
+#if EIGEN_VERSION_AT_LEAST(2,92,0)
+	#define EIGEN3_API
+#endif
+#ifndef EIGEN3_API
+	#include "Eigen/Array"
+#endif
+#include <vector>
+#include <map>
+#include "third_party/any.hpp"
+
+/*! 
+	\file nabo.h
+	\brief public interface
+	\ingroup public
+*/
+
+/*!
+\mainpage libnabo
+
+from http://github.com/ethz-asl/libnabo by Stéphane Magnenat (http://stephane.magnenat.net),
+ASL-ETHZ, Switzerland (http://www.asl.ethz.ch)
+
+libnabo is a fast K Nearest Neighbour library for low-dimensional spaces.
+It provides a clean, legacy-free, scalar-type–agnostic API thanks to C++ templates.
+Its current CPU implementation is strongly inspired by \ref ANN, but with more compact data types.
+On the average, libnabo is 5% to 20% faster than \ref ANN.
+
+libnabo depends on \ref Eigen, a modern C++ matrix and linear-algebra library.
+libnabo works with either version 2 or 3 of Eigen.
+libnabo also depends on \ref Boost, a C++ general library.
+
+\section Compilation
+
+libnabo uses \ref CMake as build system.
+The complete compilation process depends on the system you are using (Linux, Mac OS X or Windows).
+You will find a nice introductory tutorial in this you tube video: http://www.youtube.com/watch?v=CLvZTyji_Uw.
+
+\subsection Prerequisites
+
+If your operating system does not provide it, you must get \ref Eigen.
+\ref Eigen only needs to be downloaded and extracted.
+
+\subsection CompilationOptions Compilation options
+
+libnabo provides the following compilation options, available through \ref CMake :
+ - \c SHARED_LIBS (boolean, default: \c false): if \c true, build a shared library, otherwise build a static library
+
+You specify them with a command-line tool, \c ccmake, or with a graphical tool, \c cmake-gui.
+Please read the <a href="http://www.cmake.org/cmake/help/cmake2.6docs.html">CMake documentation</a> for more information.
+
+\subsection QuickCompilationUnix Quick compilation and installation under Unix
+
+Under Unix, assuming that \ref Eigen is installed system-wide, you can compile (with optimisation and debug information) and install libnabo in \c /usr/local with the following commands run in the top-level directory of libnabo's sources:
+\code
+SRC_DIR=`pwd`
+BUILD_DIR=${SRC_DIR}/build
+mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ${SRC_DIR}
+# if Eigen is not available system-wide, run at that point:
+#   cmake-gui .
+# cmake-gui allows you to tell the location of Eigen
+make
+sudo make install
+\endcode
+
+These lines will compile libnabo in a \c build sub-directory and therefore keep your source tree clean.
+Note that you could compile libnabo anywhere you have write access, such as in \c /tmp/libnabo.
+This out-of-source build is a nice feature of \ref CMake.
+If \ref Eigen is not installed system-wide, you might have to tell \ref CMake where to find them (using \c ccmake or \c cmake-gui).
+
+You can generate the documentation by typing:
+\code
+make doc
+\endcode
+
+\section Usage
+
+libnabo is easy to use. For example, assuming that you are working with floats and that you have a point set \c M and a query point \c q, you can find the \c K nearest neighbours of \c q in \c M :
+
+\include trivial.cpp
+
+In this example, \c M is an \ref Eigen (refering to the software, not to the math) matrix (column major, float) and \c q is an \ref Eigen vector (float).
+The results \c indices and \c dists2 are \ref Eigen vectors of indices and squared distances refering to the columns of \c M.
+
+Here is a slightly more complex example:
+
+\include usage.cpp
+
+Note that the matrix-based interface for query is more efficient than the vector-based one, because some sanity checks can be done only once. Therefore, if you have multiple points to query, we warmly suggest to pass them as a matrix instead of calling \c knn() multiple times.
+
+\section ConstructionParameters Construction parameters
+
+The following additional construction parameters are available in KDTREE_ algorithms:
+- \c bucketSize (\c unsigned): bucket size, defaults to 8
+
+\section UnitTesting Unit testing
+
+The distribution of libnabo integrates a unit test module, based on CTest.
+Just type:
+
+\code
+make test
+\endcode
+   
+...in the build directory to run the tests.
+Their outputs are available in the \c Testing directory.
+These consist of validation and benchmarking tests.
+If \ref ANN is detected when compiling libnabo, \c make \c test will also perform comparative benchmarks.
+
+\section Citing Citing libnabo
+
+If you use libnabo in the academic context, please cite this paper that evaluates its performances in the contex of ICP:
+\code
+@article{elsebergcomparison,
+	title={Comparison of nearest-neighbor-search strategies and implementations for efficient shape registration},
+	author={Elseberg, J. and Magnenat, S. and Siegwart, R. and N{\"u}chter, A.},
+	journal={Journal of Software Engineering for Robotics (JOSER)},
+	pages={2--12},
+	volume={3},
+	number={1},
+	year={2012},
+	issn={2035-3928}
+}
+\endcode
+
+\section BugReporting Bug reporting
+
+Please use <a href="http://github.com/ethz-asl/libnabo/issues">github's issue tracker</a> to report bugs.
+
+\section License
+
+libnabo is released under a permissive BSD license.
+
+\section Faq
+
+\subsection ANN
+
+libnabo differs from \ref ANN on the following points:
+
+* API
+- templates for scalar type
+- self-match option as execution-time (instead of compile-time) parameter
+- range search instead of radius search
+- \ref Eigen library for vector and matrixes
+- reentrant
+
+* limitations
+- only euclidean distance
+- only KD-tree, no BD-tree
+- only ANN_KD_SL_MIDPT splitting rules
+
+* implementation
+- optional O(log(n)) tree heap instead of O(n) vector heap
+- compact memory representation, one memory allocation for all nodes, 5-fold smaller memory footprint compared than ANN
+- implicit reference to left child (always next node in array)
+- do not store bounds in nodes (that is, I do it like in ANN's article instead of like in ANN's source code)
+
+* performances
+- about 5% to 20% faster than ANN (both -O3 -NDEBUG), probably due to the smaller memory footprint
+- clearly memory-bound, neither OpenMP nor boost::thread improve performances 
+
+\section References
+
+\li \anchor Eigen Eigen: http://eigen.tuxfamily.org
+\li \anchor ANN ANN: http://www.cs.umd.edu/~mount/ANN
+\li \anchor CMake CMake: http://www.cmake.org
+\li \anchor Boost Boost: http://www.boost.org
+
+*/
+
+//! Namespace for Nabo
+namespace Nabo
+{
+	//! \defgroup public public interface 
+	//@{
+	
+	//! version of the Nabo library as string
+	#define NABO_VERSION "1.0.6"
+	//! version of the Nabo library as an int
+	#define NABO_VERSION_INT 10006
+	
+	//! Parameter vector
+	//
+	// TODO: replace with C++17 std::any.
+	struct Parameters: public std::map<std::string, linb::any>
+	{
+		//! Create an empty parameter vector
+		Parameters(){}
+		//! Create a parameter vector with a single entry
+		/** \param key entry key
+		 * \param value entry value
+		 */
+		Parameters(const std::string& key, const linb::any& value){(*this)[key] = value;}
+		//! Get the value of a key, return defaultValue if the key does not exist
+		/** \param key requested key
+		 * \param defaultValue value to return if the key does not exist
+		 * \return value of the key, or defaultValue if the key does not exist
+		 */
+		template<typename  T>
+		T get(const std::string& key, const T& defaultValue) const
+		{
+			const_iterator it(find(key));
+			if (it != end())
+				return linb::any_cast<T>(it->second);
+			else
+				return defaultValue;
+		}
+	};
+	
+	//! Nearest neighbour search interface, templatized on scalar type
+	template<typename T, typename Cloud_T = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
+	struct NearestNeighbourSearch
+	{
+		//! an Eigen vector of type T, to hold the coordinates of a point
+		typedef typename Eigen::Matrix<T, Eigen::Dynamic, 1> Vector; 
+		//! a column-major Eigen matrix in which each column is a point; this matrix has dim rows
+		typedef typename Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> Matrix;
+		//! a column-major Eigen matrix in which each column is a point; this matrix has dim rows
+		typedef Cloud_T CloudType;
+		//! an index to a Vector or a Matrix, for refering to data points
+		typedef int Index;
+		//! a vector of indices to data points
+		typedef typename Eigen::Matrix<Index, Eigen::Dynamic, 1> IndexVector;
+		//! a matrix of indices to data points
+		typedef typename Eigen::Matrix<Index, Eigen::Dynamic, Eigen::Dynamic> IndexMatrix;
+		
+		//! the reference to the data-point cloud, which must remain valid during the lifetime of the NearestNeighbourSearch object
+		const CloudType& cloud;
+		//! the dimensionality of the data-point cloud
+		const Index dim;
+		//! creation options
+		const unsigned creationOptionFlags;
+		//! the low bound of the search space (axis-aligned bounding box)
+		const Vector minBound;
+		//! the high bound of the search space (axis-aligned bounding box)
+		const Vector maxBound;
+		
+		//! type of search
+		enum SearchType
+		{
+			BRUTE_FORCE = 0, //!< brute force, check distance to every point in the data
+			KDTREE_LINEAR_HEAP, //!< kd-tree with linear heap, good for small k (~up to 30)
+			KDTREE_TREE_HEAP, //!< kd-tree with tree heap, good for large k (~from 30)
+			KDTREE_CL_PT_IN_NODES, //!< kd-tree using openCL, pt in nodes, only available if OpenCL enabled, UNSTABLE API
+			KDTREE_CL_PT_IN_LEAVES, //!< kd-tree using openCL, pt in leaves, only available if OpenCL enabled, UNSTABLE API
+			BRUTE_FORCE_CL, //!< brute-force using openCL, only available if OpenCL enabled, UNSTABLE API
+			SEARCH_TYPE_COUNT //!< number of search types
+		};
+		
+		//! creation option
+		enum CreationOptionFlags
+		{
+			TOUCH_STATISTICS = 1 //!< perform statistics on the number of points touched
+		};
+		
+		//! search option
+		enum SearchOptionFlags
+		{
+			ALLOW_SELF_MATCH = 1, //!< allows the return of the same point as the query, if this point is in the data cloud; forbidden by default
+			SORT_RESULTS = 2 //!< sort points by distances, when k > 1; do not sort by default
+		};
+		
+		//! Find the k nearest neighbours of query
+		/*!	If the search finds less than k points, the empty entries in dists2 will be filled with infinity and the indices with 0. If you must query more than one point at once, use the version of the knn() function taking matrices as input, because it is much faster.
+		 *	\param query query point
+		 *	\param indices indices of nearest neighbours, must be of size k
+		 *	\param dists2 squared distances to nearest neighbours, must be of size k
+		 *	\param k number of nearest neighbour requested
+		 *	\param epsilon maximal ratio of error for approximate search, 0 for exact search; has no effect if the number of neighbour found is smaller than the number requested
+		 *	\param optionFlags search options, a bitwise OR of elements of SearchOptionFlags
+		 *	\param maxRadius maximum radius in which to search, can be used to prune search, is not affected by epsilon
+		 *	\return if creationOptionFlags contains TOUCH_STATISTICS, return the number of point touched, otherwise return 0
+		 */
+		unsigned long knn(const Vector& query, IndexVector& indices, Vector& dists2, const Index k = 1, const T epsilon = 0, const unsigned optionFlags = 0, const T maxRadius = std::numeric_limits<T>::infinity()) const;
+		
+		//! Find the k nearest neighbours for each point of query
+		/*!	If the search finds less than k points, the empty entries in dists2 will be filled with infinity and the indices with 0.
+		 *	\param query query points
+		 *	\param indices indices of nearest neighbours, must be of size k x query.cols()
+		 *	\param dists2 squared distances to nearest neighbours, must be of size k x query.cols() 
+		 *	\param k number of nearest neighbour requested
+		 *	\param epsilon maximal ratio of error for approximate search, 0 for exact search; has no effect if the number of neighbour found is smaller than the number requested
+		 *	\param optionFlags search options, a bitwise OR of elements of SearchOptionFlags
+		 *	\param maxRadius maximum radius in which to search, can be used to prune search, is not affected by epsilon
+		 *	\return if creationOptionFlags contains TOUCH_STATISTICS, return the number of point touched, otherwise return 0
+		 */
+		virtual unsigned long knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Index k = 1, const T epsilon = 0, const unsigned optionFlags = 0, const T maxRadius = std::numeric_limits<T>::infinity()) const = 0;
+		
+		//! Find the k nearest neighbours for each point of query
+		/*!	If the search finds less than k points, the empty entries in dists2 will be filled with infinity and the indices with 0.
+		 *	\param query query points
+		 *	\param indices indices of nearest neighbours, must be of size k x query.cols()
+		 *	\param dists2 squared distances to nearest neighbours, must be of size k x query.cols() 
+		 *	\param maxRadii vector of maximum radii in which to search, used to prune search, is not affected by epsilon
+		 *	\param k number of nearest neighbour requested
+		 *	\param epsilon maximal ratio of error for approximate search, 0 for exact search; has no effect if the number of neighbour found is smaller than the number requested
+		 *	\param optionFlags search options, a bitwise OR of elements of SearchOptionFlags
+		 *	\return if creationOptionFlags contains TOUCH_STATISTICS, return the number of point touched, otherwise return 0
+		 */
+		virtual unsigned long knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Vector& maxRadii, const Index k = 1, const T epsilon = 0, const unsigned optionFlags = 0) const = 0;
+		
+		//! Create a nearest-neighbour search
+		/*!	\param cloud data-point cloud in which to search
+		 *	\param dim number of dimensions to consider, must be lower or equal to cloud.rows()
+		 *	\param preferedType type of search, one of SearchType
+		 *	\param creationOptionFlags creation options, a bitwise OR of elements of CreationOptionFlags
+		 *	\param additionalParameters additional parameters, currently only useful for KDTREE_
+		 *	\return an object on which to run nearest neighbour queries */
+		static NearestNeighbourSearch* create(const CloudType& cloud, const Index dim = std::numeric_limits<Index>::max(), const SearchType preferedType = KDTREE_LINEAR_HEAP, const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters());
+		
+		//! Create a nearest-neighbour search, using brute-force search, useful for comparison only
+		/*!	This is an helper function, you can also use create() with BRUTE_FORCE as preferedType
+		 *	\param cloud data-point cloud in which to search
+		 *	\param dim number of dimensions to consider, must be lower or equal to cloud.rows()
+		 *	\param creationOptionFlags creation options, a bitwise OR of elements of CreationOptionFlags
+		 *	\return an object on which to run nearest neighbour queries */
+		static NearestNeighbourSearch* createBruteForce(const CloudType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0);
+		
+		//! Create a nearest-neighbour search, using a kd-tree with linear heap, good for small k (~up to 30)
+		/*!	This is an helper function, you can also use create() with KDTREE_LINEAR_HEAP as preferedType
+		 *	\param cloud data-point cloud in which to search
+		 *	\param dim number of dimensions to consider, must be lower or equal to cloud.rows()
+		 *	\param creationOptionFlags creation options, a bitwise OR of elements of CreationOptionFlags
+		 *	\param additionalParameters additional parameters
+		 * 	\return an object on which to run nearest neighbour queries */
+		static NearestNeighbourSearch* createKDTreeLinearHeap(const CloudType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters());
+		
+		//! Create a nearest-neighbour search, using a kd-tree with tree heap, good for large k (~from 30)
+		/*!	This is an helper function, you can also use create() with KDTREE_TREE_HEAP as preferedType
+		 *	\param cloud data-point cloud in which to search
+		 *	\param dim number of dimensions to consider, must be lower or equal to cloud.rows()
+		 *	\param creationOptionFlags creation options, a bitwise OR of elements of CreationOptionFlags
+		 *	\param additionalParameters additional parameters
+		 * 	\return an object on which to run nearest neighbour queries */
+		static NearestNeighbourSearch* createKDTreeTreeHeap(const CloudType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters());
+		
+
+
+		//! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+		template <typename WrongMatrixType>
+		static NearestNeighbourSearch* create(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const SearchType preferedType = KDTREE_LINEAR_HEAP, const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters())
+		{
+		  typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+		  Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+		  return NULL;
+		}
+
+		//! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+		template <typename WrongMatrixType>
+		static NearestNeighbourSearch* createBruteForce(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0)
+		{
+		  typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+		  Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+		  return NULL;
+		}
+
+		//! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+		template <typename WrongMatrixType>
+		static NearestNeighbourSearch* createKDTreeLinearHeap(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters())
+		{
+		  typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+		  Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+		  return NULL;
+		}
+
+		//! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+		template <typename WrongMatrixType>
+		static NearestNeighbourSearch* createKDTreeTreeHeap(const WrongMatrixType&, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters())
+		{
+		  typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+		  Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+		  return NULL;
+		}
+
+		//! virtual destructor
+		virtual ~NearestNeighbourSearch() {}
+		
+	protected:
+		//! constructor
+		NearestNeighbourSearch(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags);
+		
+		//! Make sure that the output matrices have the right sizes. Throw an exception otherwise.
+		/*!	\param query query points
+		 *	\param k number of nearest neighbour requested
+		 *	\param indices indices of nearest neighbours, must be of size k x query.cols()
+		 *	\param dists2 squared distances to nearest neighbours, must be of size k x query.cols() 
+		 *	\param optionFlags the options passed to knn()
+			\param maxRadii if non 0, maximum radii, must be of size k */
+		void checkSizesKnn(const Matrix& query, const IndexMatrix& indices, const Matrix& dists2, const Index k, const unsigned optionFlags, const Vector* maxRadii = 0) const;
+	};
+	
+	// Convenience typedefs
+	
+	//! nearest neighbour search with scalars of type float
+	typedef NearestNeighbourSearch<float> NNSearchF;
+	//! nearest neighbour search with scalars of type double
+	typedef NearestNeighbourSearch<double> NNSearchD;
+	
+	//@}
+}
+
+#endif // __NABO_H

--- a/src/third_party/nabo/nabo_private.h
+++ b/src/third_party/nabo/nabo_private.h
@@ -1,0 +1,426 @@
+/*
+
+Copyright (c) 2010--2011, Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the author at <stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef __NABO_PRIVATE_H
+#define __NABO_PRIVATE_H
+
+#include "nabo.h"
+
+#ifdef BOOST_STDINT
+	#include <boost/cstdint.hpp>
+	using boost::uint32_t;
+#else // BOOST_STDINT
+	#include <stdint.h>
+#endif // BOOST_STDINT
+
+// OpenCL
+#ifdef HAVE_OPENCL
+	#define __CL_ENABLE_EXCEPTIONS
+	#include "CL/cl.hpp"
+#endif // HAVE_OPENCL
+
+// Unused macro, add support for your favorite compiler
+#if defined(__GNUC__)
+	#define _UNUSED __attribute__ ((unused))
+#else
+	#define _UNUSED
+#endif
+
+/*!	\file nabo_private.h
+	\brief header for implementation
+	\ingroup private
+*/
+
+namespace Nabo
+{
+	//! \defgroup private private implementation
+	//@{
+	
+	//! Euclidean distance
+	template<typename T, typename A, typename B>
+	inline T dist2(const A& v0, const B& v1)
+	{
+		return (v0 - v1).squaredNorm();
+	}
+
+	//! Brute-force nearest neighbour
+	template<typename T, typename CloudType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
+	struct BruteForceSearch : public NearestNeighbourSearch<T, CloudType>
+	{
+		typedef typename NearestNeighbourSearch<T, CloudType>::Vector Vector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Matrix Matrix;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Index Index;
+		typedef typename NearestNeighbourSearch<T, CloudType>::IndexVector IndexVector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::IndexMatrix IndexMatrix;
+		
+		using NearestNeighbourSearch<T, CloudType>::dim;
+		using NearestNeighbourSearch<T, CloudType>::creationOptionFlags;
+		using NearestNeighbourSearch<T, CloudType>::checkSizesKnn;
+		using NearestNeighbourSearch<T, CloudType>::minBound;
+		using NearestNeighbourSearch<T, CloudType>::maxBound;
+
+		//! constructor, calls NearestNeighbourSearch<T>(cloud)
+		BruteForceSearch(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags);
+		virtual unsigned long knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Index k, const T epsilon, const unsigned optionFlags, const T maxRadius) const;
+		virtual unsigned long knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Vector& maxRadii, const Index k = 1, const T epsilon = 0, const unsigned optionFlags = 0) const;
+	};
+	
+	//! KDTree, unbalanced, points in leaves, stack, implicit bounds, ANN_KD_SL_MIDPT, optimised implementation
+	template<typename T, typename Heap, typename CloudType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
+	struct KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt: public NearestNeighbourSearch<T, CloudType>
+	{
+		typedef typename NearestNeighbourSearch<T, CloudType>::Vector Vector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Matrix Matrix;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Index Index;
+		typedef typename NearestNeighbourSearch<T, CloudType>::IndexVector IndexVector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::IndexMatrix IndexMatrix;
+		
+		using NearestNeighbourSearch<T, CloudType>::dim;
+		using NearestNeighbourSearch<T, CloudType>::cloud;
+		using NearestNeighbourSearch<T, CloudType>::creationOptionFlags;
+		using NearestNeighbourSearch<T, CloudType>::minBound;
+		using NearestNeighbourSearch<T, CloudType>::maxBound;
+		using NearestNeighbourSearch<T, CloudType>::checkSizesKnn;
+		
+	protected:
+		//! indices of points during kd-tree construction
+		typedef std::vector<Index> BuildPoints;
+		//! iterator to indices of points during kd-tree construction
+		typedef typename BuildPoints::iterator BuildPointsIt;
+		//! const-iterator to indices of points during kd-tree construction
+		typedef typename BuildPoints::const_iterator BuildPointsCstIt;
+		
+		//! size of bucket
+		const unsigned bucketSize;
+		
+		//! number of bits required to store dimension index + number of dimensions
+		const uint32_t dimBitCount;
+		//! mask to access dim
+		const uint32_t dimMask;
+		
+		//! create the compound index containing the dimension and the index of the child or the bucket size
+		inline uint32_t createDimChildBucketSize(const uint32_t dim, const uint32_t childIndex) const
+		{ return dim | (childIndex << dimBitCount); }
+		//! get the dimension out of the compound index
+		inline uint32_t getDim(const uint32_t dimChildBucketSize) const
+		{ return dimChildBucketSize & dimMask; }
+		//! get the child index or the bucket size out of the coumpount index
+		inline uint32_t getChildBucketSize(const uint32_t dimChildBucketSize) const
+		{ return dimChildBucketSize >> dimBitCount; }
+		
+		struct BucketEntry;
+		
+		//! search node
+		struct Node
+		{
+			uint32_t dimChildBucketSize; //!< cut dimension for split nodes (dimBitCount lsb), index of right node or number of bucket(rest). Note that left index is current+1
+			union
+			{
+				T cutVal; //!< for split node, split value
+				uint32_t bucketIndex; //!< for leaf node, pointer to bucket
+			};
+			
+			//! construct a split node
+			Node(const uint32_t dimChild, const T cutVal):
+				dimChildBucketSize(dimChild), cutVal(cutVal) {}
+			//! construct a leaf node
+			Node(const uint32_t bucketSize, const uint32_t bucketIndex):
+				dimChildBucketSize(bucketSize), bucketIndex(bucketIndex) {}
+		};
+		//! dense vector of search nodes, provides better memory performances than many small objects
+		typedef std::vector<Node> Nodes;
+		
+		//! entry in a bucket
+		struct BucketEntry
+		{
+			const T* pt; //!< pointer to first value of point data, 0 if end of bucket
+			Index index; //!< index of point
+			
+			//! create a new bucket entry for a point in the data
+			/** \param pt pointer to first component of the point, components must be continuous
+			 * \param index index of the point in the data
+			 */
+			BucketEntry(const T* pt = 0, const Index index = 0): pt(pt), index(index) {}
+		};
+		
+		//! bucket data
+		typedef std::vector<BucketEntry> Buckets;
+		
+		//! search nodes
+		Nodes nodes;
+		
+		//! buckets
+		Buckets buckets;
+		
+		//! return the bounds of points from [first..last[ on dimension dim
+		std::pair<T,T> getBounds(const BuildPointsIt first, const BuildPointsIt last, const unsigned dim);
+		//! construct nodes for points [first..last[ inside the hyperrectangle [minValues..maxValues]
+		unsigned buildNodes(const BuildPointsIt first, const BuildPointsIt last, const Vector minValues, const Vector maxValues);
+		
+		//! search one point, call recurseKnn with the correct template parameters
+		/** \param query pointer to query coordinates 
+		 *	\param indices indices of nearest neighbours, must be of size k x query.cols()
+		 *	\param dists2 squared distances to nearest neighbours, must be of size k x query.cols() 
+		 *	\param i index of point to search
+		 * 	\param heap reference to heap
+		 * 	\param off reference to array of offsets
+		 *	\param maxError error factor (1 + epsilon) 
+		 *	\param maxRadius2 square of maximum radius
+		 *	\param allowSelfMatch whether to allow self match
+		 *	\param collectStatistics whether to collect statistics
+		 *	\param sortResults wether to sort results
+		 */
+		unsigned long onePointKnn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, int i, Heap& heap, std::vector<T>& off, const T maxError, const T maxRadius2, const bool allowSelfMatch, const bool collectStatistics, const bool sortResults) const;
+		
+		//! recursive search, strongly inspired by ANN and [Arya & Mount, Algorithms for fast vector quantization, 1993]
+		/**	\param query pointer to query coordinates 
+		 * 	\param n index of node to visit
+		 * 	\param rd squared dist to this rect
+		 * 	\param heap reference to heap
+		 * 	\param off reference to array of offsets
+		 * 	\param maxError error factor (1 + epsilon) 
+		 *	\param maxRadius2 square of maximum radius
+		 */
+		template<bool allowSelfMatch, bool collectStatistics>
+		unsigned long recurseKnn(const T* query, const unsigned n, T rd, Heap& heap, std::vector<T>& off, const T maxError, const T maxRadius2) const;
+		
+	public:
+		//! constructor, calls NearestNeighbourSearch<T>(cloud)
+		KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const Parameters& additionalParameters);
+		virtual unsigned long knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Index k, const T epsilon, const unsigned optionFlags, const T maxRadius) const;
+		virtual unsigned long knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Vector& maxRadii, const Index k = 1, const T epsilon = 0, const unsigned optionFlags = 0) const;
+	};
+	
+	#ifdef HAVE_OPENCL
+	
+	//! OpenCL support for nearest neighbour search	
+	template<typename T, typename CloudType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
+	struct OpenCLSearch: public NearestNeighbourSearch<T, CloudType>
+	{
+		typedef typename NearestNeighbourSearch<T, CloudType>::Vector Vector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Matrix Matrix;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Index Index;
+		typedef typename NearestNeighbourSearch<T, CloudType>::IndexVector IndexVector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::IndexMatrix IndexMatrix;
+		
+		using NearestNeighbourSearch<T, CloudType>::dim;
+		using NearestNeighbourSearch<T, CloudType>::cloud;
+		using NearestNeighbourSearch<T, CloudType>::creationOptionFlags;
+		using NearestNeighbourSearch<T, CloudType>::checkSizesKnn;
+		
+	protected:
+		const cl_device_type deviceType; //!< the type of device to run CL code on (CL_DEVICE_TYPE_CPU or CL_DEVICE_TYPE_GPU)
+		cl::Context& context; //!< the CL context
+		mutable cl::Kernel knnKernel; //!< the kernel to perform knnSearch, mutable because it is stateful, but conceptually const
+		cl::CommandQueue queue; //!< the command queue
+		cl::Buffer cloudCL; //!< the buffer for the input data
+		
+		//! constructor, calls NearestNeighbourSearch<T, CloudType>(cloud)
+		OpenCLSearch(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const cl_device_type deviceType);
+		//! Initialize CL support
+		/** \param clFileName name of file containing CL code
+		 * \param kernelName name of the CL kernel function
+		 * \param additionalDefines additional CL code to pass to compiler
+		 */
+		void initOpenCL(const char* clFileName, const char* kernelName, const std::string& additionalDefines = "");
+	
+	public:
+		virtual unsigned long knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Index k, const T epsilon, const unsigned optionFlags, const T maxRadius) const;
+		virtual unsigned long knn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, const Vector& maxRadii, const Index k = 1, const T epsilon = 0, const unsigned optionFlags = 0) const;
+	};
+	
+	//! KDTree, balanced, points in leaves, stack, implicit bounds, balance aspect ratio
+	template<typename T, typename CloudType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
+	struct BruteForceSearchOpenCL: public OpenCLSearch<T, CloudType>
+	{
+		typedef typename NearestNeighbourSearch<T, CloudType>::Vector Vector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Matrix Matrix;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Index Index;
+		
+		using OpenCLSearch<T, CloudType>::initOpenCL;
+		
+		//! constructor, calls OpenCLSearch<T, CloudType>(cloud, ...)
+		BruteForceSearchOpenCL(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const cl_device_type deviceType);
+	};
+	
+	//! KDTree, balanced, points in leaves, stack, implicit bounds, balance aspect ratio
+	template<typename T, typename CloudType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
+	struct KDTreeBalancedPtInLeavesStackOpenCL: public OpenCLSearch<T, CloudType>
+	{
+		typedef typename NearestNeighbourSearch<T, CloudType>::Vector Vector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Matrix Matrix;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Index Index;
+		typedef typename NearestNeighbourSearch<T, CloudType>::IndexVector IndexVector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::IndexMatrix IndexMatrix;
+		
+		using NearestNeighbourSearch<T, CloudType>::dim;
+		using NearestNeighbourSearch<T, CloudType>::cloud;
+		using NearestNeighbourSearch<T, CloudType>::creationOptionFlags;
+		using NearestNeighbourSearch<T, CloudType>::minBound;
+		using NearestNeighbourSearch<T, CloudType>::maxBound;
+		
+		using OpenCLSearch<T, CloudType>::context;
+		using OpenCLSearch<T, CloudType>::knnKernel;
+		
+		using OpenCLSearch<T, CloudType>::initOpenCL;
+		
+	protected:
+		//! Point during kd-tree construction
+		struct BuildPoint
+		{
+			Vector pos; //!< point
+			size_t index; //!< index of point in cloud
+			//! Construct a build point, at a given pos with a specific index
+			BuildPoint(const Vector& pos =  Vector(), const size_t index = 0): pos(pos), index(index) {}
+		};
+		//! points during kd-tree construction
+		typedef std::vector<BuildPoint> BuildPoints;
+		//! iterator to points during kd-tree construction
+		typedef typename BuildPoints::iterator BuildPointsIt;
+		//! const-iterator to points during kd-tree construction
+		typedef typename BuildPoints::const_iterator BuildPointsCstIt;
+		
+		//! Functor to compare point values on a given dimension
+		struct CompareDim
+		{
+			size_t dim; //!< dimension on which to compare
+			//! Build the functor for a specific dimension
+			CompareDim(const size_t dim):dim(dim){}
+			//! Compare the values of p0 and p1 on dim, and return whether p0[dim] < p1[dim]
+			bool operator() (const BuildPoint& p0, const BuildPoint& p1) { return p0.pos(dim) < p1.pos(dim); }
+		};
+		
+		//! Tree node for CL
+		struct Node
+		{
+			int dim; //!< dimension of the cut, or, if negative, index of the point: -1 == invalid, <= -2 = index of pt
+			T cutVal; //!< value of the cut
+			//! Build a tree node, with a given dimension and value to cut on, or, if leaf and dim <= -2, the index of the point as (-dim-2)
+			Node(const int dim = -1, const T cutVal = 0):dim(dim), cutVal(cutVal) {}
+		};
+		//! dense vector of search nodes
+		typedef std::vector<Node> Nodes;
+		
+		Nodes nodes; //!< search nodes
+		cl::Buffer nodesCL; //!< CL buffer for search nodes
+		
+		
+		inline size_t childLeft(size_t pos) const { return 2*pos + 1; } //!< Return the left child of pos
+		inline size_t childRight(size_t pos) const { return 2*pos + 2; } //!< Return the right child of pos
+		inline size_t parent(size_t pos) const { return (pos-1)/2; } //!< Return the parent of pos
+		size_t getTreeDepth(size_t size) const; //!< Return the max depth of a tree of a given size
+		size_t getTreeSize(size_t size) const; //!< Return the storage size of tree of a given size
+		
+		//! Recurse to build nodes
+		void buildNodes(const BuildPointsIt first, const BuildPointsIt last, const size_t pos, const Vector minValues, const Vector maxValues);
+		
+	public:
+		//! constructor, calls OpenCLSearch<T, CloudType>(cloud, ...)
+		KDTreeBalancedPtInLeavesStackOpenCL(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const cl_device_type deviceType);
+	};
+	
+	//! KDTree, balanced, points in nodes, stack, implicit bounds, balance aspect ratio
+	template<typename T, typename CloudType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
+	struct KDTreeBalancedPtInNodesStackOpenCL: public OpenCLSearch<T, CloudType>
+	{
+		typedef typename NearestNeighbourSearch<T, CloudType>::Vector Vector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Matrix Matrix;
+		typedef typename NearestNeighbourSearch<T, CloudType>::Index Index;
+		typedef typename NearestNeighbourSearch<T, CloudType>::IndexVector IndexVector;
+		typedef typename NearestNeighbourSearch<T, CloudType>::IndexMatrix IndexMatrix;
+		
+		using NearestNeighbourSearch<T, CloudType>::dim;
+		using NearestNeighbourSearch<T, CloudType>::cloud;
+		using NearestNeighbourSearch<T, CloudType>::creationOptionFlags;
+		using NearestNeighbourSearch<T, CloudType>::minBound;
+		using NearestNeighbourSearch<T, CloudType>::maxBound;
+		
+		using OpenCLSearch<T, CloudType>::context;
+		using OpenCLSearch<T, CloudType>::knnKernel;
+		
+		using OpenCLSearch<T, CloudType>::initOpenCL;
+		
+	protected:
+		//! a point during kd-tree construction is just its index
+		typedef Index BuildPoint;
+		//! points during kd-tree construction
+		typedef std::vector<BuildPoint> BuildPoints;
+		//! iterator to points during kd-tree construction
+		typedef typename BuildPoints::iterator BuildPointsIt;
+		//! const-iterator to points during kd-tree construction
+		typedef typename BuildPoints::const_iterator BuildPointsCstIt;
+		
+		//! Functor to compare point values on a given dimension
+		struct CompareDim
+		{
+			const CloudType& cloud; //!< reference to data points used to compare
+			size_t dim; //!< dimension on which to compare
+			//! Build the functor for a specific dimension on a specific cloud
+			CompareDim(const CloudType& cloud, const size_t dim): cloud(cloud), dim(dim){}
+			//! Compare the values of p0 and p1 on dim, and return whether p0[dim] < p1[dim]
+			bool operator() (const BuildPoint& p0, const BuildPoint& p1) { return cloud.coeff(dim, p0) < cloud.coeff(dim, p1); }
+		};
+		
+		//! Tree node for CL
+		struct Node
+		{
+			int dim; //!< dimension of the cut, or, if -1 == leaf, -2 == invalid
+			Index index; //!< index of the point to cut
+			//! Build a tree node, with a given index and a given dimension to cut on
+			Node(const int dim = -2, const Index index = 0):dim(dim), index(index) {}
+		};
+		//! dense vector of search nodes
+		typedef std::vector<Node> Nodes;
+		
+		Nodes nodes; //!< search nodes
+		cl::Buffer nodesCL;  //!< CL buffer for search nodes
+		
+		
+		inline size_t childLeft(size_t pos) const { return 2*pos + 1; } //!< Return the left child of pos
+		inline size_t childRight(size_t pos) const { return 2*pos + 2; } //!< Return the right child of pos
+		inline size_t parent(size_t pos) const { return (pos-1)/2; } //!< Return the parent of pos
+		size_t getTreeDepth(size_t size) const; //!< Return the max depth of a tree of a given size
+		size_t getTreeSize(size_t size) const; //!< Return the storage size of tree of a given size
+		
+		//! Recurse to build nodes
+		void buildNodes(const BuildPointsIt first, const BuildPointsIt last, const size_t pos, const Vector minValues, const Vector maxValues);
+		
+	public:
+		//! constructor, calls OpenCLSearch<T, CloudType>(cloud, ...)
+		KDTreeBalancedPtInNodesStackOpenCL(const CloudType& cloud, const Index dim, const unsigned creationOptionFlags, const cl_device_type deviceType);
+	};
+	
+	#endif // HAVE_OPENCL
+	
+	//@}
+}
+
+#endif // __NABO_H

--- a/src/third_party/nabo/opencl/heap.cl
+++ b/src/third_party/nabo/opencl/heap.cl
@@ -1,0 +1,37 @@
+T heapHeadValue(const HeapEntry* heap)
+{
+	return heap->value;
+}
+
+void heapHeadReplace(HeapEntry* heap, const int index, const T value, const uint K)
+{
+	uint i = 0;
+	for (; i < K - 1; ++i)
+	{
+		if (heap[i + 1].value > value)
+			heap[i] = heap[i + 1];
+		else
+			break;
+	}
+	heap[i].value = value;
+	heap[i].index = index;
+}
+
+void heapInit(HeapEntry* heap, const uint K)
+{
+	for (uint i = 0; i < K; ++i)
+		heap[i].value = HUGE_VALF;
+}
+
+void heapCopy(global int* indices, global T* dists2, const HeapEntry* heap, const uint K)
+{
+	for (uint i = 0; i < K; ++i)
+	{
+		*indices++ = heap[K-i-1].index;
+		*dists2++ = heap[K-i-1].value;
+	}
+}
+
+void heapSort(const HeapEntry* heap)
+{
+}

--- a/src/third_party/nabo/opencl/knn_bf.cl
+++ b/src/third_party/nabo/opencl/knn_bf.cl
@@ -1,0 +1,47 @@
+kernel void knnBruteForce(const global T* cloud,
+						const global T* query,
+						global int* indices,
+						global T* dists2,
+						const uint K,
+						const T maxError,
+						const T maxRadius2,
+						const uint optionFlags,
+						const uint indexStride,
+						const uint dists2Stride,
+						const uint pointCount
+#ifdef TOUCH_STATISTICS
+						,
+						global uint* touchStatistics
+#endif
+						)
+{
+	HeapEntry heap[MAX_K];
+	heapInit(heap, K);
+	
+	const size_t queryId = get_global_id(0);
+	const bool allowSelfMatch = optionFlags & ALLOW_SELF_MATCH;
+	const bool doSort = optionFlags & SORT_RESULTS;
+	const global T* q = &query[queryId * POINT_STRIDE];
+	
+	for (uint index = 0; index < pointCount; ++index)
+	{
+		const global T* p = &cloud[index * POINT_STRIDE];
+		T dist = 0;
+		for (uint i = 0; i < DIM_COUNT; ++i)
+		{
+			const T diff = q[i] - p[i];
+			dist += diff * diff;
+		}
+		if ((dist <= maxRadius2) &&
+			(dist < heapHeadValue(heap) &&
+			(allowSelfMatch || (dist > 0)))
+			heapHeadReplace(heap, index, dist, K);
+	}
+	
+	if (doSort)
+		heapSort(heap);
+	heapCopy(&indices[queryId * indexStride], &dists2[queryId * dists2Stride], heap, K);
+	#ifdef TOUCH_STATISTICS
+	touchStatistics[queryId] = pointCount;
+	#endif
+}

--- a/src/third_party/nabo/opencl/knn_kdtree_pt_in_leaves.cl
+++ b/src/third_party/nabo/opencl/knn_kdtree_pt_in_leaves.cl
@@ -1,0 +1,154 @@
+#define INVALID_NODE -1
+
+#define OP_BEGIN_FUNCTION 0
+#define OP_REC1 1
+#define OP_REC2 2
+
+typedef struct { 
+	int dim; // -1 == invalid, <= -2 = index of pt
+	T cutVal; //!< for split node, split value 
+} Node;
+
+typedef struct {
+	uint op;
+	size_t n;
+	size_t other_n;
+	T rd;
+	T old_off;
+	T new_off;
+} StackEntry;
+
+size_t childLeft(const size_t pos) { return 2*pos + 1; }
+size_t childRight(const size_t pos) { return 2*pos + 2; }
+
+void offInit(T *off)
+{
+	for (uint i = 0; i < DIM_COUNT; ++i)
+		off[i] = 0;
+}
+
+// for cloud and result, use DirectAccessBit and stride
+// preconditions:
+// 		K < MAX_K
+//		stack_ptr < MAX_STACK_DEPTH
+kernel void knnKDTree(	const global T* cloud,
+						const global T* query,
+						global int* indices,
+						global T* dists2,
+						const uint K,
+						const T maxError,
+						const T maxRadius2,
+						const uint optionFlags,
+						const uint indexStride,
+						const uint dists2Stride,
+						const uint pointCount,
+#ifdef TOUCH_STATISTICS
+						global uint* touchStatistics,
+#endif
+						const global Node* nodes
+ 					)
+{
+	StackEntry stack[MAX_STACK_DEPTH];
+	HeapEntry heap[MAX_K];
+	T off[DIM_COUNT];
+
+#ifdef TOUCH_STATISTICS
+	uint visitCount = 0;
+#endif
+
+	const size_t queryId = get_global_id(0);
+	const bool allowSelfMatch = optionFlags & ALLOW_SELF_MATCH;
+	const bool doSort = optionFlags & SORT_RESULTS;
+	const global T* q = &query[queryId * POINT_STRIDE];
+	
+	heapInit(heap, K);
+	offInit(off);
+	
+	uint stackPtr = 1;
+	stack[0].op = OP_BEGIN_FUNCTION;
+	stack[0].n = 0;
+	stack[0].rd = 0;
+
+	while (stackPtr != 0)
+	{
+		--stackPtr;
+		StackEntry* s = stack + stackPtr;
+		const size_t n = s->n;
+		const global Node* node = nodes + n;
+		const int cd = node->dim;
+		switch (stack[stackPtr].op)
+		{
+			case OP_BEGIN_FUNCTION:
+			if (cd < 0)
+			{
+				if (cd != -1)
+				{
+					const int index = -(cd + 2);
+					const global T* p = &cloud[index * POINT_STRIDE];
+					T dist = 0;
+					for (uint i = 0; i < DIM_COUNT; ++i)
+					{
+						const T diff = q[i] - p[i];
+						dist += diff * diff;
+					}
+					if ((dist <= maxRadius2) &&
+						(dist < heapHeadValue(heap) &&
+						(allowSelfMatch || (dist > (T)EPSILON))))
+						heapHeadReplace(heap, index, dist, K);
+#ifdef TOUCH_STATISTICS
+					++visitCount;
+#endif
+				}
+			}
+			else
+			{
+				s->old_off = off[cd];
+				s->new_off = q[cd] - node->cutVal;
+				(s+1)->op = OP_BEGIN_FUNCTION;
+				s->op = OP_REC1;
+				if (s->new_off > 0)
+				{
+					(s+1)->n = childRight(n);
+					s->other_n = childLeft(n);
+				}
+				else
+				{
+					(s+1)->n = childLeft(n);
+					s->other_n = childRight(n);
+				}
+				(s+1)->rd = s->rd;
+				stackPtr+=2;
+			}
+			break;
+			
+			case OP_REC1:
+			{
+				T rdE;
+				s->rd += - (s->old_off*s->old_off) + (s->new_off*s->new_off);
+				if ((s->rd <= maxRadius2) &&
+					(s->rd * maxError < heapHeadValue(heap)))
+				{
+					off[cd] = s->new_off;
+					(s+1)->op = OP_BEGIN_FUNCTION;
+					(s+1)->n = s->other_n;
+					(s+1)->rd = s->rd;
+					s->op = OP_REC2;
+					stackPtr+=2;
+				}
+			}
+			break;
+			
+			case OP_REC2:
+			off[cd] = s->old_off;
+			break;
+		}
+	}
+	
+	if (doSort)
+		heapSort(heap);
+	heapCopy(&indices[queryId * indexStride], &dists2[queryId * dists2Stride], heap, K);
+#ifdef TOUCH_STATISTICS
+	touchStatistics[queryId] = visitCount;
+#endif
+}
+

--- a/src/third_party/nabo/opencl/knn_kdtree_pt_in_nodes.cl
+++ b/src/third_party/nabo/opencl/knn_kdtree_pt_in_nodes.cl
@@ -1,0 +1,125 @@
+typedef struct { 
+	int dim;  // >=0 cut dim, -1 == leaf, -2 == invalid
+	int index;
+} Node;
+
+#define OFFSIDE 0
+#define ONSIDE 1
+
+typedef struct {
+	size_t n;
+	uint state;
+} StackEntry;
+
+size_t childLeft(const size_t pos) { return 2*pos + 1; }
+size_t childRight(const size_t pos) { return 2*pos + 2; }
+
+// for cloud and result, use DirectAccessBit and stride
+// preconditions:
+// 		K < MAX_K
+//		stack_ptr < MAX_STACK_DEPTH
+kernel void knnKDTree(	const global T* cloud,
+						const global T* query,
+						global int* indices,
+						global T* dists2,
+						const uint K,
+						const T maxError,
+						const T maxRadius2,
+						const uint optionFlags,
+						const uint indexStride,
+						const uint dists2Stride,
+						const uint pointCount,
+#ifdef TOUCH_STATISTICS
+						global uint* touchStatistics,
+#endif
+						const global Node* nodes
+ 					)
+{
+	StackEntry stack[MAX_STACK_DEPTH];
+	HeapEntry heap[MAX_K];
+	
+#ifdef TOUCH_STATISTICS
+	uint visitCount = 0;
+#endif
+	
+	const size_t queryId = get_global_id(0);
+	const bool allowSelfMatch = optionFlags & ALLOW_SELF_MATCH;
+	const bool doSort = optionFlags & SORT_RESULTS;
+	const global T* q = &query[queryId * POINT_STRIDE];
+	
+	heapInit(heap, K);
+	
+	uint stackPtr = 1;
+	stack[0].state = ONSIDE;
+	stack[0].n = 0;
+	
+	while (stackPtr != 0)
+	{
+		--stackPtr;
+		StackEntry* s = stack + stackPtr;
+		const size_t n = s->n;
+		const global Node* node = nodes + n;
+		const int cd = node->dim;
+		if (cd == -2)
+			continue;
+		const int index = node->index;
+		const global T* p = &cloud[index * POINT_STRIDE];
+		// check whether we already have better dist
+		if ((s->state == OFFSIDE) && (cd >= 0))
+		{
+			const T diff = q[cd] - p[cd];
+			// TODO: use approximate dist
+			// FIXME: bug in this early out
+			//if (diff * diff > heapHeadValue(heap))
+			//	continue;
+		}
+		// compute new distance and update if lower
+		T dist = 0;
+		for (uint i = 0; i < DIM_COUNT; ++i)
+		{
+			const T diff = q[i] - p[i];
+			dist += diff * diff;
+		}
+		if ((dist <= maxRadius2) &&
+			(dist < heapHeadValue(heap) &&
+			(allowSelfMatch || (dist > (T)EPSILON))))
+			heapHeadReplace(heap, index, dist, K);
+#ifdef TOUCH_STATISTICS
+		++visitCount;
+#endif
+		// look for recursion
+		if (cd >= 0)
+		{
+			const T side = q[cd] - p[cd];
+			const T side2 = side*side;
+			// should we enqueue off side?
+			if ((side2 <= maxRadius2) &&
+				(side2 * maxError < heapHeadValue(heap)))
+			{
+				// yes
+				s->state = OFFSIDE;
+				if (side >= 0)
+					s->n = childLeft(n);
+				else
+					s->n = childRight(n);
+				++stackPtr;
+			}
+			// always enqueue on side
+			s = stack + stackPtr;
+			s->state = ONSIDE;
+			if (side >= 0)
+				s->n = childRight(n);
+			else
+				s->n = childLeft(n);
+			++stackPtr;
+		}
+	}
+	
+	if (doSort)
+		heapSort(heap);
+	heapCopy(&indices[queryId * indexStride], &dists2[queryId * dists2Stride], heap, K);
+#ifdef TOUCH_STATISTICS
+	touchStatistics[queryId] = visitCount;
+#endif
+}
+

--- a/src/third_party/nabo/opencl/structure.cl
+++ b/src/third_party/nabo/opencl/structure.cl
@@ -1,0 +1,7 @@
+#define ALLOW_SELF_MATCH 1
+#define SORT_RESULTS 2
+
+typedef struct {
+	T value;
+	int index;
+} HeapEntry;

--- a/src/third_party/nabo/third_party/any.hpp
+++ b/src/third_party/nabo/third_party/any.hpp
@@ -1,0 +1,458 @@
+//
+// Implementation of N4562 std::experimental::any (merged into C++17) for C++11 compilers.
+//
+// See also:
+//   + http://en.cppreference.com/w/cpp/any
+//   + http://en.cppreference.com/w/cpp/experimental/any
+//   + http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4562.html#any
+//   + https://cplusplus.github.io/LWG/lwg-active.html#2509
+//
+//
+// Copyright (c) 2016 Denilson das Merc�s Amorim
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+#ifndef LINB_ANY_HPP
+#define LINB_ANY_HPP
+#pragma once
+#include <typeinfo>
+#include <type_traits>
+#include <stdexcept>
+
+namespace linb
+{
+
+class bad_any_cast : public std::bad_cast
+{
+public:
+    const char* what() const noexcept override
+    {
+        return "bad any cast";
+    }
+};
+
+class any final
+{
+public:
+    /// Constructs an object of type any with an empty state.
+    any() :
+        vtable(nullptr)
+    {
+    }
+
+    /// Constructs an object of type any with an equivalent state as other.
+    any(const any& rhs) :
+        vtable(rhs.vtable)
+    {
+        if(!rhs.empty())
+        {
+            rhs.vtable->copy(rhs.storage, this->storage);
+        }
+    }
+
+    /// Constructs an object of type any with a state equivalent to the original state of other.
+    /// rhs is left in a valid but otherwise unspecified state.
+    any(any&& rhs) noexcept :
+        vtable(rhs.vtable)
+    {
+        if(!rhs.empty())
+        {
+            rhs.vtable->move(rhs.storage, this->storage);
+            rhs.vtable = nullptr;
+        }
+    }
+
+    /// Same effect as this->clear().
+    ~any()
+    {
+        this->clear();
+    }
+
+    /// Constructs an object of type any that contains an object of type T direct-initialized with std::forward<ValueType>(value).
+    ///
+    /// T shall satisfy the CopyConstructible requirements, otherwise the program is ill-formed.
+    /// This is because an `any` may be copy constructed into another `any` at any time, so a copy should always be allowed.
+    template<typename ValueType, typename = typename std::enable_if<!std::is_same<typename std::decay<ValueType>::type, any>::value>::type>
+    any(ValueType&& value)
+    {
+        static_assert(std::is_copy_constructible<typename std::decay<ValueType>::type>::value,
+            "T shall satisfy the CopyConstructible requirements.");
+        this->construct(std::forward<ValueType>(value));
+    }
+
+    /// Has the same effect as any(rhs).swap(*this). No effects if an exception is thrown.
+    any& operator=(const any& rhs)
+    {
+        any(rhs).swap(*this);
+        return *this;
+    }
+
+    /// Has the same effect as any(std::move(rhs)).swap(*this).
+    ///
+    /// The state of *this is equivalent to the original state of rhs and rhs is left in a valid
+    /// but otherwise unspecified state.
+    any& operator=(any&& rhs) noexcept
+    {
+        any(std::move(rhs)).swap(*this);
+        return *this;
+    }
+
+    /// Has the same effect as any(std::forward<ValueType>(value)).swap(*this). No effect if a exception is thrown.
+    ///
+    /// T shall satisfy the CopyConstructible requirements, otherwise the program is ill-formed.
+    /// This is because an `any` may be copy constructed into another `any` at any time, so a copy should always be allowed.
+    template<typename ValueType, typename = typename std::enable_if<!std::is_same<typename std::decay<ValueType>::type, any>::value>::type>
+    any& operator=(ValueType&& value)
+    {
+        static_assert(std::is_copy_constructible<typename std::decay<ValueType>::type>::value,
+            "T shall satisfy the CopyConstructible requirements.");
+        any(std::forward<ValueType>(value)).swap(*this);
+        return *this;
+    }
+
+    /// If not empty, destroys the contained object.
+    void clear() noexcept
+    {
+        if(!empty())
+        {
+            this->vtable->destroy(storage);
+            this->vtable = nullptr;
+        }
+    }
+
+    /// Returns true if *this has no contained object, otherwise false.
+    bool empty() const noexcept
+    {
+        return this->vtable == nullptr;
+    }
+
+    /// If *this has a contained object of type T, typeid(T); otherwise typeid(void).
+    const std::type_info& type() const noexcept
+    {
+        return empty()? typeid(void) : this->vtable->type();
+    }
+
+    /// Exchange the states of *this and rhs.
+    void swap(any& rhs) noexcept
+    {
+        if(this->vtable != rhs.vtable)
+        {
+            any tmp(std::move(rhs));
+
+            // move from *this to rhs.
+            rhs.vtable = this->vtable;
+            if(this->vtable != nullptr)
+            {
+                this->vtable->move(this->storage, rhs.storage);
+                //this->vtable = nullptr; -- uneeded, see below
+            }
+
+            // move from tmp (previously rhs) to *this.
+            this->vtable = tmp.vtable;
+            if(tmp.vtable != nullptr)
+            {
+                tmp.vtable->move(tmp.storage, this->storage);
+                tmp.vtable = nullptr;
+            }
+        }
+        else // same types
+        {
+            if(this->vtable != nullptr)
+                this->vtable->swap(this->storage, rhs.storage);
+        }
+    }
+
+private: // Storage and Virtual Method Table
+
+    union storage_union
+    {
+        using stack_storage_t = typename std::aligned_storage<2 * sizeof(void*), std::alignment_of<void*>::value>::type;
+
+        void*               dynamic;
+        stack_storage_t     stack;      // 2 words for e.g. shared_ptr
+    };
+
+    /// Base VTable specification.
+    struct vtable_type
+    {
+        // Note: The caller is responssible for doing .vtable = nullptr after destructful operations
+        // such as destroy() and/or move().
+
+        /// The type of the object this vtable is for.
+        const std::type_info& (*type)() noexcept;
+
+        /// Destroys the object in the union.
+        /// The state of the union after this call is unspecified, caller must ensure not to use src anymore.
+        void(*destroy)(storage_union&) noexcept;
+
+        /// Copies the **inner** content of the src union into the yet unitialized dest union.
+        /// As such, both inner objects will have the same state, but on separate memory locations.
+        void(*copy)(const storage_union& src, storage_union& dest);
+
+        /// Moves the storage from src to the yet unitialized dest union.
+        /// The state of src after this call is unspecified, caller must ensure not to use src anymore.
+        void(*move)(storage_union& src, storage_union& dest) noexcept;
+
+        /// Exchanges the storage between lhs and rhs.
+        void(*swap)(storage_union& lhs, storage_union& rhs) noexcept;
+    };
+
+    /// VTable for dynamically allocated storage.
+    template<typename T>
+    struct vtable_dynamic
+    {
+        static const std::type_info& type() noexcept
+        {
+            return typeid(T);
+        }
+
+        static void destroy(storage_union& storage) noexcept
+        {
+            //assert(reinterpret_cast<T*>(storage.dynamic));
+            delete reinterpret_cast<T*>(storage.dynamic);
+        }
+
+        static void copy(const storage_union& src, storage_union& dest)
+        {
+            dest.dynamic = new T(*reinterpret_cast<const T*>(src.dynamic));
+        }
+
+        static void move(storage_union& src, storage_union& dest) noexcept
+        {
+            dest.dynamic = src.dynamic;
+            src.dynamic = nullptr;
+        }
+
+        static void swap(storage_union& lhs, storage_union& rhs) noexcept
+        {
+            // just exchage the storage pointers.
+            std::swap(lhs.dynamic, rhs.dynamic);
+        }
+    };
+
+    /// VTable for stack allocated storage.
+    template<typename T>
+    struct vtable_stack
+    {
+        static const std::type_info& type() noexcept
+        {
+            return typeid(T);
+        }
+
+        static void destroy(storage_union& storage) noexcept
+        {
+            reinterpret_cast<T*>(&storage.stack)->~T();
+        }
+
+        static void copy(const storage_union& src, storage_union& dest)
+        {
+            new (&dest.stack) T(reinterpret_cast<const T&>(src.stack));
+        }
+
+        static void move(storage_union& src, storage_union& dest) noexcept
+        {
+            // one of the conditions for using vtable_stack is a nothrow move constructor,
+            // so this move constructor will never throw a exception.
+            new (&dest.stack) T(std::move(reinterpret_cast<T&>(src.stack)));
+            destroy(src);
+        }
+
+        static void swap(storage_union& lhs, storage_union& rhs) noexcept
+        {
+            std::swap(reinterpret_cast<T&>(lhs.stack), reinterpret_cast<T&>(rhs.stack));
+        }
+    };
+
+    /// Whether the type T must be dynamically allocated or can be stored on the stack.
+    template<typename T>
+    struct requires_allocation :
+        std::integral_constant<bool,
+                !(std::is_nothrow_move_constructible<T>::value      // N4562 �6.3/3 [any.class]
+                  && sizeof(T) <= sizeof(storage_union::stack)
+                  && std::alignment_of<T>::value <= std::alignment_of<storage_union::stack_storage_t>::value)>
+    {};
+
+    /// Returns the pointer to the vtable of the type T.
+    template<typename T>
+    static vtable_type* vtable_for_type()
+    {
+        using VTableType = typename std::conditional<requires_allocation<T>::value, vtable_dynamic<T>, vtable_stack<T>>::type;
+        static vtable_type table = {
+            VTableType::type, VTableType::destroy,
+            VTableType::copy, VTableType::move,
+            VTableType::swap,
+        };
+        return &table;
+    }
+
+protected:
+    template<typename T>
+    friend const T* any_cast(const any* operand) noexcept;
+    template<typename T>
+    friend T* any_cast(any* operand) noexcept;
+
+    /// Same effect as is_same(this->type(), t);
+    bool is_typed(const std::type_info& t) const
+    {
+        return is_same(this->type(), t);
+    }
+
+    /// Checks if two type infos are the same.
+    ///
+    /// If ANY_IMPL_FAST_TYPE_INFO_COMPARE is defined, checks only the address of the
+    /// type infos, otherwise does an actual comparision. Checking addresses is
+    /// only a valid approach when there's no interaction with outside sources
+    /// (other shared libraries and such).
+    static bool is_same(const std::type_info& a, const std::type_info& b)
+    {
+#ifdef ANY_IMPL_FAST_TYPE_INFO_COMPARE
+        return &a == &b;
+#else
+        return a == b;
+#endif
+    }
+
+    /// Casts (with no type_info checks) the storage pointer as const T*.
+    template<typename T>
+    const T* cast() const noexcept
+    {
+        return requires_allocation<typename std::decay<T>::type>::value?
+            reinterpret_cast<const T*>(storage.dynamic) :
+            reinterpret_cast<const T*>(&storage.stack);
+    }
+
+    /// Casts (with no type_info checks) the storage pointer as T*.
+    template<typename T>
+    T* cast() noexcept
+    {
+        return requires_allocation<typename std::decay<T>::type>::value?
+            reinterpret_cast<T*>(storage.dynamic) :
+            reinterpret_cast<T*>(&storage.stack);
+    }
+
+private:
+    storage_union storage; // on offset(0) so no padding for align
+    vtable_type*  vtable;
+
+    template<typename ValueType, typename T>
+    typename std::enable_if<requires_allocation<T>::value>::type
+    do_construct(ValueType&& value)
+    {
+        storage.dynamic = new T(std::forward<ValueType>(value));
+    }
+
+    template<typename ValueType, typename T>
+    typename std::enable_if<!requires_allocation<T>::value>::type
+    do_construct(ValueType&& value)
+    {
+        new (&storage.stack) T(std::forward<ValueType>(value));
+    }
+
+    /// Chooses between stack and dynamic allocation for the type decay_t<ValueType>,
+    /// assigns the correct vtable, and constructs the object on our storage.
+    template<typename ValueType>
+    void construct(ValueType&& value)
+    {
+        using T = typename std::decay<ValueType>::type;
+
+        this->vtable = vtable_for_type<T>();
+
+        do_construct<ValueType,T>(std::forward<ValueType>(value));
+    }
+};
+
+
+
+namespace detail
+{
+    template<typename ValueType>
+    inline ValueType any_cast_move_if_true(typename std::remove_reference<ValueType>::type* p, std::true_type)
+    {
+        return std::move(*p);
+    }
+
+    template<typename ValueType>
+    inline ValueType any_cast_move_if_true(typename std::remove_reference<ValueType>::type* p, std::false_type)
+    {
+        return *p;
+    }
+}
+
+/// Performs *any_cast<add_const_t<remove_reference_t<ValueType>>>(&operand), or throws bad_any_cast on failure.
+template<typename ValueType>
+inline ValueType any_cast(const any& operand)
+{
+    auto p = any_cast<typename std::add_const<typename std::remove_reference<ValueType>::type>::type>(&operand);
+    if(p == nullptr) throw bad_any_cast();
+    return *p;
+}
+
+/// Performs *any_cast<remove_reference_t<ValueType>>(&operand), or throws bad_any_cast on failure.
+template<typename ValueType>
+inline ValueType any_cast(any& operand)
+{
+    auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
+    if(p == nullptr) throw bad_any_cast();
+    return *p;
+}
+
+///
+/// If ANY_IMPL_ANYCAST_MOVEABLE is not defined, does as N4562 specifies:
+///     Performs *any_cast<remove_reference_t<ValueType>>(&operand), or throws bad_any_cast on failure.
+///
+/// If ANY_IMPL_ANYCAST_MOVEABLE is defined, does as LWG Defect 2509 specifies:
+///     If ValueType is MoveConstructible and isn't a lvalue reference, performs
+///     std::move(*any_cast<remove_reference_t<ValueType>>(&operand)), otherwise
+///     *any_cast<remove_reference_t<ValueType>>(&operand). Throws bad_any_cast on failure.
+///
+template<typename ValueType>
+inline ValueType any_cast(any&& operand)
+{
+#ifdef ANY_IMPL_ANY_CAST_MOVEABLE
+    // https://cplusplus.github.io/LWG/lwg-active.html#2509
+    using can_move = std::integral_constant<bool,
+        std::is_move_constructible<ValueType>::value
+        && !std::is_lvalue_reference<ValueType>::value>;
+#else
+    using can_move = std::false_type;
+#endif
+
+    auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
+    if(p == nullptr) throw bad_any_cast();
+    return detail::any_cast_move_if_true<ValueType>(p, can_move());
+}
+
+/// If operand != nullptr && operand->type() == typeid(ValueType), a pointer to the object
+/// contained by operand, otherwise nullptr.
+template<typename T>
+inline const T* any_cast(const any* operand) noexcept
+{
+    if(operand == nullptr || !operand->is_typed(typeid(T)))
+        return nullptr;
+    else
+        return operand->cast<T>();
+}
+
+/// If operand != nullptr && operand->type() == typeid(ValueType), a pointer to the object
+/// contained by operand, otherwise nullptr.
+template<typename T>
+inline T* any_cast(any* operand) noexcept
+{
+    if(operand == nullptr || !operand->is_typed(typeid(T)))
+        return nullptr;
+    else
+        return operand->cast<T>();
+}
+
+}
+
+namespace std
+{
+    inline void swap(linb::any& lhs, linb::any& rhs) noexcept
+    {
+        lhs.swap(rhs);
+    }
+}
+
+#endif


### PR DESCRIPTION
Hi, 

this PR aims at bringing Iterative Closest Point (ICP) algorithm for registering two point clouds. 

It follows the general ICP idea with subsampling. Given two point sets T (target) and D (data), it computes the best rigid transformation (R,t) that maps the point cloud D on T. The general algorithm is summarized in theses steps : 

1.  Compute D', a subsampled version of the point cloud D 
2. For each point d in D' computes it's nearest point t in T 
3. Given the pairs (d,t) compute the best transformation that maps point cloud D' on T'
4. Compute err, the MSE projection err of D on T, if err is under a user defined threshold, the algorithm stops 
5. If err is less than the best error computed so far, update the final transformation 
6. repeat, starting at step 1. 

Notes :
- The subsampling in step 1 uses only 1/10 of the points in D is is obtained using uniform sampling.
- The algorithm stops either with step 5. or when a specified number of iteration is met. 
- The best transformation in step 3. is either computed using Point to Point metric or using point to normal metric (if available). 
- The step 2. is computed using libnabo ( https://github.com/ethz-asl/libnabo ) , I provide a slightly modified version of this library to remove the need of boost. 

Hope it helps. 