### PR TITLE
Speedup compilation times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,13 +65,13 @@ before_script:
       -DCMAKE_CXX_COMPILER=$COMPILER \
       -DCMAKE_BUILD_TYPE=release \
       -DOpenMVG_BUILD_TESTS=ON \
-      -DOpenMVG_BUILD_EXAMPLES=OFF \
-      -DOpenMVG_BUILD_SOFTWARES=OFF \
+      -DOpenMVG_BUILD_EXAMPLES=ON \
+      -DOpenMVG_BUILD_SOFTWARES=ON \
       -DSCHUR_SPECIALIZATIONS=OFF \
       . $OPENMVG_SOURCE
 
 script:
 # limit GCC builds to a reduced number of thread for the virtual machine
-  - make -j 2
+  - make all -j 2
   - make test
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -415,6 +415,8 @@ add_subdirectory(openMVG)
 set(OpenMVG_LIBRARIES
   openMVG_image
   openMVG_features
+  openMVG_geometry
+  openMVG_cameras
   openMVG_matching_image_collection
   openMVG_kvld
   openMVG_multiview

--- a/src/nonFree/sift/CMakeLists.txt
+++ b/src/nonFree/sift/CMakeLists.txt
@@ -25,7 +25,7 @@ set(FEATS
   vl/mathop.c
   vl/random.c)
 set_source_files_properties(${FEATS} PROPERTIES LANGUAGE C)
-add_library(vlsift ${FEATS})
+add_library(vlsift ${FEATS} SIFT_describer.cpp)
 install(TARGETS vlsift DESTINATION lib EXPORT openMVG-targets)
 set_property(TARGET vlsift PROPERTY FOLDER OpenMVG/nonFree)
 install(

--- a/src/nonFree/sift/SIFT_describer.cpp
+++ b/src/nonFree/sift/SIFT_describer.cpp
@@ -1,0 +1,214 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "nonFree/sift/SIFT_describer.hpp"
+#include "openMVG/features/descriptor.hpp"
+#include "openMVG/features/regions_factory.hpp"
+#include "openMVG/image/image_container.hpp"
+
+#include <cereal/cereal.hpp>
+
+//#include <algorithm>
+//#include <iostream>
+#include <numeric>
+
+extern "C" {
+#include "nonFree/sift/vl/sift.h"
+}
+
+namespace openMVG {
+namespace features {
+
+// Bibliography:
+// [1] R. Arandjelović, A. Zisserman.
+// Three things everyone should know to improve object retrieval. CVPR2012.
+
+inline void siftDescToUChar(
+  vl_sift_pix descr[128],
+  Descriptor<unsigned char,128> & descriptor,
+  bool brootSift = false)
+{
+  if (brootSift)  {
+    // rootsift = sqrt( sift / sum(sift) );
+    const float sum = std::accumulate(descr, descr+128, 0.0f);
+    for (int k=0;k<128;++k)
+      descriptor[k] = static_cast<unsigned char>(512.f*sqrt(descr[k]/sum));
+  }
+  else
+    for (int k=0;k<128;++k)
+    descriptor[k] = static_cast<unsigned char>(512.f*descr[k]);
+}
+
+SIFT_Image_describer::Params::Params(
+  int first_octave,
+  int num_octaves,
+  int num_scales,
+  float edge_threshold,
+  float peak_threshold,
+  bool root_sift
+):
+  _first_octave(first_octave),
+  _num_octaves(num_octaves),
+  _num_scales(num_scales),
+  _edge_threshold(edge_threshold),
+  _peak_threshold(peak_threshold),
+  _root_sift(root_sift)
+{
+}
+
+template<class Archive>
+void SIFT_Image_describer::Params::serialize( Archive & ar )
+{
+  ar(
+    cereal::make_nvp("first_octave", _first_octave),
+    cereal::make_nvp("num_octaves",_num_octaves),
+    cereal::make_nvp("num_scales",_num_scales),
+    cereal::make_nvp("edge_threshold",_edge_threshold),
+    cereal::make_nvp("peak_threshold",_peak_threshold),
+    cereal::make_nvp("root_sift",_root_sift));
+}
+
+SIFT_Image_describer::SIFT_Image_describer
+(
+  const Params params,
+  bool bOrientation
+):Image_describer(), _params(params), _bOrientation(bOrientation)
+{
+  vl_constructor();
+}
+
+SIFT_Image_describer::~SIFT_Image_describer()
+{
+  vl_destructor();
+}
+
+bool SIFT_Image_describer::Set_configuration_preset(EDESCRIBER_PRESET preset)
+{
+  switch(preset)
+  {
+  case NORMAL_PRESET:
+    _params._peak_threshold = 0.04f;
+  break;
+  case HIGH_PRESET:
+    _params._peak_threshold = 0.01f;
+  break;
+  case ULTRA_PRESET:
+    _params._peak_threshold = 0.01f;
+    _params._first_octave = -1;
+  break;
+  default:
+    return false;
+  }
+  return true;
+}
+
+bool SIFT_Image_describer::Describe
+(
+  const image::Image<unsigned char>& image,
+  std::unique_ptr<Regions> &regions,
+  const image::Image<unsigned char> * mask
+)
+{
+  const int w = image.Width(), h = image.Height();
+  //Convert to float
+  const image::Image<float> If(image.GetMat().cast<float>());
+
+  VlSiftFilt *filt = vl_sift_new(w, h,
+    _params._num_octaves, _params._num_scales, _params._first_octave);
+  if (_params._edge_threshold >= 0)
+    vl_sift_set_edge_thresh(filt, _params._edge_threshold);
+  if (_params._peak_threshold >= 0)
+    vl_sift_set_peak_thresh(filt, 255*_params._peak_threshold/_params._num_scales);
+
+  Descriptor<vl_sift_pix, 128> descr;
+  Descriptor<unsigned char, 128> descriptor;
+
+  // Process SIFT computation
+  vl_sift_process_first_octave(filt, If.data());
+
+  Allocate(regions);
+
+  // Build alias to cached data
+  SIFT_Regions * regionsCasted = dynamic_cast<SIFT_Regions*>(regions.get());
+  // reserve some memory for faster keypoint saving
+  regionsCasted->Features().reserve(2000);
+  regionsCasted->Descriptors().reserve(2000);
+
+  while (true) {
+    vl_sift_detect(filt);
+
+    VlSiftKeypoint const *keys  = vl_sift_get_keypoints(filt);
+    const int nkeys = vl_sift_get_nkeypoints(filt);
+
+    // Update gradient before launching parallel extraction
+    vl_sift_update_gradient(filt);
+
+    #ifdef OPENMVG_USE_OPENMP
+    #pragma omp parallel for private(descr, descriptor)
+    #endif
+    for (int i = 0; i < nkeys; ++i) {
+
+      // Feature masking
+      if (mask)
+      {
+        const image::Image<unsigned char> & maskIma = *mask;
+        if (maskIma(keys[i].y, keys[i].x) == 0)
+          continue;
+      }
+
+      double angles [4] = {0.0, 0.0, 0.0, 0.0};
+      int nangles = 1; // by default (1 upright feature)
+      if (_bOrientation)
+      { // compute from 1 to 4 orientations
+        nangles = vl_sift_calc_keypoint_orientations(filt, angles, keys+i);
+      }
+
+      for (int q=0 ; q < nangles ; ++q) {
+        vl_sift_calc_keypoint_descriptor(filt, &descr[0], keys+i, angles[q]);
+        const SIOPointFeature fp(keys[i].x, keys[i].y,
+          keys[i].sigma, static_cast<float>(angles[q]));
+
+        siftDescToUChar(&descr[0], descriptor, _params._root_sift);
+        #ifdef OPENMVG_USE_OPENMP
+        #pragma omp critical
+        #endif
+        {
+          regionsCasted->Descriptors().push_back(descriptor);
+          regionsCasted->Features().push_back(fp);
+        }
+      }
+    }
+    if (vl_sift_process_next_octave(filt))
+      break; // Last octave
+  }
+  vl_sift_delete(filt);
+
+  return true;
+}
+
+/// Allocate Regions type depending of the Image_describer
+void SIFT_Image_describer::Allocate(std::unique_ptr<Regions> &regions) const
+{
+  regions.reset( new SIFT_Regions );
+}
+
+template<class Archive>
+void SIFT_Image_describer::serialize( Archive & ar )
+{
+  ar(
+   cereal::make_nvp("params", _params),
+   cereal::make_nvp("bOrientation", _bOrientation));
+}
+
+} // namespace features
+} // namespace openMVG
+
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/archives/json.hpp>
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Image_describer, "SIFT_Image_describer");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::SIFT_Image_describer)

--- a/src/nonFree/sift/SIFT_describer.hpp
+++ b/src/nonFree/sift/SIFT_describer.hpp
@@ -10,16 +10,6 @@
 #define OPENMVG_PATENTED_SIFT_SIFT_DESCRIBER_HPP
 
 #include "openMVG/features/image_describer.hpp"
-#include "openMVG/features/regions_factory.hpp"
-#include "openMVG/image/image_container.hpp"
-
-#include <algorithm>
-#include <iostream>
-#include <numeric>
-
-extern "C" {
-#include "nonFree/sift/vl/sift.h"
-}
 
 namespace openMVG {
 namespace features {
@@ -27,22 +17,6 @@ namespace features {
 // Bibliography:
 // [1] R. Arandjelović, A. Zisserman.
 // Three things everyone should know to improve object retrieval. CVPR2012.
-
-inline void siftDescToUChar(
-  vl_sift_pix descr[128],
-  Descriptor<unsigned char,128> & descriptor,
-  bool brootSift = false)
-{
-  if (brootSift)  {
-    // rootsift = sqrt( sift / sum(sift) );
-    const float sum = std::accumulate(descr, descr+128, 0.0f);
-    for (int k=0;k<128;++k)
-      descriptor[k] = static_cast<unsigned char>(512.f*sqrt(descr[k]/sum));
-  }
-  else
-    for (int k=0;k<128;++k)
-    descriptor[k] = static_cast<unsigned char>(512.f*descr[k]);
-}
 
 class SIFT_Image_describer : public Image_describer
 {
@@ -57,25 +31,10 @@ public:
       float edge_threshold = 10.0f,
       float peak_threshold = 0.04f,
       bool root_sift = true
-    ):
-      _first_octave(first_octave),
-      _num_octaves(num_octaves),
-      _num_scales(num_scales),
-      _edge_threshold(edge_threshold),
-      _peak_threshold(peak_threshold),
-      _root_sift(root_sift) {}
+    );
 
     template<class Archive>
-    void serialize( Archive & ar )
-    {
-      ar(
-        cereal::make_nvp("first_octave", _first_octave),
-        cereal::make_nvp("num_octaves",_num_octaves),
-        cereal::make_nvp("num_scales",_num_scales),
-        cereal::make_nvp("edge_threshold",_edge_threshold),
-        cereal::make_nvp("peak_threshold",_peak_threshold),
-        cereal::make_nvp("root_sift",_root_sift));
-    }
+    void serialize( Archive & ar );
 
     // Parameters
     int _first_octave;      // Use original image, or perform an upscale if == -1
@@ -93,35 +52,11 @@ public:
   (
     const Params params = Params(),
     bool bOrientation = true
-  ):Image_describer(), _params(params), _bOrientation(bOrientation)
-  {
-    vl_constructor();
-  }
+  );
 
-  ~SIFT_Image_describer()
-  {
-    vl_destructor();
-  }
+  ~SIFT_Image_describer();
 
-  bool Set_configuration_preset(EDESCRIBER_PRESET preset) override
-  {
-    switch(preset)
-    {
-    case NORMAL_PRESET:
-      _params._peak_threshold = 0.04f;
-    break;
-    case HIGH_PRESET:
-      _params._peak_threshold = 0.01f;
-    break;
-    case ULTRA_PRESET:
-      _params._peak_threshold = 0.01f;
-      _params._first_octave = -1;
-    break;
-    default:
-      return false;
-    }
-    return true;
-  }
+  bool Set_configuration_preset(EDESCRIBER_PRESET preset) override;
 
   /**
   @brief Detect regions on the image and compute their attributes (description)
@@ -135,98 +70,13 @@ public:
     const image::Image<unsigned char>& image,
     std::unique_ptr<Regions> &regions,
     const image::Image<unsigned char> * mask = nullptr
-  ) override
-  {
-    const int w = image.Width(), h = image.Height();
-    //Convert to float
-    const image::Image<float> If(image.GetMat().cast<float>());
-
-    VlSiftFilt *filt = vl_sift_new(w, h,
-      _params._num_octaves, _params._num_scales, _params._first_octave);
-    if (_params._edge_threshold >= 0)
-      vl_sift_set_edge_thresh(filt, _params._edge_threshold);
-    if (_params._peak_threshold >= 0)
-      vl_sift_set_peak_thresh(filt, 255*_params._peak_threshold/_params._num_scales);
-
-    Descriptor<vl_sift_pix, 128> descr;
-    Descriptor<unsigned char, 128> descriptor;
-
-    // Process SIFT computation
-    vl_sift_process_first_octave(filt, If.data());
-
-    Allocate(regions);
-
-    // Build alias to cached data
-    SIFT_Regions * regionsCasted = dynamic_cast<SIFT_Regions*>(regions.get());
-    // reserve some memory for faster keypoint saving
-    regionsCasted->Features().reserve(2000);
-    regionsCasted->Descriptors().reserve(2000);
-
-    while (true) {
-      vl_sift_detect(filt);
-
-      VlSiftKeypoint const *keys  = vl_sift_get_keypoints(filt);
-      const int nkeys = vl_sift_get_nkeypoints(filt);
-
-      // Update gradient before launching parallel extraction
-      vl_sift_update_gradient(filt);
-
-      #ifdef OPENMVG_USE_OPENMP
-      #pragma omp parallel for private(descr, descriptor)
-      #endif
-      for (int i = 0; i < nkeys; ++i) {
-
-        // Feature masking
-        if (mask)
-        {
-          const image::Image<unsigned char> & maskIma = *mask;
-          if (maskIma(keys[i].y, keys[i].x) == 0)
-            continue;
-        }
-
-        double angles [4] = {0.0, 0.0, 0.0, 0.0};
-        int nangles = 1; // by default (1 upright feature)
-        if (_bOrientation)
-        { // compute from 1 to 4 orientations
-          nangles = vl_sift_calc_keypoint_orientations(filt, angles, keys+i);
-        }
-
-        for (int q=0 ; q < nangles ; ++q) {
-          vl_sift_calc_keypoint_descriptor(filt, &descr[0], keys+i, angles[q]);
-          const SIOPointFeature fp(keys[i].x, keys[i].y,
-            keys[i].sigma, static_cast<float>(angles[q]));
-
-          siftDescToUChar(&descr[0], descriptor, _params._root_sift);
-          #ifdef OPENMVG_USE_OPENMP
-          #pragma omp critical
-          #endif
-          {
-            regionsCasted->Descriptors().push_back(descriptor);
-            regionsCasted->Features().push_back(fp);
-          }
-        }
-      }
-      if (vl_sift_process_next_octave(filt))
-        break; // Last octave
-    }
-    vl_sift_delete(filt);
-
-    return true;
-  };
+  ) override;
 
   /// Allocate Regions type depending of the Image_describer
-  void Allocate(std::unique_ptr<Regions> &regions) const override
-  {
-    regions.reset( new SIFT_Regions );
-  }
+  void Allocate(std::unique_ptr<Regions> &regions) const override;
 
   template<class Archive>
-  void serialize( Archive & ar )
-  {
-    ar(
-     cereal::make_nvp("params", _params),
-     cereal::make_nvp("bOrientation", _bOrientation));
-  }
+  void serialize( Archive & ar );
 
 private:
   Params _params;
@@ -235,10 +85,5 @@ private:
 
 } // namespace features
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/archives/json.hpp>
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Image_describer, "SIFT_Image_describer");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::SIFT_Image_describer)
 
 #endif // OPENMVG_PATENTED_SIFT_SIFT_DESCRIBER_HPP

--- a/src/openMVG/cameras/CMakeLists.txt
+++ b/src/openMVG/cameras/CMakeLists.txt
@@ -1,14 +1,35 @@
 
-UNIT_TEST(openMVG Camera_IO "openMVG_multiview;stlplus;openMVG_geometry")
+file(
+  GLOB_RECURSE
+  cameras_files_header
+  *.hpp
+)
+file(
+  GLOB_RECURSE
+  cameras_files_cpp
+  *.cpp
+)
+file(GLOB_RECURSE REMOVEFILESUNITTEST *_test.cpp)
+#Remove the future main files
+list(REMOVE_ITEM cameras_files_cpp ${REMOVEFILESUNITTEST})
 
-UNIT_TEST(openMVG Camera_Pinhole "openMVG_multiview;openMVG_geometry")
+add_library(openMVG_cameras ${cameras_files_header} ${cameras_files_cpp})
+set_target_properties(openMVG_cameras PROPERTIES SOVERSION ${OPENMVG_VERSION_MAJOR} VERSION "${OPENMVG_VERSION_MAJOR}.${OPENMVG_VERSION_MINOR}")
 
-UNIT_TEST(openMVG Camera_Pinhole_Radial "openMVG_multiview;openMVG_geometry")
+target_link_libraries(openMVG_cameras openMVG_multiview openMVG_geometry)
 
-UNIT_TEST(openMVG Camera_Pinhole_Brown "openMVG_multiview;openMVG_geometry")
+install(TARGETS openMVG_cameras DESTINATION lib EXPORT openMVG-targets)
 
-UNIT_TEST(openMVG Camera_Pinhole_Fisheye "openMVG_multiview;openMVG_geometry")
+UNIT_TEST(openMVG Camera_IO "stlplus;openMVG_cameras")
 
-UNIT_TEST(openMVG Camera_Spherical "openMVG_multiview;openMVG_geometry")
+UNIT_TEST(openMVG Camera_Pinhole "openMVG_cameras")
 
-UNIT_TEST(openMVG Camera_Subset_Parametrization "openMVG_multiview;openMVG_geometry")
+UNIT_TEST(openMVG Camera_Pinhole_Radial "openMVG_cameras")
+
+UNIT_TEST(openMVG Camera_Pinhole_Brown "openMVG_cameras")
+
+UNIT_TEST(openMVG Camera_Pinhole_Fisheye "openMVG_cameras")
+
+UNIT_TEST(openMVG Camera_Spherical "openMVG_cameras")
+
+UNIT_TEST(openMVG Camera_Subset_Parametrization "openMVG_cameras")

--- a/src/openMVG/cameras/CMakeLists.txt
+++ b/src/openMVG/cameras/CMakeLists.txt
@@ -1,14 +1,14 @@
 
-UNIT_TEST(openMVG Camera_IO "openMVG_multiview;stlplus")
+UNIT_TEST(openMVG Camera_IO "openMVG_multiview;stlplus;openMVG_geometry")
 
-UNIT_TEST(openMVG Camera_Pinhole "openMVG_multiview")
+UNIT_TEST(openMVG Camera_Pinhole "openMVG_multiview;openMVG_geometry")
 
-UNIT_TEST(openMVG Camera_Pinhole_Radial "openMVG_multiview")
+UNIT_TEST(openMVG Camera_Pinhole_Radial "openMVG_multiview;openMVG_geometry")
 
-UNIT_TEST(openMVG Camera_Pinhole_Brown "openMVG_multiview")
+UNIT_TEST(openMVG Camera_Pinhole_Brown "openMVG_multiview;openMVG_geometry")
 
-UNIT_TEST(openMVG Camera_Pinhole_Fisheye "openMVG_multiview")
+UNIT_TEST(openMVG Camera_Pinhole_Fisheye "openMVG_multiview;openMVG_geometry")
 
-UNIT_TEST(openMVG Camera_Spherical "openMVG_multiview")
+UNIT_TEST(openMVG Camera_Spherical "openMVG_multiview;openMVG_geometry")
 
-UNIT_TEST(openMVG Camera_Subset_Parametrization "openMVG_multiview")
+UNIT_TEST(openMVG Camera_Subset_Parametrization "openMVG_multiview;openMVG_geometry")

--- a/src/openMVG/cameras/Camera_IO.hpp
+++ b/src/openMVG/cameras/Camera_IO.hpp
@@ -9,13 +9,7 @@
 #ifndef OPENMVG_CAMERAS_CAMERA_IO_HPP
 #define OPENMVG_CAMERAS_CAMERA_IO_HPP
 
-#include <fstream>
-#include <iostream>
-#include <string>
-#include <vector>
-
 #include "openMVG/cameras/PinholeCamera.hpp"
-#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 namespace openMVG
 {
@@ -30,23 +24,9 @@ namespace cameras
 * @retval true If write is correct
 * @retval false If there was an error during export
 */
-static bool save(
+bool save(
   const std::string & scameraFile,
-  const PinholeCamera & cam )
-{
-  if ( stlplus::extension_part( scameraFile ) != "bin" )
-  {
-    return false;
-  }
-
-  const Mat34 & PMat = cam._P;
-  std::ofstream file( scameraFile.c_str(), std::ios::out | std::ios::binary );
-  file.write( ( const char* )PMat.data(), ( std::streamsize )( 3 * 4 )*sizeof( double ) );
-
-  const bool bOk = ( !file.fail() );
-  file.close();
-  return bOk;
-}
+  const PinholeCamera & cam );
 
 
 /**
@@ -56,48 +36,9 @@ static bool save(
 * @retval true If loading is correct
 * @retval false If there was an error during loading
 */
-static bool load(
+bool load(
   const std::string & scameraFile,
-  PinholeCamera & cam )
-{
-  std::vector<double> val;
-
-  if ( stlplus::extension_part( scameraFile ) == "bin" )
-  {
-    std::ifstream in( scameraFile.c_str(), std::ios::in | std::ios::binary );
-    if ( !in.is_open() )
-    {
-      std::cerr << "Error: failed to open file '" << scameraFile
-                << "' for reading" << std::endl;
-      return false;
-    }
-    val.resize(12);
-    in.read(reinterpret_cast<char*>(&val[0]),(std::streamsize)12*sizeof(double));
-    if (in.fail())
-    {
-      val.clear();
-    }
-  }
-  else
-  {
-    return false;
-  }
-
-  if ( val.size() == 3 * 4 ) //P Matrix
-  {
-    Mat34 P;
-    P << val[0], val[3], val[6], val[9],
-    val[1], val[4], val[7], val[10],
-    val[2], val[5], val[8], val[11];
-
-    Mat3 R, K;
-    Vec3 t;
-    KRt_From_P( P, &K, &R, &t );
-    cam = PinholeCamera( K, R, t );
-    return true;
-  }
-  return false;
-}
+  PinholeCamera & cam );
 
 } // namespace cameras
 } // namespace openMVG

--- a/src/openMVG/cameras/Camera_IO_test.cpp
+++ b/src/openMVG/cameras/Camera_IO_test.cpp
@@ -7,10 +7,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "openMVG/cameras/Camera_IO.hpp"
-
 #include "openMVG/cameras/cameras.hpp"
+
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
 #include <cereal/archives/json.hpp>
+#include <cereal/types/polymorphic.hpp>
 #include <cereal/cereal.hpp>
+
+#include <fstream>
 
 using namespace openMVG;
 using namespace openMVG::cameras;

--- a/src/openMVG/cameras/Camera_Intrinsics.cpp
+++ b/src/openMVG/cameras/Camera_Intrinsics.cpp
@@ -101,3 +101,25 @@ template void IntrinsicBase::save<class cereal::PortableBinaryOutputArchive>(cla
 
 } // namespace cameras
 } // namespace openMVG
+
+#include "openMVG/cameras/cameras.hpp"
+
+bool openMVG::cameras::IntrinsicBase::registerCameraTypes()
+{
+  // Force dynamic inititalization of cameras.
+  // See http://uscilab.github.io/cereal/polymorphism.html#registering-from-a-source-file
+  //
+  // "Be careful that there are special considerations to make for placing registration in 
+  // a source file, especially if you will not be explicitly referencing anything within
+  // that source file."
+
+  openMVG::cameras::Pinhole_Intrinsic p1;
+  openMVG::cameras::Pinhole_Intrinsic_Brown_T2 p2;
+  openMVG::cameras::Pinhole_Intrinsic_Fisheye p3;
+  openMVG::cameras::Pinhole_Intrinsic_Radial_K1 p4;
+  openMVG::cameras::Pinhole_Intrinsic_Radial_K3 p5;
+  openMVG::cameras::Intrinsic_Spherical p6;
+  static_assert(openMVG::cameras::PINHOLE_CAMERA_END==6, 
+    "If you've added a camera type, you need to initialize it here.");
+  return true;
+}

--- a/src/openMVG/cameras/Camera_Intrinsics.cpp
+++ b/src/openMVG/cameras/Camera_Intrinsics.cpp
@@ -1,0 +1,103 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/cameras/Camera_Intrinsics.hpp"
+#include "openMVG/stl/hash.hpp"
+#include "openMVG/numeric/numeric.h"
+
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
+namespace openMVG
+{
+namespace cameras
+{
+
+Vec2 IntrinsicBase::project(
+  const geometry::Pose3 & pose,
+  const Vec3 & pt3D ) const
+{
+  const Vec3 X = pose( pt3D ); // apply pose
+  if ( this->have_disto() ) // apply disto & intrinsics
+  {
+    return this->cam2ima( this->add_disto( X.hnormalized() ) );
+  }
+  else // apply intrinsics
+  {
+    return this->cam2ima( X.hnormalized() );
+  }
+}
+
+Vec2 IntrinsicBase::residual(
+  const geometry::Pose3 & pose,
+  const Vec3 & X,
+  const Vec2 & x ) const
+{
+  const Vec2 proj = this->project( pose, X );
+  return x - proj;
+}
+
+template <class Archive>
+void IntrinsicBase::save( Archive & ar ) const
+{
+  ar( cereal::make_nvp( "width", w_ ) );
+  ar( cereal::make_nvp( "height", h_ ) );
+}
+
+template <class Archive>
+void IntrinsicBase::load( Archive & ar )
+{
+  ar( cereal::make_nvp( "width", w_ ) );
+  ar( cereal::make_nvp( "height", h_ ) );
+}
+
+std::size_t IntrinsicBase::hashValue() const
+{
+  size_t seed = 0;
+  stl::hash_combine( seed, static_cast<int>( this->getType() ) );
+  stl::hash_combine( seed, w_ );
+  stl::hash_combine( seed, h_ );
+  const std::vector<double> params = this->getParams();
+  for ( const auto & param : params )
+    stl::hash_combine( seed , param );
+  return seed;
+}
+
+
+double AngleBetweenRay(
+  const geometry::Pose3 & pose1,
+  const IntrinsicBase * intrinsic1,
+  const geometry::Pose3 & pose2,
+  const IntrinsicBase * intrinsic2,
+  const Vec2 & x1, const Vec2 & x2 )
+{
+  // x = (u, v, 1.0)  // image coordinates
+  // X = R.t() * K.inv() * x + C // Camera world point
+  // getting the ray:
+  // ray = X - C = R.t() * K.inv() * x
+  const Vec3 ray1 = ( pose1.rotation().transpose() * intrinsic1->operator()( x1 ) ).normalized();
+  const Vec3 ray2 = ( pose2.rotation().transpose() * intrinsic2->operator()( x2 ) ).normalized();
+  const double mag = ray1.norm() * ray2.norm();
+  const double dotAngle = ray1.dot( ray2 );
+  return R2D( acos( clamp( dotAngle / mag, -1.0 + 1.e-8, 1.0 - 1.e-8 ) ) );
+}
+
+
+template void IntrinsicBase::load<class cereal::XMLInputArchive>(class cereal::XMLInputArchive &);
+template void IntrinsicBase::save<class cereal::XMLOutputArchive>(class cereal::XMLOutputArchive &) const;
+template void IntrinsicBase::load<class cereal::JSONInputArchive>(class cereal::JSONInputArchive &);
+template void IntrinsicBase::save<class cereal::JSONOutputArchive>(class cereal::JSONOutputArchive &) const;
+template void IntrinsicBase::load<class cereal::BinaryInputArchive>(class cereal::BinaryInputArchive &);
+template void IntrinsicBase::save<class cereal::BinaryOutputArchive>(class cereal::BinaryOutputArchive &)const;
+template void IntrinsicBase::load<class cereal::PortableBinaryInputArchive>(class cereal::PortableBinaryInputArchive &);
+template void IntrinsicBase::save<class cereal::PortableBinaryOutputArchive>(class cereal::PortableBinaryOutputArchive &) const;
+
+} // namespace cameras
+} // namespace openMVG

--- a/src/openMVG/cameras/Camera_Intrinsics.hpp
+++ b/src/openMVG/cameras/Camera_Intrinsics.hpp
@@ -13,10 +13,6 @@
 
 #include "openMVG/cameras/Camera_Common.hpp"
 #include "openMVG/geometry/pose3.hpp"
-#include "openMVG/numeric/numeric.h"
-#include "openMVG/stl/hash.hpp"
-
-#include <cereal/types/polymorphic.hpp>
 
 namespace openMVG
 {
@@ -86,18 +82,7 @@ struct IntrinsicBase : public Clonable<IntrinsicBase>
   */
   virtual Vec2 project(
     const geometry::Pose3 & pose,
-    const Vec3 & pt3D ) const
-  {
-    const Vec3 X = pose( pt3D ); // apply pose
-    if ( this->have_disto() ) // apply disto & intrinsics
-    {
-      return this->cam2ima( this->add_disto( X.hnormalized() ) );
-    }
-    else // apply intrinsics
-    {
-      return this->cam2ima( X.hnormalized() );
-    }
-  }
+    const Vec3 & pt3D ) const;
 
   /**
   * @brief Compute the residual between the 3D projected point and an image observation
@@ -109,11 +94,7 @@ struct IntrinsicBase : public Clonable<IntrinsicBase>
   Vec2 residual(
     const geometry::Pose3 & pose,
     const Vec3 & X,
-    const Vec2 & x ) const
-  {
-    const Vec2 proj = this->project( pose, X );
-    return x - proj;
-  }
+    const Vec2 & x ) const;
 
   // --
   // Virtual members
@@ -223,38 +204,20 @@ struct IntrinsicBase : public Clonable<IntrinsicBase>
   * @param ar Archive
   */
   template <class Archive>
-  void save( Archive & ar ) const
-  {
-    ar( cereal::make_nvp( "width", w_ ) );
-    ar( cereal::make_nvp( "height", h_ ) );
-  }
+  void save( Archive & ar ) const;
 
   /**
   * @brief  Serialization in
   * @param ar Archive
   */
   template <class Archive>
-  void load( Archive & ar )
-  {
-    ar( cereal::make_nvp( "width", w_ ) );
-    ar( cereal::make_nvp( "height", h_ ) );
-  }
+  void load( Archive & ar );
 
   /**
   * @brief Generate a unique Hash from the camera parameters (used for grouping)
   * @return Hash value
   */
-  virtual std::size_t hashValue() const
-  {
-    size_t seed = 0;
-    stl::hash_combine( seed, static_cast<int>( this->getType() ) );
-    stl::hash_combine( seed, w_ );
-    stl::hash_combine( seed, h_ );
-    const std::vector<double> params = this->getParams();
-    for ( const auto & param : params )
-      stl::hash_combine( seed , param );
-    return seed;
-  }
+  virtual std::size_t hashValue() const;
 };
 
 
@@ -271,23 +234,12 @@ struct IntrinsicBase : public Clonable<IntrinsicBase>
 *
 * @return Angle (in degree) between the two rays
 */
-inline double AngleBetweenRay(
+double AngleBetweenRay(
   const geometry::Pose3 & pose1,
   const IntrinsicBase * intrinsic1,
   const geometry::Pose3 & pose2,
   const IntrinsicBase * intrinsic2,
-  const Vec2 & x1, const Vec2 & x2 )
-{
-  // x = (u, v, 1.0)  // image coordinates
-  // X = R.t() * K.inv() * x + C // Camera world point
-  // getting the ray:
-  // ray = X - C = R.t() * K.inv() * x
-  const Vec3 ray1 = ( pose1.rotation().transpose() * intrinsic1->operator()( x1 ) ).normalized();
-  const Vec3 ray2 = ( pose2.rotation().transpose() * intrinsic2->operator()( x2 ) ).normalized();
-  const double mag = ray1.norm() * ray2.norm();
-  const double dotAngle = ray1.dot( ray2 );
-  return R2D( acos( clamp( dotAngle / mag, -1.0 + 1.e-8, 1.0 - 1.e-8 ) ) );
-}
+  const Vec2 & x1, const Vec2 & x2 );
 
 } // namespace cameras
 } // namespace openMVG

--- a/src/openMVG/cameras/Camera_Intrinsics.hpp
+++ b/src/openMVG/cameras/Camera_Intrinsics.hpp
@@ -218,6 +218,12 @@ struct IntrinsicBase : public Clonable<IntrinsicBase>
   * @return Hash value
   */
   virtual std::size_t hashValue() const;
+
+  /**
+  * @brief This funcion has to be called when cameras is compiled as a static library.
+  * @return true
+  */
+  static bool registerCameraTypes();
 };
 
 

--- a/src/openMVG/cameras/Camera_Pinhole.cpp
+++ b/src/openMVG/cameras/Camera_Pinhole.cpp
@@ -1,0 +1,197 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/cameras/Camera_Pinhole.hpp"
+#include "openMVG/multiview/projection.hpp"
+
+#include <cereal/types/vector.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
+namespace openMVG
+{
+namespace cameras
+{
+
+Pinhole_Intrinsic::Pinhole_Intrinsic(
+  unsigned int w,
+  unsigned int h,
+  double focal_length_pix,
+  double ppx,
+  double ppy )
+  : IntrinsicBase( w, h )
+{
+  K_ << focal_length_pix, 0., ppx, 0., focal_length_pix, ppy, 0., 0., 1.;
+  Kinv_ = K_.inverse();
+}
+
+Pinhole_Intrinsic::Pinhole_Intrinsic(
+  unsigned int w,
+  unsigned int h,
+  const Mat3& K)
+  : IntrinsicBase( w, h ), K_(K)
+{
+  K_(0,0) = K_(1,1) = (K(0,0) + K(1,1)) / 2.0;
+  Kinv_ = K_.inverse();
+}
+
+EINTRINSIC Pinhole_Intrinsic::getType() const
+{
+  return PINHOLE_CAMERA;
+}
+
+const Mat3& Pinhole_Intrinsic::K() const
+{
+  return K_;
+}
+
+const Mat3& Pinhole_Intrinsic::Kinv() const
+{
+  return Kinv_;
+}
+
+double Pinhole_Intrinsic::focal() const
+{
+  return K_( 0, 0 );
+}
+
+Vec2 Pinhole_Intrinsic::principal_point() const
+{
+  return Vec2( K_( 0, 2 ), K_( 1, 2 ) );
+}
+
+Vec3 Pinhole_Intrinsic::operator () ( const Vec2& p ) const
+{
+  return (Kinv_ * p.homogeneous()).normalized();
+}
+
+Vec2 Pinhole_Intrinsic::cam2ima( const Vec2& p ) const
+{
+  return focal() * p + principal_point();
+}
+
+Vec2 Pinhole_Intrinsic::ima2cam( const Vec2& p ) const
+{
+  return ( p -  principal_point() ) / focal();
+}
+
+bool Pinhole_Intrinsic::have_disto() const
+{
+  return false;
+}
+
+Vec2 Pinhole_Intrinsic::add_disto( const Vec2& p ) const
+{
+  return p;
+}
+
+Vec2 Pinhole_Intrinsic::remove_disto( const Vec2& p ) const
+{
+  return p;
+}
+
+double Pinhole_Intrinsic::imagePlane_toCameraPlaneError( double value ) const
+{
+  return value / focal();
+}
+
+Mat34 Pinhole_Intrinsic::get_projective_equivalent( const geometry::Pose3 & pose ) const
+{
+  Mat34 P;
+  P_From_KRt( K(), pose.rotation(), pose.translation(), &P );
+  return P;
+}
+
+std::vector<double> Pinhole_Intrinsic::getParams() const
+{
+  return  { K_(0, 0), K_(0, 2), K_(1, 2) };
+}
+
+bool Pinhole_Intrinsic::updateFromParams(const std::vector<double> & params)
+{
+  if ( params.size() == 3 )
+  {
+    *this = Pinhole_Intrinsic( w_, h_, params[0], params[1], params[2] );
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+std::vector<int> Pinhole_Intrinsic::subsetParameterization
+(
+  const Intrinsic_Parameter_Type & parametrization) const
+{
+  std::vector<int> constant_index;
+  const int param = static_cast<int>(parametrization);
+  if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_FOCAL_LENGTH)
+       || param & (int)Intrinsic_Parameter_Type::NONE )
+  {
+    constant_index.push_back(0);
+  }
+  if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_PRINCIPAL_POINT)
+      || param & (int)Intrinsic_Parameter_Type::NONE )
+  {
+    constant_index.push_back(1);
+    constant_index.push_back(2);
+  }
+  return constant_index;
+}
+
+Vec2 Pinhole_Intrinsic::get_ud_pixel( const Vec2& p ) const
+{
+  return p;
+}
+
+Vec2 Pinhole_Intrinsic::get_d_pixel( const Vec2& p ) const
+{
+  return p;
+}
+
+template <class Archive>
+void Pinhole_Intrinsic::save( Archive & ar ) const
+{
+  IntrinsicBase::save(ar);
+  ar( cereal::make_nvp( "focal_length", K_( 0, 0 ) ) );
+  const std::vector<double> pp = {K_( 0, 2 ), K_( 1, 2 )};
+  ar( cereal::make_nvp( "principal_point", pp ) );
+}
+
+
+template <class Archive>
+void Pinhole_Intrinsic::load( Archive & ar )
+{
+  IntrinsicBase::load(ar);
+  double focal_length;
+  ar( cereal::make_nvp( "focal_length", focal_length ) );
+  std::vector<double> pp( 2 );
+  ar( cereal::make_nvp( "principal_point", pp ) );
+  *this = Pinhole_Intrinsic( w_, h_, focal_length, pp[0], pp[1] );
+}
+
+IntrinsicBase * Pinhole_Intrinsic::clone( void ) const
+{
+  return new class_type( *this );
+}
+
+template void Pinhole_Intrinsic::load<cereal::JSONInputArchive>(class cereal::JSONInputArchive &);
+template void Pinhole_Intrinsic::save<cereal::JSONOutputArchive>(class cereal::JSONOutputArchive &)const;
+template void Pinhole_Intrinsic::load<cereal::XMLInputArchive>(class cereal::XMLInputArchive &);
+template void Pinhole_Intrinsic::save<cereal::XMLOutputArchive>(class cereal::XMLOutputArchive &)const;
+template void Pinhole_Intrinsic::load<cereal::PortableBinaryInputArchive>(class cereal::PortableBinaryInputArchive &);
+template void Pinhole_Intrinsic::save<cereal::PortableBinaryOutputArchive>(class cereal::PortableBinaryOutputArchive &)const;
+
+} // namespace cameras
+} // namespace openMVG
+
+#include <cereal/types/polymorphic.hpp>
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic, "pinhole");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic);

--- a/src/openMVG/cameras/Camera_Pinhole.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole.hpp
@@ -15,6 +15,7 @@
 #include "openMVG/cameras/Camera_Intrinsics.hpp"
 #include "openMVG/geometry/pose3.hpp"
 #include "openMVG/numeric/eigen_alias_definition.hpp"
+#include "openMVG/multiview/projection.hpp"
 
 namespace openMVG
 {

--- a/src/openMVG/cameras/Camera_Pinhole_Brown.cpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Brown.cpp
@@ -1,0 +1,169 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Sida Li, Pierre Moulon.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/cameras/Camera_Pinhole_Brown.hpp"
+
+#include <cereal/types/vector.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
+namespace openMVG
+{
+namespace cameras
+{
+
+Pinhole_Intrinsic_Brown_T2::Pinhole_Intrinsic_Brown_T2(
+  int w,  int h,
+  double focal, double ppx, double ppy,
+  double k1, double k2, double k3,
+  double t1, double t2 )
+  : Pinhole_Intrinsic( w, h, focal, ppx, ppy )
+{
+  params_ = {k1, k2, k3, t1, t2};
+}
+
+EINTRINSIC Pinhole_Intrinsic_Brown_T2::getType() const
+{
+  return PINHOLE_CAMERA_BROWN;
+}
+
+bool Pinhole_Intrinsic_Brown_T2::have_disto() const
+{
+  return true;
+}
+
+Vec2 Pinhole_Intrinsic_Brown_T2::add_disto( const Vec2 & p ) const
+{
+  return ( p + distoFunction( params_, p ) );
+}
+
+Vec2 Pinhole_Intrinsic_Brown_T2::remove_disto( const Vec2 & p ) const
+{
+  const double epsilon = 1e-10; //criteria to stop the iteration
+  Vec2 p_u = p;
+
+  Vec2 d = distoFunction(params_, p_u);
+  while ((p_u + d - p).lpNorm<1>() > epsilon) //manhattan distance between the two points
+  {
+    p_u = p - d;
+    d = distoFunction(params_, p_u);
+  }
+
+  return p_u;
+}
+
+std::vector<double> Pinhole_Intrinsic_Brown_T2::getParams() const
+{
+  std::vector<double> params = Pinhole_Intrinsic::getParams();
+  params.insert(params.end(), std::begin(params_), std::end(params_));
+  return params;
+}
+
+bool Pinhole_Intrinsic_Brown_T2::updateFromParams( const std::vector<double> & params )
+{
+  if ( params.size() == 8 )
+  {
+    *this = Pinhole_Intrinsic_Brown_T2(
+              w_, h_,
+              params[0], params[1], params[2], // focal, ppx, ppy
+              params[3], params[4], params[5], // K1, K2, K3
+              params[6], params[7] );          // T1, T2
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+std::vector<int> Pinhole_Intrinsic_Brown_T2::subsetParameterization
+(
+  const Intrinsic_Parameter_Type & parametrization) const
+{
+  std::vector<int> constant_index;
+  const int param = static_cast<int>(parametrization);
+  if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_FOCAL_LENGTH)
+      || param & (int)Intrinsic_Parameter_Type::NONE )
+  {
+    constant_index.push_back(0);
+  }
+  if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_PRINCIPAL_POINT)
+      || param & (int)Intrinsic_Parameter_Type::NONE )
+  {
+    constant_index.push_back(1);
+    constant_index.push_back(2);
+  }
+  if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_DISTORTION)
+      || param & (int)Intrinsic_Parameter_Type::NONE )
+  {
+    constant_index.push_back(3);
+    constant_index.push_back(4);
+    constant_index.push_back(5);
+    constant_index.push_back(6);
+    constant_index.push_back(7);
+  }
+  return constant_index;
+}
+
+Vec2 Pinhole_Intrinsic_Brown_T2::get_ud_pixel( const Vec2& p ) const
+{
+  return cam2ima( remove_disto( ima2cam( p ) ) );
+}
+
+Vec2 Pinhole_Intrinsic_Brown_T2::get_d_pixel( const Vec2& p ) const
+{
+  return cam2ima( add_disto( ima2cam( p ) ) );
+}
+
+template <class Archive>
+void Pinhole_Intrinsic_Brown_T2::save( Archive & ar ) const
+{
+  ar(cereal::base_class<Pinhole_Intrinsic>(this));
+  ar( cereal::make_nvp( "disto_t2", params_ ) );
+}
+
+template <class Archive>
+void Pinhole_Intrinsic_Brown_T2::load( Archive & ar )
+{
+  ar(cereal::base_class<Pinhole_Intrinsic>(this));
+  ar( cereal::make_nvp( "disto_t2", params_ ) );
+}
+
+IntrinsicBase * Pinhole_Intrinsic_Brown_T2::clone( void ) const
+{
+  return new class_type( *this );
+}
+
+Vec2 Pinhole_Intrinsic_Brown_T2::distoFunction( const std::vector<double> & params, const Vec2 & p )
+{
+  const double k1 = params[0], k2 = params[1], k3 = params[2], t1 = params[3], t2 = params[4];
+  const double r2 = p( 0 ) * p( 0 ) + p( 1 ) * p( 1 );
+  const double r4 = r2 * r2;
+  const double r6 = r4 * r2;
+  const double k_diff = ( k1 * r2 + k2 * r4 + k3 * r6 );
+  const double t_x = t2 * ( r2 + 2 * p( 0 ) * p( 0 ) ) + 2 * t1 * p( 0 ) * p( 1 );
+  const double t_y = t1 * ( r2 + 2 * p( 1 ) * p( 1 ) ) + 2 * t2 * p( 0 ) * p( 1 );
+  Vec2 d( p( 0 ) * k_diff + t_x, p( 1 ) * k_diff + t_y );
+  return d;
+}
+
+template void Pinhole_Intrinsic_Brown_T2::load<cereal::JSONInputArchive>(class cereal::JSONInputArchive &);
+template void Pinhole_Intrinsic_Brown_T2::save<cereal::JSONOutputArchive>(class cereal::JSONOutputArchive &)const;
+template void Pinhole_Intrinsic_Brown_T2::load<cereal::XMLInputArchive>(class cereal::XMLInputArchive &);
+template void Pinhole_Intrinsic_Brown_T2::save<cereal::XMLOutputArchive>(class cereal::XMLOutputArchive &)const;
+template void Pinhole_Intrinsic_Brown_T2::load<cereal::PortableBinaryInputArchive>(class cereal::PortableBinaryInputArchive &);
+template void Pinhole_Intrinsic_Brown_T2::save<cereal::PortableBinaryOutputArchive>(class cereal::PortableBinaryOutputArchive &)const;
+
+} // namespace cameras
+} // namespace openMVG
+
+#include <cereal/types/polymorphic.hpp>
+
+CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::cameras::Pinhole_Intrinsic_Brown_T2, "pinhole_brown_t2" );
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Brown_T2)

--- a/src/openMVG/cameras/Camera_Pinhole_Brown.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Brown.hpp
@@ -9,11 +9,7 @@
 #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_BROWN_HPP
 #define OPENMVG_CAMERAS_CAMERA_PINHOLE_BROWN_HPP
 
-#include <vector>
-
-#include "openMVG/cameras/Camera_Common.hpp"
 #include "openMVG/cameras/Camera_Pinhole.hpp"
-#include "openMVG/numeric/eigen_alias_definition.hpp"
 
 namespace openMVG
 {
@@ -53,39 +49,26 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
       int w = 0, int h = 0,
       double focal = 0.0, double ppx = 0, double ppy = 0,
       double k1 = 0.0, double k2 = 0.0, double k3 = 0.0,
-      double t1 = 0.0, double t2 = 0.0 )
-      : Pinhole_Intrinsic( w, h, focal, ppx, ppy )
-    {
-      params_ = {k1, k2, k3, t1, t2};
-    }
+      double t1 = 0.0, double t2 = 0.0 );
 
     /**
     * @brief Get type of the intrinsic
     * @retval PINHOLE_CAMERA_BROWN
     */
-    EINTRINSIC getType() const override
-    {
-      return PINHOLE_CAMERA_BROWN;
-    }
+	EINTRINSIC getType() const override;
 
     /**
     * @brief Does the camera model handle a distortion field?
     * @retval true
     */
-    bool have_disto() const override
-    {
-      return true;
-    }
+	bool have_disto() const override;
 
     /**
     * @brief Add the distortion field to a point (that is in normalized camera frame)
     * @param p Point before distortion computation (in normalized camera frame)
     * @return point with distortion
     */
-    Vec2 add_disto( const Vec2 & p ) const override
-    {
-      return ( p + distoFunction( params_, p ) );
-    }
+    Vec2 add_disto( const Vec2 & p ) const override;
 
     /**
     * @brief Remove the distortion to a camera point (that is in normalized camera frame)
@@ -95,31 +78,13 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
     * Heikkila J (2000) Geometric Camera Calibration Using Circular Control Points.
     * IEEE Trans. Pattern Anal. Mach. Intell., 22:1066-1077
     */
-    Vec2 remove_disto( const Vec2 & p ) const override
-    {
-      const double epsilon = 1e-10; //criteria to stop the iteration
-      Vec2 p_u = p;
-
-      Vec2 d = distoFunction(params_, p_u);
-      while ((p_u + d - p).lpNorm<1>() > epsilon) //manhattan distance between the two points
-      {
-        p_u = p - d;
-        d = distoFunction(params_, p_u);
-      }
-
-      return p_u;
-    }
+    Vec2 remove_disto( const Vec2 & p ) const override;
 
     /**
     * @brief Data wrapper for non linear optimization (get data)
     * @return vector of parameter of this intrinsic
     */
-    std::vector<double> getParams() const override
-    {
-      std::vector<double> params = Pinhole_Intrinsic::getParams();
-      params.insert(params.end(), std::begin(params_), std::end(params_));
-      return params;
-    }
+	std::vector<double> getParams() const override;
 
     /**
     * @brief Data wrapper for non linear optimization (update from data)
@@ -127,22 +92,7 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
     * @retval true if update is correct
     * @retval false if there was an error during update
     */
-    bool updateFromParams( const std::vector<double> & params ) override
-    {
-      if ( params.size() == 8 )
-      {
-        *this = Pinhole_Intrinsic_Brown_T2(
-                  w_, h_,
-                  params[0], params[1], params[2], // focal, ppx, ppy
-                  params[3], params[4], params[5], // K1, K2, K3
-                  params[6], params[7] );          // T1, T2
-        return true;
-      }
-      else
-      {
-        return false;
-      }
-    }
+    bool updateFromParams( const std::vector<double> & params ) override;
 
     /**
     * @brief Return the list of parameter indexes that must be held constant
@@ -150,83 +100,41 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
     */
     std::vector<int> subsetParameterization
     (
-      const Intrinsic_Parameter_Type & parametrization) const override
-    {
-      std::vector<int> constant_index;
-      const int param = static_cast<int>(parametrization);
-      if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_FOCAL_LENGTH)
-          || param & (int)Intrinsic_Parameter_Type::NONE )
-      {
-        constant_index.push_back(0);
-      }
-      if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_PRINCIPAL_POINT)
-          || param & (int)Intrinsic_Parameter_Type::NONE )
-      {
-        constant_index.push_back(1);
-        constant_index.push_back(2);
-      }
-      if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_DISTORTION)
-          || param & (int)Intrinsic_Parameter_Type::NONE )
-      {
-        constant_index.push_back(3);
-        constant_index.push_back(4);
-        constant_index.push_back(5);
-        constant_index.push_back(6);
-        constant_index.push_back(7);
-      }
-      return constant_index;
-    }
+      const Intrinsic_Parameter_Type & parametrization) const override;
 
     /**
     * @brief Return the un-distorted pixel (with removed distortion)
     * @param p Input distorted pixel
     * @return Point without distortion
     */
-    Vec2 get_ud_pixel( const Vec2& p ) const override
-    {
-      return cam2ima( remove_disto( ima2cam( p ) ) );
-    }
+    Vec2 get_ud_pixel( const Vec2& p ) const override;
 
     /**
     * @brief Return the distorted pixel (with added distortion)
     * @param p Input pixel
     * @return Distorted pixel
     */
-    Vec2 get_d_pixel( const Vec2& p ) const override
-    {
-      return cam2ima( add_disto( ima2cam( p ) ) );
-    }
+    Vec2 get_d_pixel( const Vec2& p ) const override;
 
     /**
     * @brief Serialization out
     * @param ar Archive
     */
     template <class Archive>
-    void save( Archive & ar ) const
-    {
-      ar(cereal::base_class<Pinhole_Intrinsic>(this));
-      ar( cereal::make_nvp( "disto_t2", params_ ) );
-    }
+    void save( Archive & ar ) const;
 
     /**
     * @brief  Serialization in
     * @param ar Archive
     */
     template <class Archive>
-    void load( Archive & ar )
-    {
-      ar(cereal::base_class<Pinhole_Intrinsic>(this));
-      ar( cereal::make_nvp( "disto_t2", params_ ) );
-    }
+    void load( Archive & ar );
 
     /**
     * @brief Clone the object
     * @return A clone (copy of the stored object)
     */
-    IntrinsicBase * clone( void ) const override
-    {
-      return new class_type( *this );
-    }
+    IntrinsicBase * clone( void ) const override;
 
   private:
 
@@ -237,28 +145,11 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
     * @param p Input point
     * @return Transformed point
     */
-    static Vec2 distoFunction( const std::vector<double> & params, const Vec2 & p )
-    {
-      const double k1 = params[0], k2 = params[1], k3 = params[2], t1 = params[3], t2 = params[4];
-      const double r2 = p( 0 ) * p( 0 ) + p( 1 ) * p( 1 );
-      const double r4 = r2 * r2;
-      const double r6 = r4 * r2;
-      const double k_diff = ( k1 * r2 + k2 * r4 + k3 * r6 );
-      const double t_x = t2 * ( r2 + 2 * p( 0 ) * p( 0 ) ) + 2 * t1 * p( 0 ) * p( 1 );
-      const double t_y = t1 * ( r2 + 2 * p( 1 ) * p( 1 ) ) + 2 * t2 * p( 0 ) * p( 1 );
-      Vec2 d( p( 0 ) * k_diff + t_x, p( 1 ) * k_diff + t_y );
-      return d;
-    }
+    static Vec2 distoFunction( const std::vector<double> & params, const Vec2 & p );
 };
 
 
 } // namespace cameras
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/types/vector.hpp>
-
-CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::cameras::Pinhole_Intrinsic_Brown_T2, "pinhole_brown_t2" );
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Brown_T2)
 
 #endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_BROWN_HPP

--- a/src/openMVG/cameras/Camera_Pinhole_Fisheye.cpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Fisheye.cpp
@@ -1,0 +1,184 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Romain Janvier <romain.janvier~AT~univ-orleans.fr> for the given adaptation
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This is an adaptation of the Fisheye distortion model implemented in OpenCV
+// https://github.com/Itseez/opencv/blob/master/modules/calib3d/src/fisheye.cpp
+
+
+#include "openMVG/cameras/Camera_Pinhole_Fisheye.hpp"
+
+#include <cereal/types/vector.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
+namespace openMVG
+{
+namespace cameras
+{
+
+Pinhole_Intrinsic_Fisheye::Pinhole_Intrinsic_Fisheye(
+    int w, int h,
+    double focal, double ppx, double ppy,
+    double k1, double k2, double k3, double k4 )
+    : Pinhole_Intrinsic( w, h, focal, ppx, ppy )
+{
+    params_ = {k1, k2, k3, k4};
+}
+
+EINTRINSIC Pinhole_Intrinsic_Fisheye::getType() const
+{
+    return PINHOLE_CAMERA_FISHEYE;
+}
+
+bool Pinhole_Intrinsic_Fisheye::have_disto() const
+{
+    return true;
+}
+
+Vec2 Pinhole_Intrinsic_Fisheye::add_disto( const Vec2 & p ) const
+{
+    const double eps = 1e-8;
+    const double k1 = params_[0], k2 = params_[1], k3 = params_[2], k4 = params_[3];
+    const double r = std::sqrt( p( 0 ) * p( 0 ) + p( 1 ) * p( 1 ) );
+    const double theta = std::atan( r );
+    const double
+    theta2 = theta * theta,
+    theta3 = theta2 * theta,
+    theta4 = theta2 * theta2,
+    theta5 = theta4 * theta,
+    theta6 = theta3 * theta3,
+    theta7 = theta6 * theta,
+    theta8 = theta4 * theta4,
+    theta9 = theta8 * theta;
+    const double theta_dist = theta + k1 * theta3 + k2 * theta5 + k3 * theta7 + k4 * theta9;
+    const double inv_r = r > eps ? 1.0 / r : 1.0;
+    const double cdist = r > eps ? theta_dist * inv_r : 1.0;
+    return  p * cdist;
+}
+
+Vec2 Pinhole_Intrinsic_Fisheye::remove_disto( const Vec2 & p ) const
+{
+    const double eps = 1e-8;
+    double scale = 1.0;
+    const double theta_dist = std::sqrt( p[0] * p[0] + p[1] * p[1] );
+    if ( theta_dist > eps )
+    {
+    double theta = theta_dist;
+    for ( int j = 0; j < 10; ++j )
+    {
+        const double
+        theta2 = theta * theta,
+        theta4 = theta2 * theta2,
+        theta6 = theta4 * theta2,
+        theta8 = theta6 * theta2;
+        theta = theta_dist /
+                ( 1 + params_[0] * theta2
+                    + params_[1] * theta4
+                    + params_[2] * theta6
+                    + params_[3] * theta8 );
+    }
+    scale = std::tan( theta ) / theta_dist;
+    }
+    return p * scale;
+}
+
+std::vector<double> Pinhole_Intrinsic_Fisheye::getParams() const
+{
+    std::vector<double> params = Pinhole_Intrinsic::getParams();
+    params.insert(params.end(), std::begin(params_), std::end(params_));
+    return params;
+}
+
+bool Pinhole_Intrinsic_Fisheye::updateFromParams( const std::vector<double> & params )
+{
+    if ( params.size() == 7 )
+    {
+    *this = Pinhole_Intrinsic_Fisheye(
+                w_, h_,
+                params[0], params[1], params[2], // focal, ppx, ppy
+                params[3], params[4], params[5], params[6] ); // k1, k2, k3, k4
+    return true;
+    }
+    else
+    {
+    return false;
+    }
+}
+
+std::vector<int> Pinhole_Intrinsic_Fisheye::subsetParameterization
+(
+    const Intrinsic_Parameter_Type & parametrization) const
+{
+    std::vector<int> constant_index;
+    const int param = static_cast<int>(parametrization);
+    if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_FOCAL_LENGTH)
+        || param & (int)Intrinsic_Parameter_Type::NONE )
+    {
+    constant_index.push_back(0);
+    }
+    if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_PRINCIPAL_POINT)
+        || param & (int)Intrinsic_Parameter_Type::NONE )
+    {
+    constant_index.push_back(1);
+    constant_index.push_back(2);
+    }
+    if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_DISTORTION)
+        || param & (int)Intrinsic_Parameter_Type::NONE )
+    {
+    constant_index.push_back(3);
+    constant_index.push_back(4);
+    constant_index.push_back(5);
+    constant_index.push_back(6);
+    }
+    return constant_index;
+}
+
+Vec2 Pinhole_Intrinsic_Fisheye::get_ud_pixel( const Vec2& p ) const
+{
+    return cam2ima( remove_disto( ima2cam( p ) ) );
+}
+
+Vec2 Pinhole_Intrinsic_Fisheye::get_d_pixel( const Vec2& p ) const
+{
+    return cam2ima( add_disto( ima2cam( p ) ) );
+}
+
+template <class Archive>
+void Pinhole_Intrinsic_Fisheye::save( Archive & ar ) const
+{
+    ar(cereal::base_class<Pinhole_Intrinsic>(this));
+    ar( cereal::make_nvp( "fisheye", params_ ) );
+}
+
+template <class Archive>
+void Pinhole_Intrinsic_Fisheye::load( Archive & ar )
+{
+    ar(cereal::base_class<Pinhole_Intrinsic>(this));
+    ar( cereal::make_nvp( "fisheye", params_ ) );
+}
+
+IntrinsicBase * Pinhole_Intrinsic_Fisheye::clone( void ) const
+{
+    return new class_type( *this );
+}
+
+template void Pinhole_Intrinsic_Fisheye::load<cereal::JSONInputArchive>(class cereal::JSONInputArchive &);
+template void Pinhole_Intrinsic_Fisheye::save<cereal::JSONOutputArchive>(class cereal::JSONOutputArchive &)const;
+template void Pinhole_Intrinsic_Fisheye::load<cereal::XMLInputArchive>(class cereal::XMLInputArchive &);
+template void Pinhole_Intrinsic_Fisheye::save<cereal::XMLOutputArchive>(class cereal::XMLOutputArchive &)const;
+template void Pinhole_Intrinsic_Fisheye::load<cereal::PortableBinaryInputArchive>(class cereal::PortableBinaryInputArchive &);
+template void Pinhole_Intrinsic_Fisheye::save<cereal::PortableBinaryOutputArchive>(class cereal::PortableBinaryOutputArchive &)const;
+
+} // namespace cameras
+} // namespace openMVG
+
+#include <cereal/types/polymorphic.hpp>
+
+CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::cameras::Pinhole_Intrinsic_Fisheye, "fisheye" );
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Fisheye)

--- a/src/openMVG/cameras/Camera_Pinhole_Radial.cpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Radial.cpp
@@ -1,0 +1,338 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/cameras/Camera_Pinhole_Radial.hpp"
+#include "openMVG/numeric/numeric.h"
+
+#include <cereal/types/vector.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
+namespace openMVG{
+namespace cameras{
+namespace radial_distortion{
+
+
+template <class Disto_Functor>
+double bisection_Radius_Solve(
+  const std::vector<double> & params, // radial distortion parameters
+  double r2, // targeted radius
+  Disto_Functor & functor,
+  double epsilon = 1e-10 // criteria to stop the bisection
+)
+{
+  // Guess plausible upper and lower bound
+  double lowerbound = r2, upbound = r2;
+  while ( functor( params, lowerbound ) > r2 )
+  {
+    lowerbound /= 1.05;
+  }
+  while ( functor( params, upbound ) < r2 )
+  {
+    upbound *= 1.05;
+  }
+
+  // Perform a bisection until epsilon accuracy is not reached
+  while ( epsilon < upbound - lowerbound )
+  {
+    const double mid = .5 * ( lowerbound + upbound );
+    if ( functor( params, mid ) > r2 )
+    {
+      upbound = mid;
+    }
+    else
+    {
+      lowerbound = mid;
+    }
+  }
+  return .5 * ( lowerbound + upbound );
+}
+
+} // namespace radial_distortion
+
+Pinhole_Intrinsic_Radial_K1::Pinhole_Intrinsic_Radial_K1(
+    int w, int h,
+    double focal, double ppx, double ppy,
+    double k1 )
+    : Pinhole_Intrinsic( w, h, focal, ppx, ppy )
+{
+    params_ = {k1};
+}
+
+EINTRINSIC Pinhole_Intrinsic_Radial_K1::Pinhole_Intrinsic_Radial_K1::getType() const
+{
+    return PINHOLE_CAMERA_RADIAL1;
+}
+
+bool Pinhole_Intrinsic_Radial_K1::have_disto() const
+{
+    return true;
+}
+
+Vec2 Pinhole_Intrinsic_Radial_K1::add_disto( const Vec2 & p ) const
+{
+
+    const double k1 = params_[0];
+
+    const double r2 = p( 0 ) * p( 0 ) + p( 1 ) * p( 1 );
+    const double r_coeff = ( 1. + k1 * r2 );
+
+    return ( p * r_coeff );
+}
+
+Vec2 Pinhole_Intrinsic_Radial_K1::remove_disto( const Vec2& p ) const
+{
+    // Compute the radius from which the point p comes from thanks to a bisection
+    // Minimize disto(radius(p')^2) == actual Squared(radius(p))
+
+    const double r2 = p( 0 ) * p( 0 ) + p( 1 ) * p( 1 );
+    const double radius = ( r2 == 0 ) ?
+                        1. :
+                        ::sqrt( radial_distortion::bisection_Radius_Solve( params_, r2, distoFunctor ) / r2 );
+    return radius * p;
+}
+
+std::vector<double> Pinhole_Intrinsic_Radial_K1::getParams() const
+{
+    std::vector<double> params = Pinhole_Intrinsic::getParams();
+    params.insert(params.end(), std::begin(params_), std::end(params_));
+    return params;
+}
+
+bool Pinhole_Intrinsic_Radial_K1::updateFromParams( const std::vector<double> & params )
+{
+    if ( params.size() == 4 )
+    {
+    *this = Pinhole_Intrinsic_Radial_K1(
+                w_, h_,
+                params[0], params[1], params[2], // focal, ppx, ppy
+                params[3] ); //K1
+    return true;
+    }
+    else
+    {
+    return false;
+    }
+}
+
+std::vector<int> Pinhole_Intrinsic_Radial_K1::subsetParameterization
+(
+    const Intrinsic_Parameter_Type & parametrization) const
+{
+    std::vector<int> constant_index;
+    const int param = static_cast<int>(parametrization);
+    if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_FOCAL_LENGTH)
+        || param & (int)Intrinsic_Parameter_Type::NONE )
+    {
+    constant_index.push_back(0);
+    }
+    if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_PRINCIPAL_POINT)
+        || param & (int)Intrinsic_Parameter_Type::NONE )
+    {
+    constant_index.push_back(1);
+    constant_index.push_back(2);
+    }
+    if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_DISTORTION)
+        || param & (int)Intrinsic_Parameter_Type::NONE )
+    {
+    constant_index.push_back(3);
+    }
+    return constant_index;
+}
+
+Vec2 Pinhole_Intrinsic_Radial_K1::get_ud_pixel( const Vec2& p ) const
+{
+    return cam2ima( remove_disto( ima2cam( p ) ) );
+}
+
+Vec2 Pinhole_Intrinsic_Radial_K1::get_d_pixel( const Vec2& p ) const
+{
+    return cam2ima( add_disto( ima2cam( p ) ) );
+}
+
+template <class Archive>
+void Pinhole_Intrinsic_Radial_K1::save( Archive & ar ) const
+{
+    Pinhole_Intrinsic::save( ar );
+    ar( cereal::make_nvp( "disto_k1", params_ ) );
+}
+
+template <class Archive>
+void Pinhole_Intrinsic_Radial_K1::load( Archive & ar )
+{
+    Pinhole_Intrinsic::load(ar);
+    ar( cereal::make_nvp( "disto_k1", params_ ) );
+}
+
+IntrinsicBase * Pinhole_Intrinsic_Radial_K1::clone( void ) const
+{
+    return new class_type( *this );
+}
+
+
+double Pinhole_Intrinsic_Radial_K1::distoFunctor( const std::vector<double> & params, double r2 )
+{
+    const double & k1 = params[0];
+    return r2 * Square( 1. + r2 * k1 );
+}
+
+Pinhole_Intrinsic_Radial_K3::Pinhole_Intrinsic_Radial_K3(
+    int w, int h,
+    double focal, double ppx, double ppy,
+    double k1, double k2, double k3 )
+    : Pinhole_Intrinsic( w, h, focal, ppx, ppy )
+{
+    params_ = {k1, k2, k3};
+}
+
+EINTRINSIC Pinhole_Intrinsic_Radial_K3::getType() const
+{
+    return PINHOLE_CAMERA_RADIAL3;
+}
+
+bool Pinhole_Intrinsic_Radial_K3::have_disto() const
+{
+    return true;
+}
+
+Vec2 Pinhole_Intrinsic_Radial_K3::add_disto( const Vec2 & p ) const
+{
+    const double & k1 = params_[0], & k2 = params_[1], & k3 = params_[2];
+
+    const double r2 = p( 0 ) * p( 0 ) + p( 1 ) * p( 1 );
+    const double r4 = r2 * r2;
+    const double r6 = r4 * r2;
+    const double r_coeff = ( 1. + k1 * r2 + k2 * r4 + k3 * r6 );
+
+    return ( p * r_coeff );
+}
+Vec2 Pinhole_Intrinsic_Radial_K3::remove_disto( const Vec2& p ) const
+{
+    // Compute the radius from which the point p comes from thanks to a bisection
+    // Minimize disto(radius(p')^2) == actual Squared(radius(p))
+
+    const double r2 = p( 0 ) * p( 0 ) + p( 1 ) * p( 1 );
+    const double radius = ( r2 == 0 ) ? //1. : ::sqrt(bisectionSolve(_params, r2) / r2);
+                        1. :
+                        ::sqrt( radial_distortion::bisection_Radius_Solve( params_, r2, distoFunctor ) / r2 );
+    return radius * p;
+}
+
+std::vector<double> Pinhole_Intrinsic_Radial_K3::getParams() const
+{
+    std::vector<double> params = Pinhole_Intrinsic::getParams();
+    params.insert( params.end(), std::begin(params_), std::end(params_));
+    return params;
+}
+
+bool Pinhole_Intrinsic_Radial_K3::updateFromParams( const std::vector<double> & params )
+{
+    if ( params.size() == 6 )
+    {
+    *this = Pinhole_Intrinsic_Radial_K3(
+                w_, h_,
+                params[0], params[1], params[2], // focal, ppx, ppy
+                params[3], params[4], params[5] ); // K1, K2, K3
+    return true;
+    }
+    else
+    {
+    return false;
+    }
+}
+
+std::vector<int> Pinhole_Intrinsic_Radial_K3::subsetParameterization
+(
+    const Intrinsic_Parameter_Type & parametrization) const
+{
+    std::vector<int> constant_index;
+    const int param = static_cast<int>(parametrization);
+    if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_FOCAL_LENGTH)
+        || param & (int)Intrinsic_Parameter_Type::NONE )
+    {
+    constant_index.push_back(0);
+    }
+    if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_PRINCIPAL_POINT)
+        || param & (int)Intrinsic_Parameter_Type::NONE )
+    {
+    constant_index.push_back(1);
+    constant_index.push_back(2);
+    }
+    if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_DISTORTION)
+        || param & (int)Intrinsic_Parameter_Type::NONE )
+    {
+    constant_index.push_back(3);
+    constant_index.push_back(4);
+    constant_index.push_back(5);
+    }
+    return constant_index;
+}
+
+Vec2 Pinhole_Intrinsic_Radial_K3::get_ud_pixel( const Vec2& p ) const
+{
+    return cam2ima( remove_disto( ima2cam( p ) ) );
+}
+
+Vec2 Pinhole_Intrinsic_Radial_K3::get_d_pixel( const Vec2& p ) const
+{
+    return cam2ima( add_disto( ima2cam( p ) ) );
+}
+
+template <class Archive>
+void Pinhole_Intrinsic_Radial_K3::save( Archive & ar ) const
+{
+    Pinhole_Intrinsic::save(ar);
+    ar( cereal::make_nvp( "disto_k3", params_ ) );
+}
+
+template <class Archive>
+void Pinhole_Intrinsic_Radial_K3::load( Archive & ar )
+{
+    Pinhole_Intrinsic::load(ar);
+    ar( cereal::make_nvp( "disto_k3", params_ ) );
+}
+
+IntrinsicBase * Pinhole_Intrinsic_Radial_K3::clone( void ) const
+{
+    return new class_type( *this );
+}
+
+double Pinhole_Intrinsic_Radial_K3::distoFunctor( const std::vector<double> & params, double r2 )
+{
+    const double & k1 = params[0], & k2 = params[1], & k3 = params[2];
+    return r2 * Square( 1. + r2 * ( k1 + r2 * ( k2 + r2 * k3 ) ) );
+}
+
+template void Pinhole_Intrinsic_Radial_K1::load<cereal::JSONInputArchive>(class cereal::JSONInputArchive &);
+template void Pinhole_Intrinsic_Radial_K1::save<cereal::JSONOutputArchive>(class cereal::JSONOutputArchive &)const;
+
+template void Pinhole_Intrinsic_Radial_K3::load<cereal::JSONInputArchive>(class cereal::JSONInputArchive &);
+template void Pinhole_Intrinsic_Radial_K3::save<cereal::JSONOutputArchive>(class cereal::JSONOutputArchive &)const;
+
+template void Pinhole_Intrinsic_Radial_K1::load<cereal::XMLInputArchive>(class cereal::XMLInputArchive &);
+template void Pinhole_Intrinsic_Radial_K1::save<cereal::XMLOutputArchive>(class cereal::XMLOutputArchive &)const;
+
+template void Pinhole_Intrinsic_Radial_K3::load<cereal::XMLInputArchive>(class cereal::XMLInputArchive &);
+template void Pinhole_Intrinsic_Radial_K3::save<cereal::XMLOutputArchive>(class cereal::XMLOutputArchive &)const;
+
+template void Pinhole_Intrinsic_Radial_K1::load<cereal::PortableBinaryInputArchive>(class cereal::PortableBinaryInputArchive &);
+template void Pinhole_Intrinsic_Radial_K1::save<cereal::PortableBinaryOutputArchive>(class cereal::PortableBinaryOutputArchive &)const;
+
+template void Pinhole_Intrinsic_Radial_K3::load<cereal::PortableBinaryInputArchive>(class cereal::PortableBinaryInputArchive &);
+template void Pinhole_Intrinsic_Radial_K3::save<cereal::PortableBinaryOutputArchive>(class cereal::PortableBinaryOutputArchive &)const;
+
+} // namespace cameras
+} // namespace openMVG
+
+#include <cereal/types/polymorphic.hpp>
+
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic_Radial_K1, "pinhole_radial_k1");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Radial_K1);
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic_Radial_K3, "pinhole_radial_k3");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Radial_K3);

--- a/src/openMVG/cameras/Camera_Pinhole_Radial.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Radial.hpp
@@ -21,58 +21,6 @@ namespace cameras
 {
 
 /**
-* @brief Namespace handling radial distortion computation
-*/
-namespace radial_distortion
-{
-
-
-/**
-* @brief Solve by bisection the p' radius such that Square(disto(radius(p'))) = r^2
-* @param params Parameters of the distortion
-* @param r2 Target radius
-* @param functor Functor used to paramatrize the distortion
-* @param epsilon Error driven threshold
-* @return Best radius
-*/
-template <class Disto_Functor>
-double bisection_Radius_Solve(
-  const std::vector<double> & params, // radial distortion parameters
-  double r2, // targeted radius
-  Disto_Functor & functor,
-  double epsilon = 1e-10 // criteria to stop the bisection
-)
-{
-  // Guess plausible upper and lower bound
-  double lowerbound = r2, upbound = r2;
-  while ( functor( params, lowerbound ) > r2 )
-  {
-    lowerbound /= 1.05;
-  }
-  while ( functor( params, upbound ) < r2 )
-  {
-    upbound *= 1.05;
-  }
-
-  // Perform a bisection until epsilon accuracy is not reached
-  while ( epsilon < upbound - lowerbound )
-  {
-    const double mid = .5 * ( lowerbound + upbound );
-    if ( functor( params, mid ) > r2 )
-    {
-      upbound = mid;
-    }
-    else
-    {
-      lowerbound = mid;
-    }
-  }
-  return .5 * ( lowerbound + upbound );
-}
-
-} // namespace radial_distortion
-
-/**
  * @brief Implement a Pinhole camera with a 1 radial distortion coefficient.
  * \f$ x_d = x_u (1 + K_1 r^2 ) \f$
  */
@@ -98,11 +46,7 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
     Pinhole_Intrinsic_Radial_K1(
       int w = 0, int h = 0,
       double focal = 0.0, double ppx = 0, double ppy = 0,
-      double k1 = 0.0 )
-      : Pinhole_Intrinsic( w, h, focal, ppx, ppy )
-    {
-      params_ = {k1};
-    }
+      double k1 = 0.0 );
 
     ~Pinhole_Intrinsic_Radial_K1() override = default;
 
@@ -110,64 +54,34 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
     * @brief Tell from which type the embed camera is
     * @retval PINHOLE_CAMERA_RADIAL1
     */
-    EINTRINSIC getType() const override
-    {
-      return PINHOLE_CAMERA_RADIAL1;
-    }
+    EINTRINSIC getType() const override;
 
     /**
     * @brief Does the camera model handle a distortion field?
     * @retval true if intrinsic holds distortion
     * @retval false if intrinsic does not hold distortion
     */
-    bool have_disto() const override
-    {
-      return true;
-    }
+    bool have_disto() const override;
 
     /**
     * @brief Add the distortion field to a point (that is in normalized camera frame)
     * @param p Point before distortion computation (in normalized camera frame)
     * @return point with distortion
     */
-    Vec2 add_disto( const Vec2 & p ) const override
-    {
-
-      const double k1 = params_[0];
-
-      const double r2 = p( 0 ) * p( 0 ) + p( 1 ) * p( 1 );
-      const double r_coeff = ( 1. + k1 * r2 );
-
-      return ( p * r_coeff );
-    }
+    Vec2 add_disto( const Vec2 & p ) const override;
 
     /**
     * @brief Remove the distortion to a camera point (that is in normalized camera frame)
     * @param p Point with distortion
     * @return Point without distortion
     */
-    Vec2 remove_disto( const Vec2& p ) const override
-    {
-      // Compute the radius from which the point p comes from thanks to a bisection
-      // Minimize disto(radius(p')^2) == actual Squared(radius(p))
-
-      const double r2 = p( 0 ) * p( 0 ) + p( 1 ) * p( 1 );
-      const double radius = ( r2 == 0 ) ?
-                            1. :
-                            ::sqrt( radial_distortion::bisection_Radius_Solve( params_, r2, distoFunctor ) / r2 );
-      return radius * p;
-    }
+    Vec2 remove_disto( const Vec2& p ) const override;
 
     /**
     * @brief Data wrapper for non linear optimization (get data)
     * @return vector of parameter of this intrinsic
     */
-    std::vector<double> getParams() const override
-    {
-      std::vector<double> params = Pinhole_Intrinsic::getParams();
-      params.insert(params.end(), std::begin(params_), std::end(params_));
-      return params;
-    }
+    std::vector<double> getParams() const override;
 
     /**
     * @brief Data wrapper for non linear optimization (update from data)
@@ -175,21 +89,7 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
     * @retval true if update is correct
     * @retval false if there was an error during update
     */
-    bool updateFromParams( const std::vector<double> & params ) override
-    {
-      if ( params.size() == 4 )
-      {
-        *this = Pinhole_Intrinsic_Radial_K1(
-                  w_, h_,
-                  params[0], params[1], params[2], // focal, ppx, ppy
-                  params[3] ); //K1
-        return true;
-      }
-      else
-      {
-        return false;
-      }
-    }
+    bool updateFromParams( const std::vector<double> & params ) override;
 
     /**
     * @brief Return the list of parameter indexes that must be held constant
@@ -197,82 +97,41 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
     */
     std::vector<int> subsetParameterization
     (
-      const Intrinsic_Parameter_Type & parametrization) const override
-    {
-      std::vector<int> constant_index;
-      const int param = static_cast<int>(parametrization);
-      if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_FOCAL_LENGTH)
-          || param & (int)Intrinsic_Parameter_Type::NONE )
-      {
-        constant_index.push_back(0);
-      }
-      if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_PRINCIPAL_POINT)
-          || param & (int)Intrinsic_Parameter_Type::NONE )
-      {
-        constant_index.push_back(1);
-        constant_index.push_back(2);
-      }
-      if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_DISTORTION)
-          || param & (int)Intrinsic_Parameter_Type::NONE )
-      {
-        constant_index.push_back(3);
-      }
-      return constant_index;
-    }
+      const Intrinsic_Parameter_Type & parametrization) const override;
 
     /**
     * @brief Return the un-distorted pixel (with removed distortion)
     * @param p Input distorted pixel
     * @return Point without distortion
     */
-    Vec2 get_ud_pixel( const Vec2& p ) const override
-    {
-      return cam2ima( remove_disto( ima2cam( p ) ) );
-    }
+    Vec2 get_ud_pixel( const Vec2& p ) const override;
 
     /**
     * @brief Return the distorted pixel (with added distortion)
     * @param p Input pixel
     * @return Distorted pixel
     */
-    Vec2 get_d_pixel( const Vec2& p ) const override
-    {
-      return cam2ima( add_disto( ima2cam( p ) ) );
-    }
+    Vec2 get_d_pixel( const Vec2& p ) const override;
 
     /**
     * @brief Serialization out
     * @param ar Archive
     */
     template <class Archive>
-    void save( Archive & ar ) const
-    {
-      Pinhole_Intrinsic::save( ar );
-      ar( cereal::make_nvp( "disto_k1", params_ ) );
-    }
+    void save( Archive & ar ) const;
 
     /**
     * @brief  Serialization in
     * @param ar Archive
     */
     template <class Archive>
-    void load( Archive & ar )
-    {
-      Pinhole_Intrinsic::load(ar);
-      ar( cereal::make_nvp( "disto_k1", params_ ) );
-    }
+    void load( Archive & ar );
 
     /**
     * @brief Clone the object
     * @return A clone (copy of the stored object)
     */
-    IntrinsicBase * clone( void ) const override
-    {
-      return new class_type( *this );
-    }
-
-  private:
-
+    IntrinsicBase * clone( void ) const override;
 
     /**
     * @brief Functor to solve Square(disto(radius(p'))) = r^2
@@ -280,11 +139,7 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
     * @param r2 square distance (relative to center)
     * @return distance
     */
-    static inline double distoFunctor( const std::vector<double> & params, double r2 )
-    {
-      const double & k1 = params[0];
-      return r2 * Square( 1. + r2 * k1 );
-    }
+    static double distoFunctor( const std::vector<double> & params, double r2 );
 };
 
 /**
@@ -316,11 +171,7 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
     Pinhole_Intrinsic_Radial_K3(
       int w = 0, int h = 0,
       double focal = 0.0, double ppx = 0, double ppy = 0,
-      double k1 = 0.0, double k2 = 0.0, double k3 = 0.0 )
-      : Pinhole_Intrinsic( w, h, focal, ppx, ppy )
-    {
-      params_ = {k1, k2, k3};
-    }
+      double k1 = 0.0, double k2 = 0.0, double k3 = 0.0 );
 
     ~Pinhole_Intrinsic_Radial_K3() override = default;
 
@@ -328,64 +179,33 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
     * @brief Tell from which type the embed camera is
     * @retval PINHOLE_CAMERA_RADIAL3
     */
-    EINTRINSIC getType() const override
-    {
-      return PINHOLE_CAMERA_RADIAL3;
-    }
+    EINTRINSIC getType() const override;
 
     /**
     * @brief Does the camera model handle a distortion field?
     * @retval true
     */
-    bool have_disto() const override
-    {
-      return true;
-    }
+    bool have_disto() const override;
 
     /**
     * @brief Add the distortion field to a point (that is in normalized camera frame)
     * @param p Point before distortion computation (in normalized camera frame)
     * @return point with distortion
     */
-    Vec2 add_disto( const Vec2 & p ) const override
-    {
-      const double & k1 = params_[0], & k2 = params_[1], & k3 = params_[2];
-
-      const double r2 = p( 0 ) * p( 0 ) + p( 1 ) * p( 1 );
-      const double r4 = r2 * r2;
-      const double r6 = r4 * r2;
-      const double r_coeff = ( 1. + k1 * r2 + k2 * r4 + k3 * r6 );
-
-      return ( p * r_coeff );
-    }
+    Vec2 add_disto( const Vec2 & p ) const override;
 
     /**
     * @brief Remove the distortion to a camera point (that is in normalized camera frame)
     * @param p Point with distortion
     * @return Point without distortion
     */
-    Vec2 remove_disto( const Vec2& p ) const override
-    {
-      // Compute the radius from which the point p comes from thanks to a bisection
-      // Minimize disto(radius(p')^2) == actual Squared(radius(p))
-
-      const double r2 = p( 0 ) * p( 0 ) + p( 1 ) * p( 1 );
-      const double radius = ( r2 == 0 ) ? //1. : ::sqrt(bisectionSolve(_params, r2) / r2);
-                            1. :
-                            ::sqrt( radial_distortion::bisection_Radius_Solve( params_, r2, distoFunctor ) / r2 );
-      return radius * p;
-    }
+    Vec2 remove_disto( const Vec2& p ) const override;
 
     /**
     * @brief Data wrapper for non linear optimization (get data)
     * @return vector of parameter of this intrinsic
     */
-    std::vector<double> getParams() const override
-    {
-      std::vector<double> params = Pinhole_Intrinsic::getParams();
-      params.insert( params.end(), std::begin(params_), std::end(params_));
-      return params;
-    }
+    std::vector<double> getParams() const override;
 
     /**
     * @brief Data wrapper for non linear optimization (update from data)
@@ -393,21 +213,7 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
     * @retval true if update is correct
     * @retval false if there was an error during update
     */
-    bool updateFromParams( const std::vector<double> & params ) override
-    {
-      if ( params.size() == 6 )
-      {
-        *this = Pinhole_Intrinsic_Radial_K3(
-                  w_, h_,
-                  params[0], params[1], params[2], // focal, ppx, ppy
-                  params[3], params[4], params[5] ); // K1, K2, K3
-        return true;
-      }
-      else
-      {
-        return false;
-      }
-    }
+    bool updateFromParams( const std::vector<double> & params ) override;
 
     /**
     * @brief Return the list of parameter indexes that must be held constant
@@ -415,81 +221,41 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
     */
     std::vector<int> subsetParameterization
     (
-      const Intrinsic_Parameter_Type & parametrization) const override
-    {
-      std::vector<int> constant_index;
-      const int param = static_cast<int>(parametrization);
-      if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_FOCAL_LENGTH)
-          || param & (int)Intrinsic_Parameter_Type::NONE )
-      {
-        constant_index.push_back(0);
-      }
-      if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_PRINCIPAL_POINT)
-          || param & (int)Intrinsic_Parameter_Type::NONE )
-      {
-        constant_index.push_back(1);
-        constant_index.push_back(2);
-      }
-      if ( !(param & (int)Intrinsic_Parameter_Type::ADJUST_DISTORTION)
-          || param & (int)Intrinsic_Parameter_Type::NONE )
-      {
-        constant_index.push_back(3);
-        constant_index.push_back(4);
-        constant_index.push_back(5);
-      }
-      return constant_index;
-    }
+      const Intrinsic_Parameter_Type & parametrization) const override;
 
     /**
     * @brief Return the un-distorted pixel (with removed distortion)
     * @param p Input distorted pixel
     * @return Point without distortion
     */
-    Vec2 get_ud_pixel( const Vec2& p ) const override
-    {
-      return cam2ima( remove_disto( ima2cam( p ) ) );
-    }
+    Vec2 get_ud_pixel( const Vec2& p ) const override;
 
     /**
     * @brief Return the distorted pixel (with added distortion)
     * @param p Input pixel
     * @return Distorted pixel
     */
-    Vec2 get_d_pixel( const Vec2& p ) const override
-    {
-      return cam2ima( add_disto( ima2cam( p ) ) );
-    }
+    Vec2 get_d_pixel( const Vec2& p ) const override;
 
     /**
     * @brief Serialization out
     * @param ar Archive
     */
     template <class Archive>
-    void save( Archive & ar ) const
-    {
-      Pinhole_Intrinsic::save(ar);
-      ar( cereal::make_nvp( "disto_k3", params_ ) );
-    }
+    void save( Archive & ar ) const;
 
     /**
     * @brief  Serialization in
     * @param ar Archive
     */
     template <class Archive>
-    void load( Archive & ar )
-    {
-      Pinhole_Intrinsic::load(ar);
-      ar( cereal::make_nvp( "disto_k3", params_ ) );
-    }
+    void load( Archive & ar );
 
     /**
     * @brief Clone the object
     * @return A clone (copy of the stored object)
     */
-    IntrinsicBase * clone( void ) const override
-    {
-      return new class_type( *this );
-    }
+    IntrinsicBase * clone( void ) const override;
 
   private:
 
@@ -500,22 +266,10 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
     * @param r2 square distance (relative to center)
     * @return distance
     */
-    static inline double distoFunctor( const std::vector<double> & params, double r2 )
-    {
-      const double & k1 = params[0], & k2 = params[1], & k3 = params[2];
-      return r2 * Square( 1. + r2 * ( k1 + r2 * ( k2 + r2 * k3 ) ) );
-    }
+    static double distoFunctor( const std::vector<double> & params, double r2 );
 };
 
 } // namespace cameras
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/types/vector.hpp>
-
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic_Radial_K1, "pinhole_radial_k1");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Radial_K1);
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic_Radial_K3, "pinhole_radial_k3");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Radial_K3);
 
 #endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_RADIAL_K_HPP

--- a/src/openMVG/cameras/Camera_Spherical.cpp
+++ b/src/openMVG/cameras/Camera_Spherical.cpp
@@ -1,0 +1,166 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2017 <Zillow Inc.> Pierre Moulon
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/numeric/numeric.h"
+#include "openMVG/cameras/Camera_Spherical.hpp"
+
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
+namespace openMVG{
+namespace cameras{
+
+
+Intrinsic_Spherical::Intrinsic_Spherical
+(
+  unsigned int w,
+  unsigned int h
+)
+: IntrinsicBase(w, h)
+{
+}
+
+EINTRINSIC Intrinsic_Spherical::getType() const
+{
+  return CAMERA_SPHERICAL;
+}
+
+std::vector<double> Intrinsic_Spherical::getParams() const
+{
+  return {};
+}
+
+bool Intrinsic_Spherical::updateFromParams(const std::vector<double> &params)
+{
+  return true;
+}
+
+std::vector<int> Intrinsic_Spherical::subsetParameterization
+(
+  const Intrinsic_Parameter_Type & parametrization
+) const
+{
+  return {};
+}
+
+Vec2 Intrinsic_Spherical::cam2ima(const Vec2 &p) const
+{
+  const size_t size = std::max(w(), h());
+  return {
+    p.x() * size + w() / 2.0,
+    p.y() * size + h() / 2.0 };
+}
+
+Vec2 Intrinsic_Spherical::ima2cam(const Vec2 &p) const
+{
+  const size_t size = std::max(w(), h());
+  return {
+    (p.x() - w() / 2.0) / size,
+    (p.y() - h() / 2.0) / size };
+}
+
+Vec3 Intrinsic_Spherical::operator () ( const Vec2& p ) const
+{
+  const Vec2 uv = ima2cam(p);
+
+  const double
+    lon = uv.x() * 2 * M_PI,
+    lat = uv.y() * 2 * M_PI;
+
+  return {
+    cos(lat) * sin(lon),
+    -sin(lat),
+    cos(lat) * cos(lon)};
+}
+
+Vec2 Intrinsic_Spherical::project(
+  const geometry::Pose3 & pose,
+  const Vec3 & pt3D ) const
+{
+  const Vec3 X = pose( pt3D ); // apply pose
+  const double lon = atan2(X.x(), X.z()); // Horizontal normalization of the  X-Z component
+  const double lat = atan2(-X.y(), sqrt(X.x()*X.x() + X.z()*X.z())); // Tilt angle
+  // denormalization (angle to pixel value)
+  return cam2ima({lon / (2 * M_PI), lat / (2 * M_PI)});
+}
+
+bool Intrinsic_Spherical::have_disto() const 
+{
+    return false; 
+}
+
+Vec2 Intrinsic_Spherical::add_disto(const Vec2 &p) const
+{ 
+    return p; 
+}
+
+Vec2 Intrinsic_Spherical::remove_disto(const Vec2 &p) const
+{ 
+    return p; 
+}
+
+Vec2 Intrinsic_Spherical::get_ud_pixel(const Vec2 &p) const
+{ 
+    return p; 
+}
+
+Vec2 Intrinsic_Spherical::get_d_pixel(const Vec2 &p) const
+{ 
+    return p; 
+}
+
+double Intrinsic_Spherical::imagePlane_toCameraPlaneError(double value) const
+{
+    return value; 
+}
+
+Mat34 Intrinsic_Spherical::get_projective_equivalent(const geometry::Pose3 &pose) const
+{
+  return HStack(pose.rotation(), pose.translation());
+}
+
+template <class Archive>
+void Intrinsic_Spherical::save( Archive & ar ) const
+{
+  ar(cereal::base_class<IntrinsicBase>(this));
+}
+
+template <class Archive>
+void Intrinsic_Spherical::load( Archive & ar )
+{
+  ar(cereal::base_class<IntrinsicBase>(this));
+}
+
+IntrinsicBase * Intrinsic_Spherical::clone( void ) const
+{
+  return new class_type( *this );
+}
+
+template void Intrinsic_Spherical::load<cereal::JSONInputArchive>(class cereal::JSONInputArchive &);
+template void Intrinsic_Spherical::save<cereal::JSONOutputArchive>(class cereal::JSONOutputArchive &)const;
+template void Intrinsic_Spherical::load<cereal::XMLInputArchive>(class cereal::XMLInputArchive &);
+template void Intrinsic_Spherical::save<cereal::XMLOutputArchive>(class cereal::XMLOutputArchive &)const;
+template void Intrinsic_Spherical::load<cereal::PortableBinaryInputArchive>(class cereal::PortableBinaryInputArchive &);
+template void Intrinsic_Spherical::save<cereal::PortableBinaryOutputArchive>(class cereal::PortableBinaryOutputArchive &)const;
+
+} // namespace cameras
+} // namespace openMVG
+
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/vector.hpp>
+
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Intrinsic_Spherical, "spherical");
+
+namespace cereal
+{
+  // This struct specialization will tell cereal which is the right way to serialize the ambiguity
+  template <class Archive> struct specialize<Archive, openMVG::cameras::Intrinsic_Spherical, cereal::specialization::member_load_save> {};
+}
+
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Intrinsic_Spherical);

--- a/src/openMVG/cameras/Camera_Spherical.hpp
+++ b/src/openMVG/cameras/Camera_Spherical.hpp
@@ -9,7 +9,6 @@
 #ifndef OPENMVG_CAMERAS_CAMERA_SPHERICAL_HPP
 #define OPENMVG_CAMERAS_CAMERA_SPHERICAL_HPP
 
-#include "openMVG/numeric/numeric.h"
 #include "openMVG/cameras/Camera_Intrinsics.hpp"
 
 namespace openMVG
@@ -35,10 +34,7 @@ using  class_type = Intrinsic_Spherical;
   (
     unsigned int w = 0,
     unsigned int h = 0
-  )
-  : IntrinsicBase(w, h)
-  {
-  }
+  );
 
   ~Intrinsic_Spherical() override = default;
 
@@ -46,19 +42,13 @@ using  class_type = Intrinsic_Spherical;
   * @brief Tell from which type the embed camera is
   * @retval CAMERA_SPHERICAL
   */
-  virtual EINTRINSIC getType() const override
-  {
-    return CAMERA_SPHERICAL;
-  }
+  virtual EINTRINSIC getType() const override;
 
   /**
   * @brief Data wrapper for non linear optimization (get data)
   * @return an empty vector of parameter since a spherical camera does not have any intrinsic parameter
   */
-  virtual std::vector<double> getParams() const override
-  {
-    return {};
-  }
+  virtual std::vector<double> getParams() const override;
 
   /**
   * @brief Data wrapper for non linear optimization (update from data)
@@ -66,10 +56,7 @@ using  class_type = Intrinsic_Spherical;
   * @retval true if update is correct
   * @retval false if there was an error during update
   */
-  virtual bool updateFromParams(const std::vector<double> &params) override
-  {
-    return true;
-  }
+  virtual bool updateFromParams(const std::vector<double> &params) override;
 
   /**
   * @brief Return the list of parameter indexes that must be held constant
@@ -78,54 +65,27 @@ using  class_type = Intrinsic_Spherical;
   virtual std::vector<int> subsetParameterization
   (
     const Intrinsic_Parameter_Type & parametrization
-  ) const override
-  {
-    return {};
-  }
+  ) const override;
 
   /**
   * @brief Transform a point from the camera plane to the image plane
   * @param p Camera plane point
   * @return Point on image plane
   */
-  virtual Vec2 cam2ima(const Vec2 &p) const override
-  {
-    const size_t size = std::max(w(), h());
-    return {
-      p.x() * size + w() / 2.0,
-      p.y() * size + h() / 2.0 };
-  }
+  virtual Vec2 cam2ima(const Vec2 &p) const override;
 
   /**
   * @brief Transform a point from the image plane to the camera plane
   * @param p Image plane point
   * @return camera plane point
   */
-  virtual Vec2 ima2cam(const Vec2 &p) const override
-  {
-    const size_t size = std::max(w(), h());
-    return {
-      (p.x() - w() / 2.0) / size,
-      (p.y() - h() / 2.0) / size };
-  }
+  virtual Vec2 ima2cam(const Vec2 &p) const override;
 
   /**
   * @brief Get bearing vector of a point given an image coordinate
   * @return bearing vector
   */
-  virtual Vec3 operator () ( const Vec2& p ) const override
-  {
-    const Vec2 uv = ima2cam(p);
-
-    const double
-      lon = uv.x() * 2 * M_PI,
-      lat = uv.y() * 2 * M_PI;
-
-    return {
-      cos(lat) * sin(lon),
-      -sin(lat),
-      cos(lat) * cos(lon)};
-  }
+  virtual Vec3 operator () ( const Vec2& p ) const override;
 
   /**
   * @brief Compute projection of a 3D point into the image plane
@@ -136,111 +96,79 @@ using  class_type = Intrinsic_Spherical;
   */
   Vec2 project(
     const geometry::Pose3 & pose,
-    const Vec3 & pt3D ) const override
-  {
-    const Vec3 X = pose( pt3D ); // apply pose
-    const double lon = atan2(X.x(), X.z()); // Horizontal normalization of the  X-Z component
-    const double lat = atan2(-X.y(), sqrt(X.x()*X.x() + X.z()*X.z())); // Tilt angle
-    // denormalization (angle to pixel value)
-    return cam2ima({lon / (2 * M_PI), lat / (2 * M_PI)});
-  }
+    const Vec3 & pt3D ) const override;
 
   /**
   * @brief Does the camera model handle a distortion field?
   * @retval false
   */
-  virtual bool have_disto() const override { return false; }
+  virtual bool have_disto() const override;
 
   /**
   * @brief Add the distortion field to a point (that is in normalized camera frame)
   * @param p Point before distortion computation (in normalized camera frame)
   * @return the initial point p (spherical camera does not have distortion field)
   */
-  virtual Vec2 add_disto(const Vec2 &p) const override { return p; }
+  virtual Vec2 add_disto(const Vec2 &p) const override;
 
   /**
   * @brief Remove the distortion to a camera point (that is in normalized camera frame)
   * @param p Point with distortion
   * @return the initial point p (spherical camera does not have distortion field)
   */
-  virtual Vec2 remove_disto(const Vec2 &p) const override { return p; }
+  virtual Vec2 remove_disto(const Vec2 &p) const override;
 
   /**
   * @brief Return the un-distorted pixel (with removed distortion)
   * @param p Input distorted pixel
   * @return Point without distortion
   */
-  virtual Vec2 get_ud_pixel(const Vec2 &p) const override { return p; }
+  virtual Vec2 get_ud_pixel(const Vec2 &p) const override;
 
   /**
   * @brief Return the distorted pixel (with added distortion)
   * @param p Input pixel
   * @return Distorted pixel
   */
-  virtual Vec2 get_d_pixel(const Vec2 &p) const override { return p; }
+  virtual Vec2 get_d_pixel(const Vec2 &p) const override;
 
   /**
   * @brief Normalize a given unit pixel error to the camera plane
   * @param value Error in image plane
   * @return error of passing from the image plane to the camera plane
   */
-  virtual double imagePlane_toCameraPlaneError(double value) const override { return value; }
+  virtual double imagePlane_toCameraPlaneError(double value) const override;
 
   /**
   * @brief Return the projection matrix (interior & exterior) as a simplified projective projection
   * @param pose Extrinsic matrix
   * @return Concatenation of intrinsic matrix and extrinsic matrix
   */
-  virtual Mat34 get_projective_equivalent(const geometry::Pose3 &pose) const override
-  {
-    return HStack(pose.rotation(), pose.translation());
-  }
+  virtual Mat34 get_projective_equivalent(const geometry::Pose3 &pose) const override;
 
   /**
   * @brief Serialization out
   * @param ar Archive
   */
   template <class Archive>
-  void save( Archive & ar ) const
-  {
-    ar(cereal::base_class<IntrinsicBase>(this));
-  }
+  void save( Archive & ar ) const;
 
   /**
   * @brief  Serialization in
   * @param ar Archive
   */
   template <class Archive>
-  void load( Archive & ar )
-  {
-    ar(cereal::base_class<IntrinsicBase>(this));
-  }
+  void load( Archive & ar );
 
   /**
   * @brief Clone the object
   * @return A clone (copy of the stored object)
   */
-  IntrinsicBase * clone( void ) const override
-  {
-    return new class_type( *this );
-  }
+  IntrinsicBase * clone( void ) const override;
 
 };
 
 } // namespace cameras
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/types/vector.hpp>
-
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Intrinsic_Spherical, "spherical");
-
-namespace cereal
-{
-  // This struct specialization will tell cereal which is the right way to serialize the ambiguity
-  template <class Archive> struct specialize<Archive, openMVG::cameras::Intrinsic_Spherical, cereal::specialization::member_load_save> {};
-}
-
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Intrinsic_Spherical);
 
 #endif // #ifndef OPENMVG_CAMERAS_CAMERA_SPHERICAL_HPP

--- a/src/openMVG/cameras/Camera_undistort_image.cpp
+++ b/src/openMVG/cameras/Camera_undistort_image.cpp
@@ -124,13 +124,16 @@ void UndistortImageResized(
 using namespace openMVG::image;
 
 typedef unsigned char Gray8;
-template void UndistortImage<Image<unsigned char>>(const Image<Gray8> &, const IntrinsicBase *, Image<Gray8> &, Gray8);
+template void UndistortImage<Image<Gray8>>(const Image<Gray8> &, const IntrinsicBase *, Image<Gray8> &, Gray8);
+template void UndistortImageResized<Image<Gray8>>(const Image<Gray8> &, const IntrinsicBase *, Image<Gray8> &, Gray8, const uint32_t, const uint32_t);
 
 typedef Rgb<unsigned char> RGB8;
 template void UndistortImage<Image<RGB8>>(const Image<RGB8> &, const IntrinsicBase *, Image<RGB8> &, RGB8);
+template void UndistortImageResized<Image<RGB8>>(const Image<RGB8> &, const IntrinsicBase *, Image<RGB8> &, RGB8, const uint32_t, const uint32_t);
 
 typedef Rgba<unsigned char> RGBA8;
 template void UndistortImage<Image<RGBA8>>(const Image<RGBA8> &, const IntrinsicBase *, Image<RGBA8> &, RGBA8);
+template void UndistortImageResized<Image<RGBA8>>(const Image<RGBA8> &, const IntrinsicBase *, Image<RGBA8> &, RGBA8, const uint32_t, const uint32_t);
 
 } // namespace cameras
 } // namespace openMVG

--- a/src/openMVG/cameras/Camera_undistort_image.cpp
+++ b/src/openMVG/cameras/Camera_undistort_image.cpp
@@ -1,0 +1,137 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/cameras/Camera_undistort_image.hpp"
+#include "openMVG/image/image_container.hpp"
+#include "openMVG/image/pixel_types.hpp"
+#include "openMVG/image/sample.hpp"
+
+namespace openMVG
+{
+namespace cameras
+{
+
+template <typename Image>
+void UndistortImage(
+  const Image& imageIn,
+  const IntrinsicBase * cam,
+  Image & image_ud,
+  typename Image::Tpixel fillcolor )
+{
+  if ( !cam->have_disto() ) // no distortion, perform a direct copy
+  {
+    image_ud = imageIn;
+  }
+  else // There is distortion
+  {
+    image_ud.resize( imageIn.Width(), imageIn.Height(), true, fillcolor );
+    const image::Sampler2d<image::SamplerLinear> sampler;
+#ifdef OPENMVG_USE_OPENMP
+    #pragma omp parallel for
+#endif
+    for ( int j = 0; j < imageIn.Height(); ++j )
+      for ( int i = 0; i < imageIn.Width(); ++i )
+      {
+        const Vec2 undisto_pix( i, j );
+        // compute coordinates with distortion
+        const Vec2 disto_pix = cam->get_d_pixel( undisto_pix );
+        // pick pixel if it is in the image domain
+        if ( imageIn.Contains( disto_pix( 1 ), disto_pix( 0 ) ) )
+        {
+          image_ud( j, i ) = sampler( imageIn, disto_pix( 1 ), disto_pix( 0 ) );
+        }
+      }
+  }
+}
+
+template <typename Image>
+void UndistortImageResized(
+  const Image& imageIn,
+  const IntrinsicBase * cam,
+  Image & image_ud,
+  typename Image::Tpixel fillcolor,
+  const uint32_t max_ud_width,
+  const uint32_t max_ud_height)
+{
+  if ( !cam->have_disto() ) // no distortion, perform a direct copy
+  {
+    image_ud = imageIn;
+  }
+  else // There is distortion
+  {
+    // 1 - Compute size of the Undistorted image
+    int min_x = std::numeric_limits<int>::max();
+    int min_y = std::numeric_limits<int>::max();
+    int max_x = std::numeric_limits<int>::lowest();
+    int max_y = std::numeric_limits<int>::lowest();
+
+    for( int id_row = 0 ; id_row < imageIn.Height() ; ++id_row )
+    {
+      for( int id_col = 0 ; id_col < imageIn.Width() ; ++id_col )
+      {
+        const Vec2 dist_pix( id_col , id_row );
+        const Vec2 undist_pix = cam->get_ud_pixel( dist_pix );
+
+        const int x = static_cast<int>( undist_pix[0] );
+        const int y = static_cast<int>( undist_pix[1] );
+
+        min_x = std::min( x , min_x );
+        min_y = std::min( y , min_y );
+        max_x = std::max( x , max_x );
+        max_y = std::max( y , max_y );
+      }
+    }
+
+    // Ensure size is at least 1 pixel (width and height)
+    const int computed_size_x = std::max( 1 , max_x - min_x + 1 );
+    const int computed_size_y = std::max( 1 , max_y - min_y + 1 );
+
+    // Compute real size (ensure we do not have infinite size)
+    const uint32_t real_size_x = std::min( max_ud_width , (uint32_t)computed_size_x );
+    const uint32_t real_size_y = std::min( max_ud_height , (uint32_t)computed_size_y );
+    
+    // 2 - Compute inverse projection to fill the output image 
+    image_ud.resize( real_size_x , real_size_y , true, fillcolor );
+    const image::Sampler2d<image::SamplerLinear> sampler;
+  
+#ifdef OPENMVG_USE_OPENMP
+    #pragma omp parallel for
+#endif
+    for ( int j = 0; j < real_size_y; ++j )
+      for ( int i = 0; i < real_size_x ; ++i )
+      { 
+        const Vec2 undisto_pix( i + min_x , j + min_y );
+        // compute coordinates with distortion
+        const Vec2 disto_pix = cam->get_d_pixel( undisto_pix );
+
+        // pick pixel if it is in the image domain
+        if ( imageIn.Contains( disto_pix( 1 ), disto_pix( 0 ) ) &&
+             (! std::isnan( disto_pix[0] )) &&
+             (! std::isnan( disto_pix[1] )) &&
+             (! std::isinf( disto_pix[0] )) &&
+             (! std::isinf( disto_pix[1] )) )
+        {
+          image_ud( j, i ) = sampler( imageIn, disto_pix( 1 ), disto_pix( 0 ) );
+        }
+      }
+  }
+}
+using namespace openMVG::image;
+
+typedef unsigned char Gray8;
+template void UndistortImage<Image<unsigned char>>(const Image<Gray8> &, const IntrinsicBase *, Image<Gray8> &, Gray8);
+
+typedef Rgb<unsigned char> RGB8;
+template void UndistortImage<Image<RGB8>>(const Image<RGB8> &, const IntrinsicBase *, Image<RGB8> &, RGB8);
+
+typedef Rgba<unsigned char> RGBA8;
+template void UndistortImage<Image<RGBA8>>(const Image<RGBA8> &, const IntrinsicBase *, Image<RGBA8> &, RGBA8);
+
+} // namespace cameras
+} // namespace openMVG
+

--- a/src/openMVG/cameras/Camera_undistort_image.hpp
+++ b/src/openMVG/cameras/Camera_undistort_image.hpp
@@ -9,13 +9,17 @@
 #ifndef OPENMVG_CAMERAS_CAMERA_UNDISTORT_IMAGE_HPP
 #define OPENMVG_CAMERAS_CAMERA_UNDISTORT_IMAGE_HPP
 
+
+#include "openMVG/cameras/Camera_Intrinsics.hpp"
+
+/*
 #include <limits>
 #include <cmath>
 
 #include "openMVG/cameras/Camera_Intrinsics.hpp"
 #include "openMVG/image/image_container.hpp"
 #include "openMVG/image/sample.hpp"
-
+*/
 namespace openMVG
 {
 namespace cameras
@@ -33,33 +37,7 @@ void UndistortImage(
   const Image& imageIn,
   const IntrinsicBase * cam,
   Image & image_ud,
-  typename Image::Tpixel fillcolor = typename Image::Tpixel( 0 ) )
-{
-  if ( !cam->have_disto() ) // no distortion, perform a direct copy
-  {
-    image_ud = imageIn;
-  }
-  else // There is distortion
-  {
-    image_ud.resize( imageIn.Width(), imageIn.Height(), true, fillcolor );
-    const image::Sampler2d<image::SamplerLinear> sampler;
-#ifdef OPENMVG_USE_OPENMP
-    #pragma omp parallel for
-#endif
-    for ( int j = 0; j < imageIn.Height(); ++j )
-      for ( int i = 0; i < imageIn.Width(); ++i )
-      {
-        const Vec2 undisto_pix( i, j );
-        // compute coordinates with distortion
-        const Vec2 disto_pix = cam->get_d_pixel( undisto_pix );
-        // pick pixel if it is in the image domain
-        if ( imageIn.Contains( disto_pix( 1 ), disto_pix( 0 ) ) )
-        {
-          image_ud( j, i ) = sampler( imageIn, disto_pix( 1 ), disto_pix( 0 ) );
-        }
-      }
-  }
-}
+  typename Image::Tpixel fillcolor = typename Image::Tpixel( 0 ) );
 
 /**
 * @brief  Undistort an image according a given camera & it's distortion model
@@ -78,71 +56,7 @@ void UndistortImageResized(
   Image & image_ud,
   typename Image::Tpixel fillcolor = typename Image::Tpixel( 0 ),
   const uint32_t max_ud_width = 10000,
-  const uint32_t max_ud_height = 10000)
-{
-  if ( !cam->have_disto() ) // no distortion, perform a direct copy
-  {
-    image_ud = imageIn;
-  }
-  else // There is distortion
-  {
-    // 1 - Compute size of the Undistorted image
-    int min_x = std::numeric_limits<int>::max();
-    int min_y = std::numeric_limits<int>::max();
-    int max_x = std::numeric_limits<int>::lowest();
-    int max_y = std::numeric_limits<int>::lowest();
-
-    for( int id_row = 0 ; id_row < imageIn.Height() ; ++id_row )
-    {
-      for( int id_col = 0 ; id_col < imageIn.Width() ; ++id_col )
-      {
-        const Vec2 dist_pix( id_col , id_row );
-        const Vec2 undist_pix = cam->get_ud_pixel( dist_pix );
-
-        const int x = static_cast<int>( undist_pix[0] );
-        const int y = static_cast<int>( undist_pix[1] );
-
-        min_x = std::min( x , min_x );
-        min_y = std::min( y , min_y );
-        max_x = std::max( x , max_x );
-        max_y = std::max( y , max_y );
-      }
-    }
-
-    // Ensure size is at least 1 pixel (width and height)
-    const int computed_size_x = std::max( 1 , max_x - min_x + 1 );
-    const int computed_size_y = std::max( 1 , max_y - min_y + 1 );
-
-    // Compute real size (ensure we do not have infinite size)
-    const uint32_t real_size_x = std::min( max_ud_width , (uint32_t)computed_size_x );
-    const uint32_t real_size_y = std::min( max_ud_height , (uint32_t)computed_size_y );
-    
-    // 2 - Compute inverse projection to fill the output image 
-    image_ud.resize( real_size_x , real_size_y , true, fillcolor );
-    const image::Sampler2d<image::SamplerLinear> sampler;
-  
-#ifdef OPENMVG_USE_OPENMP
-    #pragma omp parallel for
-#endif
-    for ( int j = 0; j < real_size_y; ++j )
-      for ( int i = 0; i < real_size_x ; ++i )
-      { 
-        const Vec2 undisto_pix( i + min_x , j + min_y );
-        // compute coordinates with distortion
-        const Vec2 disto_pix = cam->get_d_pixel( undisto_pix );
-
-        // pick pixel if it is in the image domain
-        if ( imageIn.Contains( disto_pix( 1 ), disto_pix( 0 ) ) &&
-             (! std::isnan( disto_pix[0] )) &&
-             (! std::isnan( disto_pix[1] )) &&
-             (! std::isinf( disto_pix[0] )) &&
-             (! std::isinf( disto_pix[1] )) )
-        {
-          image_ud( j, i ) = sampler( imageIn, disto_pix( 1 ), disto_pix( 0 ) );
-        }
-      }
-  }
-}
+  const uint32_t max_ud_height = 10000);
 
 
 } // namespace cameras

--- a/src/openMVG/cameras/PinholeCamera.cpp
+++ b/src/openMVG/cameras/PinholeCamera.cpp
@@ -1,0 +1,111 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2012, 2013 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_CAMERAS_CAMERA_PINHOLECAMERA_HPP
+#define OPENMVG_CAMERAS_CAMERA_PINHOLECAMERA_HPP
+
+#include "openMVG/multiview/projection.hpp"
+#include "openMVG/numeric/numeric.h"
+
+namespace openMVG {
+namespace cameras {
+
+/// Pinhole camera P = K[R|t], t = -RC
+struct PinholeCamera
+{
+  PinholeCamera(
+    const Mat3 & K = Mat3::Identity(),
+    const Mat3 & R = Mat3::Identity(),
+    const Vec3 & t = Vec3::Zero())
+    : _K(K), _R(R), _t(t)
+  {
+    _C = -R.transpose() * t;
+    P_From_KRt(_K, _R, _t, &_P);
+  }
+
+  PinholeCamera(const Mat34 & P)
+  {
+    _P = P;
+    KRt_From_P(_P, &_K, &_R, &_t);
+    _C = -_R.transpose() * _t;
+  }
+
+  /// Projection matrix P = K[R|t]
+  Mat34 _P;
+
+  /// Intrinsic parameter (Focal, principal point)
+  Mat3 _K;
+
+  /// Extrinsic Rotation
+  Mat3 _R;
+
+  /// Extrinsic translation
+  Vec3 _t;
+
+  /// Camera center
+  Vec3 _C;
+
+  /// Projection of a 3D point into the camera plane
+  static Vec2 Project(const Mat34 & P, const Vec3 & pt3D)
+  {
+    return openMVG::Project(P, pt3D);
+  }
+
+  /// Projection of a 3D point into the camera plane (member function)
+  Vec2 Project(const Vec3 & pt3D) const
+  {
+    return openMVG::Project(_P, pt3D);
+  }
+
+  /// Return the residual value to the given 2d point
+  static double Residual(
+    const Mat34 & P,
+    const Vec3 & pt3D,
+    const Vec2 & ref) {
+    return (ref - openMVG::Project(P, pt3D)).norm();
+  }
+
+  /// Return the residual value to the given 2d point
+  double Residual(const Vec3 & pt3D, const Vec2 & ref) const  {
+    return (ref - openMVG::Project(_P, pt3D)).norm();
+  }
+
+  double ResidualSquared(const Vec3 & pt3D, const Vec2 & ref) const  {
+    return (ref - openMVG::Project(_P, pt3D)).squaredNorm();
+  }
+
+  // Compute the depth of the X point. R*X[2]+t[2].
+  double Depth(const Vec3 &X) const{
+    return openMVG::Depth(_R, _t, X);
+  }
+
+  /// Return the angle (degree) between two pinhole point rays
+  static double AngleBetweenRay(
+    const PinholeCamera & cam1,
+    const PinholeCamera & cam2,
+    const Vec2 & x1, const Vec2 & x2)
+  {
+    // x = (u, v, 1.0)  // image coordinates
+    // X = R.t() * K.inv() * x + C // Camera world point
+    // getting the ray:
+    // ray = X - C = R.t() * K.inv() * x
+    Vec3 ray1 = (cam1._R.transpose() *
+      (cam1._K.inverse() * Vec3(x1(0), x1(1), 1.))).normalized();
+    Vec3 ray2 = (cam2._R.transpose() *
+      (cam2._K.inverse() * Vec3(x2(0), x2(1), 1.))).normalized();
+    double mag = ray1.norm() * ray2.norm();
+    double dotAngle = ray1.dot(ray2);
+    return R2D(acos(clamp(dotAngle/mag, -1.0 + 1.e-8, 1.0 - 1.e-8)));
+  }
+
+};
+
+} // namespace cameras
+} // namespace openMVG
+
+#endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLECAMERA_HPP

--- a/src/openMVG/features/akaze/AKAZE.cpp
+++ b/src/openMVG/features/akaze/AKAZE.cpp
@@ -12,6 +12,8 @@
 #include "openMVG/image/image_diffusion.hpp"
 #include "openMVG/image/image_resampling.hpp"
 
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
 #include <cmath>
 
 namespace openMVG {
@@ -481,5 +483,18 @@ void AKAZE::Compute_Main_Orientation(
   }
 }
 
+template<class Archive>
+void AKAZE::Params::serialize(Archive & ar)
+{
+  ar(
+    cereal::make_nvp("iNbOctave", iNbOctave),
+    cereal::make_nvp("iNbSlicePerOctave", iNbSlicePerOctave),
+    cereal::make_nvp("fSigma0", fSigma0),
+    cereal::make_nvp("fThreshold", fThreshold),
+    cereal::make_nvp("fDesc_factor", fDesc_factor));
+}
+
+template void AKAZE::Params::serialize<cereal::JSONInputArchive>(cereal::JSONInputArchive&);
+template void AKAZE::Params::serialize<cereal::JSONOutputArchive>(cereal::JSONOutputArchive&);
 } // namespace features
 } // namespace openMVG

--- a/src/openMVG/features/akaze/AKAZE.hpp
+++ b/src/openMVG/features/akaze/AKAZE.hpp
@@ -38,7 +38,6 @@
 
 #include "openMVG/image/image_container.hpp"
 
-#include <cereal/cereal.hpp>
 
 namespace openMVG {
 namespace features {
@@ -87,15 +86,7 @@ public:
     }
 
     template<class Archive>
-    void serialize(Archive & ar)
-    {
-      ar(
-        cereal::make_nvp("iNbOctave", iNbOctave),
-        cereal::make_nvp("iNbSlicePerOctave", iNbSlicePerOctave),
-        cereal::make_nvp("fSigma0", fSigma0),
-        cereal::make_nvp("fThreshold", fThreshold),
-        cereal::make_nvp("fDesc_factor", fDesc_factor));
-    }
+    void serialize(Archive & ar);
 
     int iNbOctave; ///< Octave to process
     int iNbSlicePerOctave; ///< Levels per octave

--- a/src/openMVG/features/image_describer_akaze.cpp
+++ b/src/openMVG/features/image_describer_akaze.cpp
@@ -1,0 +1,251 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/features/image_describer_akaze.hpp"
+#include "openMVG/features/akaze/msurf_descriptor.hpp"
+#include "openMVG/features/liop/liop_descriptor.hpp"
+#include "openMVG/features/regions_factory.hpp"
+#include "openMVG/features/akaze/mldb_descriptor.hpp"
+
+#include <cereal/cereal.hpp>
+
+namespace openMVG {
+namespace features {
+
+AKAZE_Image_describer::Params::Params(
+  const features::AKAZE::Params config,
+  EAKAZE_DESCRIPTOR eAkazeDescriptor
+):options_(config), eAkazeDescriptor_(eAkazeDescriptor){}
+
+template<class Archive>
+void AKAZE_Image_describer::Params::serialize(Archive & ar)
+{
+  ar(options_, eAkazeDescriptor_);
+}
+
+AKAZE_Image_describer::AKAZE_Image_describer(
+  const Params & params,
+  bool bOrientation
+):Image_describer(), params_(params), bOrientation_(bOrientation) 
+{ 
+}
+
+bool AKAZE_Image_describer::Set_configuration_preset(EDESCRIBER_PRESET preset)
+{
+  switch(preset)
+  {
+  case NORMAL_PRESET:
+    params_.options_.fThreshold = features::AKAZE::Params().fThreshold;
+  break;
+  case HIGH_PRESET:
+    params_.options_.fThreshold = features::AKAZE::Params().fThreshold/10.;
+  break;
+  case ULTRA_PRESET:
+   params_.options_.fThreshold = features::AKAZE::Params().fThreshold/100.;
+  break;
+  default:
+    return false;
+  }
+  return true;
+}
+
+bool AKAZE_Image_describer::Describe
+(
+  const image::Image<unsigned char>& image,
+  std::unique_ptr<Regions> &regions,
+  const image::Image<unsigned char> * mask
+)
+{
+  params_.options_.fDesc_factor =
+    (params_.eAkazeDescriptor_ == AKAZE_MSURF ||
+    params_.eAkazeDescriptor_ == AKAZE_LIOP) ? 10.f*sqrtf(2.f)
+    : 11.f*sqrtf(2.f); // MLDB
+
+  AKAZE akaze(image, params_.options_);
+  akaze.Compute_AKAZEScaleSpace();
+  std::vector<AKAZEKeypoint> kpts;
+  kpts.reserve(5000);
+  akaze.Feature_Detection(kpts);
+  akaze.Do_Subpixel_Refinement(kpts);
+
+  Allocate(regions);
+
+  switch(params_.eAkazeDescriptor_)
+  {
+    case AKAZE_MSURF:
+    {
+      // Build alias to cached data
+      AKAZE_Float_Regions * regionsCasted = dynamic_cast<AKAZE_Float_Regions*>(regions.get());
+      regionsCasted->Features().resize(kpts.size());
+      regionsCasted->Descriptors().resize(kpts.size());
+
+    #ifdef OPENMVG_USE_OPENMP
+      #pragma omp parallel for
+    #endif
+      for (int i = 0; i < static_cast<int>(kpts.size()); ++i)
+      {
+        AKAZEKeypoint ptAkaze = kpts[i];
+
+        // Feature masking
+        if (mask)
+        {
+          const image::Image<unsigned char> & maskIma = *mask;
+          if (maskIma(ptAkaze.y, ptAkaze.x) == 0)
+            continue;
+        }
+
+        const TEvolution & cur_slice = akaze.getSlices()[ptAkaze.class_id];
+
+        if (bOrientation_)
+          akaze.Compute_Main_Orientation(ptAkaze, cur_slice.Lx, cur_slice.Ly);
+        else
+          ptAkaze.angle = 0.0f;
+
+        regionsCasted->Features()[i] =
+          SIOPointFeature(ptAkaze.x, ptAkaze.y, ptAkaze.size, ptAkaze.angle);
+
+        ComputeMSURFDescriptor(cur_slice.Lx, cur_slice.Ly, ptAkaze.octave,
+          regionsCasted->Features()[i],
+          regionsCasted->Descriptors()[i]);
+      }
+    }
+    break;
+    case AKAZE_LIOP:
+    {
+      // Build alias to cached data
+      AKAZE_Liop_Regions * regionsCasted = dynamic_cast<AKAZE_Liop_Regions*>(regions.get());
+      regionsCasted->Features().resize(kpts.size());
+      regionsCasted->Descriptors().resize(kpts.size());
+
+      // Init LIOP extractor
+      LIOP::Liop_Descriptor_Extractor liop_extractor;
+
+    #ifdef OPENMVG_USE_OPENMP
+      #pragma omp parallel for
+    #endif
+      for (int i = 0; i < static_cast<int>(kpts.size()); ++i)
+      {
+        AKAZEKeypoint ptAkaze = kpts[i];
+
+        // Feature masking
+        if (mask)
+        {
+          const image::Image<unsigned char> & maskIma = *mask;
+          if (maskIma(ptAkaze.y, ptAkaze.x) > 0)
+            continue;
+        }
+
+        const TEvolution & cur_slice = akaze.getSlices()[ptAkaze.class_id];
+
+        if (bOrientation_)
+          akaze.Compute_Main_Orientation(ptAkaze, cur_slice.Lx, cur_slice.Ly);
+        else
+          ptAkaze.angle = 0.0f;
+
+        regionsCasted->Features()[i] =
+          SIOPointFeature(ptAkaze.x, ptAkaze.y, ptAkaze.size, ptAkaze.angle);
+
+        // Compute LIOP descriptor (do not need rotation computation, since
+        //  LIOP descriptor is rotation invariant).
+        // Rescale for LIOP patch extraction
+        const SIOPointFeature fp =
+            SIOPointFeature(ptAkaze.x, ptAkaze.y,
+            ptAkaze.size/2.0, ptAkaze.angle);
+
+        float desc[144];
+        liop_extractor.extract(image, fp, desc);
+        for(int j=0; j < 144; ++j)
+          regionsCasted->Descriptors()[i][j] =
+            static_cast<unsigned char>(desc[j] * 255.f +.5f);
+      }
+    }
+    break;
+    case AKAZE_MLDB:
+    {
+      // Build alias to cached data
+      AKAZE_Binary_Regions * regionsCasted = dynamic_cast<AKAZE_Binary_Regions*>(regions.get());
+      regionsCasted->Features().resize(kpts.size());
+      regionsCasted->Descriptors().resize(kpts.size());
+
+    #ifdef OPENMVG_USE_OPENMP
+      #pragma omp parallel for
+    #endif
+      for (int i = 0; i < static_cast<int>(kpts.size()); ++i)
+      {
+        AKAZEKeypoint ptAkaze = kpts[i];
+
+        // Feature masking
+        if (mask)
+        {
+          const image::Image<unsigned char> & maskIma = *mask;
+          if (maskIma(ptAkaze.y, ptAkaze.x) > 0)
+            continue;
+        }
+
+        const TEvolution & cur_slice = akaze.getSlices()[ptAkaze.class_id];
+
+        if (bOrientation_)
+          akaze.Compute_Main_Orientation(ptAkaze, cur_slice.Lx, cur_slice.Ly);
+        else
+          ptAkaze.angle = 0.0f;
+
+        regionsCasted->Features()[i] =
+          SIOPointFeature(ptAkaze.x, ptAkaze.y, ptAkaze.size, ptAkaze.angle);
+
+        // Compute MLDB descriptor
+        Descriptor<bool,486> desc;
+        ComputeMLDBDescriptor(cur_slice.cur, cur_slice.Lx, cur_slice.Ly,
+          ptAkaze.octave, regionsCasted->Features()[i], desc);
+        // convert the bool vector to the binary unsigned char array
+        unsigned char * ptr = reinterpret_cast<unsigned char*>(&regionsCasted->Descriptors()[i]);
+        memset(ptr, 0, regionsCasted->DescriptorLength()*sizeof(unsigned char));
+        // For each byte
+        for (int j = 0; j < std::ceil(486./8.); ++j, ++ptr) {
+          // set the corresponding 8bits to the good values
+          for (int iBit = 0; iBit < 8 && j*8+iBit < 486; ++iBit)  {
+            *ptr |= desc[j*8+iBit] << iBit;
+          }
+        }
+      }
+    }
+    break;
+  }
+  return true;
+}
+
+/// Allocate Regions type depending of the Image_describer
+void AKAZE_Image_describer::Allocate(std::unique_ptr<Regions> &regions) const
+{
+  switch(params_.eAkazeDescriptor_)
+  {
+    case AKAZE_MSURF:
+      return regions.reset(new AKAZE_Float_Regions);
+    break;
+    case AKAZE_LIOP:
+      return regions.reset(new AKAZE_Liop_Regions);
+    case AKAZE_MLDB:
+     return regions.reset(new AKAZE_Binary_Regions);
+    break;
+  }
+}
+
+template<class Archive>
+void AKAZE_Image_describer::serialize(Archive & ar)
+{
+  ar(
+   cereal::make_nvp("params", params_),
+   cereal::make_nvp("bOrientation", bOrientation_));
+}
+
+} // namespace features
+} // namespace openMVG
+
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/archives/json.hpp>
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Image_describer, "AKAZE_Image_describer");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::AKAZE_Image_describer)

--- a/src/openMVG/features/image_describer_akaze.hpp
+++ b/src/openMVG/features/image_describer_akaze.hpp
@@ -9,18 +9,8 @@
 #ifndef OPENMVG_FEATURES_AKAZE_IMAGE_DESCRIBER_HPP
 #define OPENMVG_FEATURES_AKAZE_IMAGE_DESCRIBER_HPP
 
-#include <iostream>
-#include <numeric>
-#include <vector>
-
-#include "openMVG/features/akaze/AKAZE.hpp"
-#include "openMVG/features/akaze/mldb_descriptor.hpp"
-#include "openMVG/features/akaze/msurf_descriptor.hpp"
 #include "openMVG/features/image_describer.hpp"
-#include "openMVG/features/liop/liop_descriptor.hpp"
-#include "openMVG/features/regions_factory.hpp"
-
-#include <cereal/cereal.hpp>
+#include "openMVG/features/akaze/AKAZE.hpp"
 
 namespace openMVG {
 namespace features {
@@ -41,13 +31,10 @@ public:
     Params(
       const features::AKAZE::Params config = features::AKAZE::Params(),
       EAKAZE_DESCRIPTOR eAkazeDescriptor = AKAZE_MSURF
-    ):options_(config), eAkazeDescriptor_(eAkazeDescriptor){}
+    );
 
     template<class Archive>
-    void serialize(Archive & ar)
-    {
-      ar(options_, eAkazeDescriptor_);
-    }
+    void serialize(Archive & ar);
 
     // Parameters
     features::AKAZE::Params options_;
@@ -57,27 +44,10 @@ public:
   AKAZE_Image_describer(
     const Params & params = std::move(Params()),
     bool bOrientation = true
-  ):Image_describer(), params_(params), bOrientation_(bOrientation) {}
+  );
 
 
-  bool Set_configuration_preset(EDESCRIBER_PRESET preset) override
-  {
-    switch(preset)
-    {
-    case NORMAL_PRESET:
-      params_.options_.fThreshold = features::AKAZE::Params().fThreshold;
-    break;
-    case HIGH_PRESET:
-      params_.options_.fThreshold = features::AKAZE::Params().fThreshold/10.;
-    break;
-    case ULTRA_PRESET:
-     params_.options_.fThreshold = features::AKAZE::Params().fThreshold/100.;
-    break;
-    default:
-      return false;
-    }
-    return true;
-  }
+  bool Set_configuration_preset(EDESCRIBER_PRESET preset) override;;
 
   /**
   @brief Detect regions on the image and compute their attributes (description)
@@ -91,188 +61,13 @@ public:
     const image::Image<unsigned char>& image,
     std::unique_ptr<Regions> &regions,
     const image::Image<unsigned char> * mask = nullptr
-  ) override
-  {
-    params_.options_.fDesc_factor =
-      (params_.eAkazeDescriptor_ == AKAZE_MSURF ||
-      params_.eAkazeDescriptor_ == AKAZE_LIOP) ? 10.f*sqrtf(2.f)
-      : 11.f*sqrtf(2.f); // MLDB
-
-    AKAZE akaze(image, params_.options_);
-    akaze.Compute_AKAZEScaleSpace();
-    std::vector<AKAZEKeypoint> kpts;
-    kpts.reserve(5000);
-    akaze.Feature_Detection(kpts);
-    akaze.Do_Subpixel_Refinement(kpts);
-
-    Allocate(regions);
-
-    switch(params_.eAkazeDescriptor_)
-    {
-      case AKAZE_MSURF:
-      {
-        // Build alias to cached data
-        AKAZE_Float_Regions * regionsCasted = dynamic_cast<AKAZE_Float_Regions*>(regions.get());
-        regionsCasted->Features().resize(kpts.size());
-        regionsCasted->Descriptors().resize(kpts.size());
-
-      #ifdef OPENMVG_USE_OPENMP
-        #pragma omp parallel for
-      #endif
-        for (int i = 0; i < static_cast<int>(kpts.size()); ++i)
-        {
-          AKAZEKeypoint ptAkaze = kpts[i];
-
-          // Feature masking
-          if (mask)
-          {
-            const image::Image<unsigned char> & maskIma = *mask;
-            if (maskIma(ptAkaze.y, ptAkaze.x) == 0)
-              continue;
-          }
-
-          const TEvolution & cur_slice = akaze.getSlices()[ptAkaze.class_id];
-
-          if (bOrientation_)
-            akaze.Compute_Main_Orientation(ptAkaze, cur_slice.Lx, cur_slice.Ly);
-          else
-            ptAkaze.angle = 0.0f;
-
-          regionsCasted->Features()[i] =
-            SIOPointFeature(ptAkaze.x, ptAkaze.y, ptAkaze.size, ptAkaze.angle);
-
-          ComputeMSURFDescriptor(cur_slice.Lx, cur_slice.Ly, ptAkaze.octave,
-            regionsCasted->Features()[i],
-            regionsCasted->Descriptors()[i]);
-        }
-      }
-      break;
-      case AKAZE_LIOP:
-      {
-        // Build alias to cached data
-        AKAZE_Liop_Regions * regionsCasted = dynamic_cast<AKAZE_Liop_Regions*>(regions.get());
-        regionsCasted->Features().resize(kpts.size());
-        regionsCasted->Descriptors().resize(kpts.size());
-
-        // Init LIOP extractor
-        LIOP::Liop_Descriptor_Extractor liop_extractor;
-
-      #ifdef OPENMVG_USE_OPENMP
-        #pragma omp parallel for
-      #endif
-        for (int i = 0; i < static_cast<int>(kpts.size()); ++i)
-        {
-          AKAZEKeypoint ptAkaze = kpts[i];
-
-          // Feature masking
-          if (mask)
-          {
-            const image::Image<unsigned char> & maskIma = *mask;
-            if (maskIma(ptAkaze.y, ptAkaze.x) > 0)
-              continue;
-          }
-
-          const TEvolution & cur_slice = akaze.getSlices()[ptAkaze.class_id];
-
-          if (bOrientation_)
-            akaze.Compute_Main_Orientation(ptAkaze, cur_slice.Lx, cur_slice.Ly);
-          else
-            ptAkaze.angle = 0.0f;
-
-          regionsCasted->Features()[i] =
-            SIOPointFeature(ptAkaze.x, ptAkaze.y, ptAkaze.size, ptAkaze.angle);
-
-          // Compute LIOP descriptor (do not need rotation computation, since
-          //  LIOP descriptor is rotation invariant).
-          // Rescale for LIOP patch extraction
-          const SIOPointFeature fp =
-              SIOPointFeature(ptAkaze.x, ptAkaze.y,
-              ptAkaze.size/2.0, ptAkaze.angle);
-
-          float desc[144];
-          liop_extractor.extract(image, fp, desc);
-          for(int j=0; j < 144; ++j)
-            regionsCasted->Descriptors()[i][j] =
-              static_cast<unsigned char>(desc[j] * 255.f +.5f);
-        }
-      }
-      break;
-      case AKAZE_MLDB:
-      {
-        // Build alias to cached data
-        AKAZE_Binary_Regions * regionsCasted = dynamic_cast<AKAZE_Binary_Regions*>(regions.get());
-        regionsCasted->Features().resize(kpts.size());
-        regionsCasted->Descriptors().resize(kpts.size());
-
-      #ifdef OPENMVG_USE_OPENMP
-        #pragma omp parallel for
-      #endif
-        for (int i = 0; i < static_cast<int>(kpts.size()); ++i)
-        {
-          AKAZEKeypoint ptAkaze = kpts[i];
-
-          // Feature masking
-          if (mask)
-          {
-            const image::Image<unsigned char> & maskIma = *mask;
-            if (maskIma(ptAkaze.y, ptAkaze.x) > 0)
-              continue;
-          }
-
-          const TEvolution & cur_slice = akaze.getSlices()[ptAkaze.class_id];
-
-          if (bOrientation_)
-            akaze.Compute_Main_Orientation(ptAkaze, cur_slice.Lx, cur_slice.Ly);
-          else
-            ptAkaze.angle = 0.0f;
-
-          regionsCasted->Features()[i] =
-            SIOPointFeature(ptAkaze.x, ptAkaze.y, ptAkaze.size, ptAkaze.angle);
-
-          // Compute MLDB descriptor
-          Descriptor<bool,486> desc;
-          ComputeMLDBDescriptor(cur_slice.cur, cur_slice.Lx, cur_slice.Ly,
-            ptAkaze.octave, regionsCasted->Features()[i], desc);
-          // convert the bool vector to the binary unsigned char array
-          unsigned char * ptr = reinterpret_cast<unsigned char*>(&regionsCasted->Descriptors()[i]);
-          memset(ptr, 0, regionsCasted->DescriptorLength()*sizeof(unsigned char));
-          // For each byte
-          for (int j = 0; j < std::ceil(486./8.); ++j, ++ptr) {
-            // set the corresponding 8bits to the good values
-            for (int iBit = 0; iBit < 8 && j*8+iBit < 486; ++iBit)  {
-              *ptr |= desc[j*8+iBit] << iBit;
-            }
-          }
-        }
-      }
-      break;
-    }
-    return true;
-  };
+  ) override;
 
   /// Allocate Regions type depending of the Image_describer
-  void Allocate(std::unique_ptr<Regions> &regions) const override
-  {
-    switch(params_.eAkazeDescriptor_)
-    {
-      case AKAZE_MSURF:
-        return regions.reset(new AKAZE_Float_Regions);
-      break;
-      case AKAZE_LIOP:
-        return regions.reset(new AKAZE_Liop_Regions);
-      case AKAZE_MLDB:
-       return regions.reset(new AKAZE_Binary_Regions);
-      break;
-    }
-  }
+  void Allocate(std::unique_ptr<Regions> &regions) const override;
 
   template<class Archive>
-  void serialize(Archive & ar)
-  {
-    ar(
-     cereal::make_nvp("params", params_),
-     cereal::make_nvp("bOrientation", bOrientation_));
-  }
+  void serialize(Archive & ar);
 
 private:
   Params params_;
@@ -281,10 +76,5 @@ private:
 
 } // namespace features
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/archives/json.hpp>
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Image_describer, "AKAZE_Image_describer");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::AKAZE_Image_describer)
 
 #endif // OPENMVG_FEATURES_AKAZE_IMAGE_DESCRIBER_HPP

--- a/src/openMVG/features/io_regions_type.cpp
+++ b/src/openMVG/features/io_regions_type.cpp
@@ -27,6 +27,7 @@ std::unique_ptr<features::Regions> Init_region_type_from_file
   const std::string & sImage_describer_file
 )
 {
+  static bool initRegions = openMVG::features::registerRegionFormats();
   std::unique_ptr<Regions> regions_type;
   if (stlplus::is_file(sImage_describer_file))
   {

--- a/src/openMVG/features/io_regions_type.cpp
+++ b/src/openMVG/features/io_regions_type.cpp
@@ -13,6 +13,7 @@
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <cereal/archives/json.hpp>
+#include <cereal/types/polymorphic.hpp>
 
 #include <fstream>
 #include <string>

--- a/src/openMVG/features/io_regions_type.cpp
+++ b/src/openMVG/features/io_regions_type.cpp
@@ -1,0 +1,48 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+#include "openMVG/features/io_regions_type.hpp"
+#include "openMVG/features/regions_factory.hpp"
+
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+#include <cereal/archives/json.hpp>
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace openMVG {
+namespace features {
+
+std::unique_ptr<features::Regions> Init_region_type_from_file
+(
+  const std::string & sImage_describer_file
+)
+{
+  std::unique_ptr<Regions> regions_type;
+  if (stlplus::is_file(sImage_describer_file))
+  {
+    // Dynamically load the regions type from the file
+    std::ifstream stream(sImage_describer_file.c_str());
+    if (stream.is_open())
+    {
+      cereal::JSONInputArchive archive(stream);
+      archive(cereal::make_nvp("regions_type", regions_type));
+    }
+  }
+  else // By default init a SIFT regions type (keep compatibility)
+  {
+    regions_type.reset(new features::SIFT_Regions());
+  }
+  return regions_type;
+}
+
+} // namespace features
+} // namespace openMVG

--- a/src/openMVG/features/io_regions_type.hpp
+++ b/src/openMVG/features/io_regions_type.hpp
@@ -9,41 +9,16 @@
 #ifndef OPENMVG_FEATURES_IO_REGIONS_TYPE_HPP
 #define OPENMVG_FEATURES_IO_REGIONS_TYPE_HPP
 
-#include <fstream>
-#include <string>
-#include <vector>
-
-#include "openMVG/features/regions_factory.hpp"
-#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
-
-#include <cereal/archives/json.hpp>
+#include "openMVG/features/regions.hpp"
 
 namespace openMVG {
 namespace features {
 
 // Init the regions_type from an image describer file (used for regions loading)
-inline std::unique_ptr<features::Regions> Init_region_type_from_file
+std::unique_ptr<features::Regions> Init_region_type_from_file
 (
   const std::string & sImage_describer_file
-)
-{
-  std::unique_ptr<Regions> regions_type;
-  if (stlplus::is_file(sImage_describer_file))
-  {
-    // Dynamically load the regions type from the file
-    std::ifstream stream(sImage_describer_file.c_str());
-    if (stream.is_open())
-    {
-      cereal::JSONInputArchive archive(stream);
-      archive(cereal::make_nvp("regions_type", regions_type));
-    }
-  }
-  else // By default init a SIFT regions type (keep compatibility)
-  {
-    regions_type.reset(new features::SIFT_Regions());
-  }
-  return regions_type;
-}
+);
 
 } // namespace features
 } // namespace openMVG

--- a/src/openMVG/features/regions_factory.cpp
+++ b/src/openMVG/features/regions_factory.cpp
@@ -1,0 +1,27 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/features/regions_factory.hpp"
+
+//--
+// Register region type for serialization
+//--
+#include <cereal/types/array.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/vector.hpp>
+#include <cereal/archives/json.hpp>
+
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Regions, "SIFT_Regions");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::SIFT_Regions)
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Float_Regions, "AKAZE_Float_Regions");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Float_Regions)
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Liop_Regions, "AKAZE_Liop_Regions");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Liop_Regions)
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Binary_Regions, "AKAZE_Binary_Regions");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Binary_Regions)
+

--- a/src/openMVG/features/regions_factory.cpp
+++ b/src/openMVG/features/regions_factory.cpp
@@ -25,3 +25,19 @@ CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::featur
 CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Binary_Regions, "AKAZE_Binary_Regions");
 CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Binary_Regions)
 
+
+bool openMVG::features::registerRegionFormats()
+{
+  // Force dynamic inititalization of region formats.
+  // See http://uscilab.github.io/cereal/polymorphism.html#registering-from-a-source-file
+  //
+  // "Be careful that there are special considerations to make for placing registration in 
+  // a source file, especially if you will not be explicitly referencing anything within
+  // that source file."
+
+    openMVG::features::SIFT_Regions r1;
+    openMVG::features::AKAZE_Float_Regions r2;
+    openMVG::features::AKAZE_Liop_Regions r3;
+    openMVG::features::AKAZE_Binary_Regions r4;
+    return true;
+}

--- a/src/openMVG/features/regions_factory.hpp
+++ b/src/openMVG/features/regions_factory.hpp
@@ -32,19 +32,5 @@ EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_INITIALIZER_LIST(openMVG::features::SIFT_
 EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_INITIALIZER_LIST(openMVG::features::AKAZE_Float_Regions)
 EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_INITIALIZER_LIST(openMVG::features::AKAZE_Liop_Regions)
 EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_INITIALIZER_LIST(openMVG::features::AKAZE_Binary_Regions)
-//--
-// Register region type for serialization
-//--
-#include <cereal/types/array.hpp>
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/types/vector.hpp>
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Regions, "SIFT_Regions");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::SIFT_Regions)
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Float_Regions, "AKAZE_Float_Regions");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Float_Regions)
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Liop_Regions, "AKAZE_Liop_Regions");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Liop_Regions)
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Binary_Regions, "AKAZE_Binary_Regions");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Binary_Regions)
 
 #endif // OPENMVG_FEATURES_REGIONS_FACTORY_HPP

--- a/src/openMVG/features/regions_factory.hpp
+++ b/src/openMVG/features/regions_factory.hpp
@@ -25,6 +25,11 @@ using AKAZE_Liop_Regions = Scalar_Regions<SIOPointFeature, unsigned char, 144>;
 /// Define the AKAZE Keypoint (with a binary descriptor saved in an uchar array)
 using AKAZE_Binary_Regions = Binary_Regions<SIOPointFeature, 64>;
 
+/**
+ * @brief This funcion has to be called when features is compiled as a static library.
+ * @return true
+ */
+bool registerRegionFormats();
 } // namespace features
 } // namespace openMVG
 

--- a/src/openMVG/features/sift/SIFT_Anatomy_Image_Describer.cpp
+++ b/src/openMVG/features/sift/SIFT_Anatomy_Image_Describer.cpp
@@ -1,0 +1,164 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/features/sift/SIFT_Anatomy_Image_Describer.hpp"
+#include "openMVG/image/image_container.hpp"
+#include "openMVG/features/regions_factory.hpp"
+#include "openMVG/features/sift/hierarchical_gaussian_scale_space.hpp"
+#include "openMVG/features/sift/sift_DescriptorExtractor.hpp"
+#include "openMVG/features/sift/sift_KeypointExtractor.hpp"
+
+#include <cereal/cereal.hpp>
+
+namespace openMVG {
+namespace features {
+
+SIFT_Anatomy_Image_describer::Params::Params(
+  int first_octave,
+  int num_octaves,
+  int num_scales,
+  float edge_threshold,
+  float peak_threshold,
+  bool root_sift
+):
+  first_octave_(first_octave),
+  num_octaves_(num_octaves),
+  num_scales_(num_scales),
+  edge_threshold_(edge_threshold),
+  peak_threshold_(peak_threshold),
+  root_sift_(root_sift) 
+{
+}
+
+template<class Archive>
+void SIFT_Anatomy_Image_describer::Params::serialize( Archive & ar )
+{
+  ar(
+    cereal::make_nvp("first_octave", first_octave_),
+    cereal::make_nvp("num_octaves",num_octaves_),
+    cereal::make_nvp("num_scales",num_scales_),
+    cereal::make_nvp("edge_threshold",edge_threshold_),
+    cereal::make_nvp("peak_threshold",peak_threshold_),
+    cereal::make_nvp("root_sift",root_sift_));
+}
+
+SIFT_Anatomy_Image_describer::SIFT_Anatomy_Image_describer
+(
+  const Params params
+)
+:Image_describer(), params_(params)
+{
+}
+
+bool SIFT_Anatomy_Image_describer::Set_configuration_preset(EDESCRIBER_PRESET preset)
+{
+  switch(preset)
+  {
+  case NORMAL_PRESET:
+    params_.peak_threshold_ = 0.04f;
+  break;
+  case HIGH_PRESET:
+    params_.peak_threshold_ = 0.01f;
+  break;
+  case ULTRA_PRESET:
+    params_.peak_threshold_ = 0.01f;
+    params_.first_octave_ = -1;
+  break;
+  default:
+    return false;
+  }
+  return true;
+}
+
+bool SIFT_Anatomy_Image_describer::Describe
+(
+  const image::Image<unsigned char>& image,
+  std::unique_ptr<Regions> &regions,
+  const image::Image<unsigned char> * mask
+)
+{
+  // Convert to float in range [0;1]
+  const image::Image<float> If(image.GetMat().cast<float>()/255.0f);
+
+  // compute sift keypoints
+  Allocate(regions);
+
+  // Build alias to cached data
+  SIFT_Regions * regionsCasted = dynamic_cast<SIFT_Regions*>(regions.get());
+  {
+    using namespace openMVG::features::sift;
+    const int supplementary_images = 3;
+    // => in order to ensure each gaussian slice is used in the process 3 extra images are required:
+    // +1 for dog computation
+    // +2 for 3d discrete extrema definition
+
+    HierarchicalGaussianScaleSpace octave_gen(
+      params_.num_octaves_,
+      params_.num_scales_,
+      (params_.first_octave_ == -1)
+      ? GaussianScaleSpaceParams(1.6f/2.0f, 1.0f/2.0f, 0.5f, supplementary_images)
+      : GaussianScaleSpaceParams(1.6f, 1.0f, 0.5f, supplementary_images));
+    octave_gen.SetImage( If );
+
+    std::vector<Keypoint> keypoints;
+    keypoints.reserve(5000);
+    Octave octave;
+    while ( octave_gen.NextOctave( octave ) )
+    {
+      std::vector< Keypoint > keys;
+      // Find Keypoints
+      SIFT_KeypointExtractor keypointDetector(
+        params_.peak_threshold_ / octave_gen.NbSlice(),
+        params_.edge_threshold_);
+      keypointDetector(octave, keys);
+      // Find Keypoints orientation and compute their description
+      Sift_DescriptorExtractor descriptorExtractor;
+      descriptorExtractor(octave, keys);
+
+      // Concatenate the found keypoints
+      std::move(keys.begin(), keys.end(), std::back_inserter(keypoints));
+    }
+    for (const auto & k : keypoints)
+    {
+      // Feature masking
+      if (mask)
+      {
+        const image::Image<unsigned char> & maskIma = *mask;
+        if (maskIma(k.y, k.x) == 0)
+          continue;
+      }
+
+      Descriptor<unsigned char, 128> descriptor;
+      descriptor << (k.descr.cast<unsigned char>());
+      {
+        regionsCasted->Descriptors().emplace_back(descriptor);
+        regionsCasted->Features().emplace_back(k.x, k.y, k.sigma, k.theta);
+      }
+    }
+  }
+  return true;
+}
+
+void SIFT_Anatomy_Image_describer::Allocate(std::unique_ptr<Regions> &regions) const
+{
+  regions.reset( new SIFT_Regions );
+}
+
+template<class Archive>
+void SIFT_Anatomy_Image_describer::serialize( Archive & ar )
+{
+  ar(cereal::make_nvp("params", params_));
+}
+
+} // namespace features
+} // namespace openMVG
+
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/archives/json.hpp>
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Anatomy_Image_describer, "SIFT_Anatomy_Image_describer");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::SIFT_Anatomy_Image_describer)

--- a/src/openMVG/features/sift/SIFT_Anatomy_Image_Describer.hpp
+++ b/src/openMVG/features/sift/SIFT_Anatomy_Image_Describer.hpp
@@ -48,19 +48,8 @@ Changes are:
 #ifndef OPENMVG_FEATURES_SIFT_SIFT_ANATOMY_IMAGE_DESCRIBER_HPP
 #define OPENMVG_FEATURES_SIFT_SIFT_ANATOMY_IMAGE_DESCRIBER_HPP
 
-#include <iostream>
-#include <numeric>
-#include <vector>
 
-#include "openMVG/features/feature.hpp"
 #include "openMVG/features/image_describer.hpp"
-#include "openMVG/features/regions_factory.hpp"
-#include "openMVG/features/sift/hierarchical_gaussian_scale_space.hpp"
-#include "openMVG/features/sift/sift_DescriptorExtractor.hpp"
-#include "openMVG/features/sift/sift_keypoint.hpp"
-#include "openMVG/features/sift/sift_KeypointExtractor.hpp"
-
-#include <cereal/cereal.hpp>
 
 namespace openMVG {
 namespace features {
@@ -77,25 +66,10 @@ public:
       float edge_threshold = 10.0f,
       float peak_threshold = 0.04f,
       bool root_sift = true
-    ):
-      first_octave_(first_octave),
-      num_octaves_(num_octaves),
-      num_scales_(num_scales),
-      edge_threshold_(edge_threshold),
-      peak_threshold_(peak_threshold),
-      root_sift_(root_sift) {}
+    );
 
     template<class Archive>
-    void serialize( Archive & ar )
-    {
-      ar(
-        cereal::make_nvp("first_octave", first_octave_),
-        cereal::make_nvp("num_octaves",num_octaves_),
-        cereal::make_nvp("num_scales",num_scales_),
-        cereal::make_nvp("edge_threshold",edge_threshold_),
-        cereal::make_nvp("peak_threshold",peak_threshold_),
-        cereal::make_nvp("root_sift",root_sift_));
-    }
+    void serialize( Archive & ar );
 
     // Parameters
     int first_octave_;      // Use original image, or perform an upscale if == -1
@@ -109,29 +83,9 @@ public:
   SIFT_Anatomy_Image_describer
   (
     const Params params = Params()
-  )
-  :Image_describer(), params_(params)
-  {}
+  );
 
-  bool Set_configuration_preset(EDESCRIBER_PRESET preset) override
-  {
-    switch(preset)
-    {
-    case NORMAL_PRESET:
-      params_.peak_threshold_ = 0.04f;
-    break;
-    case HIGH_PRESET:
-      params_.peak_threshold_ = 0.01f;
-    break;
-    case ULTRA_PRESET:
-      params_.peak_threshold_ = 0.01f;
-      params_.first_octave_ = -1;
-    break;
-    default:
-      return false;
-    }
-    return true;
-  }
+  bool Set_configuration_preset(EDESCRIBER_PRESET preset) override;
 
   /**
   @brief Detect regions on the image and compute their attributes (description)
@@ -145,81 +99,13 @@ public:
     const image::Image<unsigned char>& image,
     std::unique_ptr<Regions> &regions,
     const image::Image<unsigned char> * mask = nullptr
-  ) override
-  {
-    // Convert to float in range [0;1]
-    const image::Image<float> If(image.GetMat().cast<float>()/255.0f);
-
-    // compute sift keypoints
-    Allocate(regions);
-
-    // Build alias to cached data
-    SIFT_Regions * regionsCasted = dynamic_cast<SIFT_Regions*>(regions.get());
-    {
-      using namespace openMVG::features::sift;
-      const int supplementary_images = 3;
-      // => in order to ensure each gaussian slice is used in the process 3 extra images are required:
-      // +1 for dog computation
-      // +2 for 3d discrete extrema definition
-
-      HierarchicalGaussianScaleSpace octave_gen(
-        params_.num_octaves_,
-        params_.num_scales_,
-        (params_.first_octave_ == -1)
-        ? GaussianScaleSpaceParams(1.6f/2.0f, 1.0f/2.0f, 0.5f, supplementary_images)
-        : GaussianScaleSpaceParams(1.6f, 1.0f, 0.5f, supplementary_images));
-      octave_gen.SetImage( If );
-
-      std::vector<Keypoint> keypoints;
-      keypoints.reserve(5000);
-      Octave octave;
-      while ( octave_gen.NextOctave( octave ) )
-      {
-        std::vector< Keypoint > keys;
-        // Find Keypoints
-        SIFT_KeypointExtractor keypointDetector(
-          params_.peak_threshold_ / octave_gen.NbSlice(),
-          params_.edge_threshold_);
-        keypointDetector(octave, keys);
-        // Find Keypoints orientation and compute their description
-        Sift_DescriptorExtractor descriptorExtractor;
-        descriptorExtractor(octave, keys);
-
-        // Concatenate the found keypoints
-        std::move(keys.begin(), keys.end(), std::back_inserter(keypoints));
-      }
-      for (const auto & k : keypoints)
-      {
-        // Feature masking
-        if (mask)
-        {
-          const image::Image<unsigned char> & maskIma = *mask;
-          if (maskIma(k.y, k.x) == 0)
-            continue;
-        }
-
-        Descriptor<unsigned char, 128> descriptor;
-        descriptor << (k.descr.cast<unsigned char>());
-        {
-          regionsCasted->Descriptors().emplace_back(descriptor);
-          regionsCasted->Features().emplace_back(k.x, k.y, k.sigma, k.theta);
-        }
-      }
-    }
-    return true;
-  };
+  ) override;
 
   /// Allocate Regions type depending of the Image_describer
-  void Allocate(std::unique_ptr<Regions> &regions) const override
-  {
-    regions.reset( new SIFT_Regions );
-  }
+  void Allocate(std::unique_ptr<Regions> &regions) const override;
 
   template<class Archive>
-  void serialize( Archive & ar )
-  {
-    ar(cereal::make_nvp("params", params_));
-  }
+  void serialize( Archive & ar );
 
 private:
   Params params_;
@@ -227,10 +113,5 @@ private:
 
 } // namespace features
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/archives/json.hpp>
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Anatomy_Image_describer, "SIFT_Anatomy_Image_describer");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::SIFT_Anatomy_Image_describer)
 
 #endif // OPENMVG_FEATURES_SIFT_SIFT_ANATOMY_IMAGE_DESCRIBER_HPP

--- a/src/openMVG/geometry/CMakeLists.txt
+++ b/src/openMVG/geometry/CMakeLists.txt
@@ -1,8 +1,29 @@
 
-UNIT_TEST(openMVG rigid_transformation3D_srt "openMVG_numeric")
+file(
+  GLOB_RECURSE
+  geometry_files_header
+  *.hpp
+)
+file(
+  GLOB_RECURSE
+  geometry_files_cpp
+  *.cpp
+)
+file(GLOB_RECURSE REMOVEFILESUNITTEST *_test.cpp)
+#Remove the future main files
+list(REMOVE_ITEM geometry_files_cpp ${REMOVEFILESUNITTEST})
 
-UNIT_TEST(openMVG half_space_intersection "openMVG_numeric;openMVG_linearProgramming")
+add_library(openMVG_geometry ${geometry_files_header} ${geometry_files_cpp})
+set_target_properties(openMVG_geometry PROPERTIES SOVERSION ${OPENMVG_VERSION_MAJOR} VERSION "${OPENMVG_VERSION_MAJOR}.${OPENMVG_VERSION_MINOR}")
 
-UNIT_TEST(openMVG frustum_intersection "openMVG_numeric;openMVG_multiview_test_data;openMVG_multiview;openMVG_linearProgramming")
+target_link_libraries(openMVG_geometry openMVG_linearProgramming)
 
-UNIT_TEST(openMVG frustum_box_intersection "openMVG_numeric;openMVG_multiview_test_data;openMVG_multiview;openMVG_linearProgramming")
+install(TARGETS openMVG_geometry DESTINATION lib EXPORT openMVG-targets)
+
+UNIT_TEST(openMVG rigid_transformation3D_srt "openMVG_numeric;openMVG_geometry")
+
+UNIT_TEST(openMVG half_space_intersection "openMVG_numeric;openMVG_linearProgramming;openMVG_geometry")
+
+UNIT_TEST(openMVG frustum_intersection "openMVG_numeric;openMVG_multiview_test_data;openMVG_multiview;openMVG_linearProgramming;openMVG_geometry")
+
+UNIT_TEST(openMVG frustum_box_intersection "openMVG_numeric;openMVG_multiview_test_data;openMVG_multiview;openMVG_linearProgramming;openMVG_geometry")

--- a/src/openMVG/geometry/Similarity3.cpp
+++ b/src/openMVG/geometry/Similarity3.cpp
@@ -1,0 +1,44 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/geometry/Similarity3.hpp"
+
+namespace openMVG{
+namespace geometry{
+
+Similarity3::Similarity3()
+  : pose_( Pose3() ),
+    scale_( 1.0 )
+{
+
+}
+
+Similarity3::Similarity3( const Pose3 & pose, const double scale )
+  : pose_( pose ),
+    scale_( scale )
+{
+
+}
+
+Mat3X Similarity3::operator () ( const Mat3X & point ) const
+{
+  return scale_ * pose_( point );
+}
+
+Pose3 Similarity3::operator () ( const Pose3 & pose ) const
+{
+  return Pose3( pose.rotation() * pose_.rotation().transpose(), this->operator()( pose.center() ) );
+}
+
+Similarity3 Similarity3::inverse() const
+{
+  return Similarity3(pose_.inverse(), 1.0 / scale_);
+}
+
+} // namespace geometry
+} // namespace openMVG

--- a/src/openMVG/geometry/Similarity3.hpp
+++ b/src/openMVG/geometry/Similarity3.hpp
@@ -31,53 +31,34 @@ struct Similarity3
   * @brief Default constructor
   * @note This define identity transformation centered at origin of a cartesian frame
   */
-  Similarity3()
-    : pose_( Pose3() ),
-      scale_( 1.0 )
-  {
-
-  }
+  Similarity3();
 
   /**
   * @brief Constructor
   * @param pose a 3d pose
   * @param scale a scale factor
   */
-  Similarity3( const Pose3 & pose, const double scale )
-    : pose_( pose ),
-      scale_( scale )
-  {
-
-  }
+  Similarity3( const Pose3 & pose, const double scale );
 
   /**
   * @brief Apply transformation to a point
   * @param point Input point
   * @return transformed point
   */
-  Mat3X operator () ( const Mat3X & point ) const
-  {
-    return scale_ * pose_( point );
-  }
+  Mat3X operator () ( const Mat3X & point ) const;
 
   /**
   * @brief Concatenation of pose
   * @param pose Pose to be concatenated with the current one
   * @return Concatenation of poses
   */
-  Pose3 operator () ( const Pose3 & pose ) const
-  {
-    return Pose3( pose.rotation() * pose_.rotation().transpose(), this->operator()( pose.center() ) );
-  }
+  Pose3 operator () ( const Pose3 & pose ) const;
 
   /**
   * @brief Get inverse of the similarity
   * @return Inverse of the similarity
   */
-  Similarity3 inverse() const
-  {
-    return Similarity3(pose_.inverse(), 1.0 / scale_);
-  }
+  Similarity3 inverse() const;
 
 };
 

--- a/src/openMVG/geometry/Similarity3_Kernel.cpp
+++ b/src/openMVG/geometry/Similarity3_Kernel.cpp
@@ -1,0 +1,61 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2016 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+#include "openMVG/geometry/Similarity3_Kernel.hpp"
+#include "openMVG/geometry/rigid_transformation3D_srt.hpp"
+
+namespace openMVG{
+namespace geometry{
+namespace kernel{
+
+void Similarity3Solver::Solve
+(
+  const Mat &x,
+  const Mat &y,
+  std::vector<Similarity3> *sims
+)
+{
+  assert(3 == x.rows());
+  assert(x.rows() == y.rows());
+  assert(x.cols() == y.cols());
+
+  double S;
+  Vec3 t;
+  Mat3 R;
+  if ( FindRTS(x, y, &S, &t, &R) )
+  {
+    // Emplace back the Similarity3
+    sims->emplace_back(geometry::Pose3(R, -R.transpose()* t/S), S);
+  }
+}
+
+Vec Similarity3ErrorSquaredMetric::ErrorVec
+(
+  const Similarity3 &S,
+  const Mat3X &x1,
+  const Mat3X &x2
+)
+{
+  return (x2 - S(x1)).colwise().squaredNorm();
+}
+
+double Similarity3ErrorSquaredMetric::Error
+(
+  const Similarity3 &S,
+  const Vec3 &x1,
+  const Vec3 &x2
+)
+{
+  return (x2 - S(x1)).squaredNorm();
+}
+
+
+} // namespace kernel
+} // namespace geometry
+} // namespace openMVG

--- a/src/openMVG/geometry/Similarity3_Kernel.hpp
+++ b/src/openMVG/geometry/Similarity3_Kernel.hpp
@@ -9,11 +9,10 @@
 #ifndef OPENMVG_GEOMETRY_SIMILARITY3_KERNEL_HPP
 #define OPENMVG_GEOMETRY_SIMILARITY3_KERNEL_HPP
 
-#include <vector>
-
 #include "openMVG/geometry/Similarity3.hpp"
-#include "openMVG/geometry/rigid_transformation3D_srt.hpp"
 #include "openMVG/multiview/two_view_kernel.hpp"
+
+#include <vector>
 
 namespace openMVG
 {
@@ -41,21 +40,7 @@ struct Similarity3Solver
     const Mat &x,
     const Mat &y,
     std::vector<Similarity3> *sims
-  )
-  {
-    assert(3 == x.rows());
-    assert(x.rows() == y.rows());
-    assert(x.cols() == y.cols());
-
-    double S;
-    Vec3 t;
-    Mat3 R;
-    if ( FindRTS(x, y, &S, &t, &R) )
-    {
-      // Emplace back the Similarity3
-      sims->emplace_back(geometry::Pose3(R, -R.transpose()* t/S), S);
-    }
-  }
+  );
 };
 
 struct Similarity3ErrorSquaredMetric
@@ -66,10 +51,7 @@ struct Similarity3ErrorSquaredMetric
     const Similarity3 &S,
     const Mat3X &x1,
     const Mat3X &x2
-  )
-  {
-    return (x2 - S(x1)).colwise().squaredNorm();
-  }
+  );
 
   // Return the Squared error between the point x2 and the transformed point S(x1)
   static double Error
@@ -77,10 +59,7 @@ struct Similarity3ErrorSquaredMetric
     const Similarity3 &S,
     const Vec3 &x1,
     const Vec3 &x2
-  )
-  {
-    return (x2 - S(x1)).squaredNorm();
-  }
+  );
 };
 
 // Define a Kernel to solve a robust 3D similarity between point cloud

--- a/src/openMVG/geometry/box.cpp
+++ b/src/openMVG/geometry/box.cpp
@@ -1,0 +1,130 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2016 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/geometry/box.hpp"
+
+#include <fstream>
+
+namespace openMVG{
+namespace geometry{
+
+Box::Box
+(
+  const Vec3 & center,
+  const double radius, // Distance from center to corner (like sphere radius)
+  const Mat3 R
+)
+{
+  const Vec3 directions[8] =
+  {
+    // Top face
+    (R * Vec3(-1,-1,1).normalized()) * radius + center,
+    (R * Vec3(-1, 1,1).normalized()) * radius + center,
+    (R * Vec3( 1, 1,1).normalized()) * radius + center,
+    (R * Vec3( 1,-1,1).normalized()) * radius + center,
+    // Bottom face
+    (R * Vec3(-1,-1,-1).normalized()) * radius + center,
+    (R * Vec3(-1, 1,-1).normalized()) * radius + center,
+    (R * Vec3( 1, 1,-1).normalized()) * radius + center,
+    (R * Vec3( 1,-1,-1).normalized()) * radius + center
+  };
+  std::copy(directions, directions + 8, points);
+
+  // Defines the supporting volume thanks to 6 half_planes
+  planes.push_back( Half_plane_p( points[0], points[1], points[3] ) ); // Top
+  planes.push_back( Half_plane_p( points[4], points[7], points[5] ) ); // Bottom
+  // Define remaining supporting planes (box borders)
+  planes.push_back( Half_plane_p( points[0], points[4], points[1] ) );
+  planes.push_back( Half_plane_p( points[0], points[3], points[4] ) );
+  planes.push_back( Half_plane_p( points[3], points[2], points[7] ) );
+  planes.push_back( Half_plane_p( points[1], points[5], points[2] ) );
+}
+
+Box::Box
+(
+  const double x_min,
+  const double y_min,
+  const double z_min,
+  const double x_max,
+  const double y_max,
+  const double z_max
+)
+{
+  const Vec3 points_[8] =
+  {
+    // Top face
+    Vec3(x_min, y_min, z_max),
+    Vec3(x_min, y_max, z_max),
+    Vec3(x_max, y_max, z_max),
+    Vec3(x_max, y_min, z_max),
+    // Bottom face
+    Vec3(x_min, y_min, z_min),
+    Vec3(x_min, y_max, z_min),
+    Vec3(x_max, y_max, z_min),
+    Vec3(x_max, y_min, z_min),
+  };
+  std::copy(points_, points_ + 8, points);
+
+  // Defines the supporting volume thanks to 6 half_planes
+  planes.push_back( Half_plane_p( points[0], points[1], points[3] ) ); // Top
+  planes.push_back( Half_plane_p( points[4], points[7], points[5] ) ); // Bottom
+  // Define remaining supporting planes (box borders)
+  planes.push_back( Half_plane_p( points[0], points[4], points[1] ) );
+  planes.push_back( Half_plane_p( points[0], points[3], points[4] ) );
+  planes.push_back( Half_plane_p( points[3], points[2], points[7] ) );
+  planes.push_back( Half_plane_p( points[1], points[5], points[2] ) );
+}
+
+bool Box::export_Ply
+(
+  const Box & box,
+  const std::string & filename,
+  const Vec3 color
+)
+{
+  std::ofstream of(filename.c_str());
+  if (!of.is_open())
+    return false;
+
+  of << "ply" << '\n'
+    << "format ascii 1.0" << '\n'
+    << "element vertex 8\n"
+    << "property float x" << '\n'
+    << "property float y" << '\n'
+    << "property float z" << '\n'
+    << "property uchar red" << '\n'
+    << "property uchar green" << '\n'
+    << "property uchar blue" << '\n'
+    << "element face 6 \n"
+    << "property list uchar int vertex_index" << '\n'
+    << "end_header" << '\n';
+
+  // Export box points
+  {
+    for (int i = 0; i < 8; ++i)
+      of << box.points[i].transpose() << " " << color.cast<int>() << '\n';
+  }
+
+  of
+    // top & bottom planes
+    << "3 0 1 3\n"
+    << "3 4 7 5\n"
+    // remaining planes
+    << "3 0 4 1\n"
+    << "3 0 3 4\n"
+    << "3 3 2 7\n"
+    << "3 1 5 2\n";
+
+  of.flush();
+  const bool bOk = of.good();
+  of.close();
+  return bOk;
+}
+
+} // namespace geometry
+} // namespace openMVG

--- a/src/openMVG/geometry/box.hpp
+++ b/src/openMVG/geometry/box.hpp
@@ -9,9 +9,6 @@
 #ifndef OPENMVG_GEOMETRY_BOX_HPP
 #define OPENMVG_GEOMETRY_BOX_HPP
 
-#include <algorithm>
-#include <fstream>
-#include <string>
 #include "openMVG/geometry/half_space_intersection.hpp"
 
 namespace openMVG
@@ -43,32 +40,7 @@ struct Box : public HalfPlaneObject
     const Vec3 & center,
     const double radius, // Distance from center to corner (like sphere radius)
     const Mat3 R = Mat3::Identity()
-  )
-  {
-    const Vec3 directions[8] =
-    {
-      // Top face
-      (R * Vec3(-1,-1,1).normalized()) * radius + center,
-      (R * Vec3(-1, 1,1).normalized()) * radius + center,
-      (R * Vec3( 1, 1,1).normalized()) * radius + center,
-      (R * Vec3( 1,-1,1).normalized()) * radius + center,
-      // Bottom face
-      (R * Vec3(-1,-1,-1).normalized()) * radius + center,
-      (R * Vec3(-1, 1,-1).normalized()) * radius + center,
-      (R * Vec3( 1, 1,-1).normalized()) * radius + center,
-      (R * Vec3( 1,-1,-1).normalized()) * radius + center
-    };
-    std::copy(directions, directions + 8, points);
-
-    // Defines the supporting volume thanks to 6 half_planes
-    planes.push_back( Half_plane_p( points[0], points[1], points[3] ) ); // Top
-    planes.push_back( Half_plane_p( points[4], points[7], points[5] ) ); // Bottom
-    // Define remaining supporting planes (box borders)
-    planes.push_back( Half_plane_p( points[0], points[4], points[1] ) );
-    planes.push_back( Half_plane_p( points[0], points[3], points[4] ) );
-    planes.push_back( Half_plane_p( points[3], points[2], points[7] ) );
-    planes.push_back( Half_plane_p( points[1], points[5], points[2] ) );
-  }
+  );
 
   /// Define a Rectangular parallelepiped bounding box from min/max axis aligned positions
   Box
@@ -79,32 +51,7 @@ struct Box : public HalfPlaneObject
     const double x_max,
     const double y_max,
     const double z_max
-  )
-  {
-    const Vec3 points_[8] =
-    {
-      // Top face
-      Vec3(x_min, y_min, z_max),
-      Vec3(x_min, y_max, z_max),
-      Vec3(x_max, y_max, z_max),
-      Vec3(x_max, y_min, z_max),
-      // Bottom face
-      Vec3(x_min, y_min, z_min),
-      Vec3(x_min, y_max, z_min),
-      Vec3(x_max, y_max, z_min),
-      Vec3(x_max, y_min, z_min),
-    };
-    std::copy(points_, points_ + 8, points);
-
-    // Defines the supporting volume thanks to 6 half_planes
-    planes.push_back( Half_plane_p( points[0], points[1], points[3] ) ); // Top
-    planes.push_back( Half_plane_p( points[4], points[7], points[5] ) ); // Bottom
-    // Define remaining supporting planes (box borders)
-    planes.push_back( Half_plane_p( points[0], points[4], points[1] ) );
-    planes.push_back( Half_plane_p( points[0], points[3], points[4] ) );
-    planes.push_back( Half_plane_p( points[3], points[2], points[7] ) );
-    planes.push_back( Half_plane_p( points[1], points[5], points[2] ) );
-  }
+  );
 
   /**
   * @brief Export the Box as a PLY file
@@ -115,46 +62,7 @@ struct Box : public HalfPlaneObject
     const Box & box,
     const std::string & filename,
     const Vec3 color = Vec3(0, 255, 0)
-  )
-  {
-    std::ofstream of(filename.c_str());
-    if (!of.is_open())
-      return false;
-
-    of << "ply" << '\n'
-      << "format ascii 1.0" << '\n'
-      << "element vertex 8\n"
-      << "property float x" << '\n'
-      << "property float y" << '\n'
-      << "property float z" << '\n'
-      << "property uchar red" << '\n'
-      << "property uchar green" << '\n'
-      << "property uchar blue" << '\n'
-      << "element face 6 \n"
-      << "property list uchar int vertex_index" << '\n'
-      << "end_header" << '\n';
-
-    // Export box points
-    {
-      for (int i = 0; i < 8; ++i)
-        of << box.points[i].transpose() << " " << color.cast<int>() << '\n';
-    }
-
-    of
-      // top & bottom planes
-      << "3 0 1 3\n"
-      << "3 4 7 5\n"
-      // remaining planes
-      << "3 0 4 1\n"
-      << "3 0 3 4\n"
-      << "3 3 2 7\n"
-      << "3 1 5 2\n";
-
-    of.flush();
-    const bool bOk = of.good();
-    of.close();
-    return bOk;
-  }
+  );
 };
 
 } // namespace geometry

--- a/src/openMVG/geometry/frustum.cpp
+++ b/src/openMVG/geometry/frustum.cpp
@@ -1,0 +1,204 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/geometry/frustum.hpp"
+
+#include <fstream>
+#include <iomanip>
+
+namespace openMVG{
+namespace geometry{
+
+Frustum::Frustum()
+  : z_near( -1. ),
+    z_far ( -1. )
+{
+}
+
+Frustum::Frustum
+(
+  const int w,
+  const int h,
+  const Mat3 & K,
+  const Mat3 & R,
+  const Vec3 & C
+)
+  : z_near( -1. ),
+    z_far ( -1. )
+{
+  const Mat3 Kinv = K.inverse();
+  const Mat3 Rt = R.transpose();
+
+  // Definition of the frustum with the supporting points
+  cones[0] = C;
+  cones[1] = Rt * ( ( Kinv * Vec3( 0, 0, 1.0 ) ) ) + C;
+  cones[2] = Rt * ( ( Kinv * Vec3( w, 0, 1.0 ) ) ) + C;
+  cones[3] = Rt * ( ( Kinv * Vec3( w, h, 1.0 ) ) ) + C;
+  cones[4] = Rt * ( ( Kinv * Vec3( 0, h, 1.0 ) ) ) + C;
+
+  // Definition of the supporting planes
+  planes.push_back( Half_plane_p( cones[0], cones[4], cones[1] ) );
+  planes.push_back( Half_plane_p( cones[0], cones[1], cones[2] ) );
+  planes.push_back( Half_plane_p( cones[0], cones[2], cones[3] ) );
+  planes.push_back( Half_plane_p( cones[0], cones[3], cones[4] ) );
+
+  // supporting point for drawing is a normalized cone, since infinity cannot be represented
+  points = std::vector<Vec3>( &cones[0], &cones[0] + 5 );
+}
+
+Frustum::Frustum
+(
+  const int w,
+  const int h,
+  const Mat3 & K,
+  const Mat3 & R,
+  const Vec3 & C ,
+  const double zFar
+)
+  : z_near( -1. ),
+    z_far ( zFar )
+{
+  const Mat3 Kinv = K.inverse();
+  const Mat3 Rt = R.transpose();
+
+  // Definition of the frustum with the supporting points
+  cones[0] = C;
+  cones[1] = Rt * ( z_far * ( Kinv * Vec3( 0, 0, 1.0 ) ) ) + C;
+  cones[2] = Rt * ( z_far * ( Kinv * Vec3( w, 0, 1.0 ) ) ) + C;
+  cones[3] = Rt * ( z_far * ( Kinv * Vec3( w, h, 1.0 ) ) ) + C;
+  cones[4] = Rt * ( z_far * ( Kinv * Vec3( 0, h, 1.0 ) ) ) + C;
+
+  // Definition of the supporting planes
+  planes.push_back( Half_plane_p( cones[0], cones[4], cones[1] ) );
+  planes.push_back( Half_plane_p( cones[0], cones[1], cones[2] ) );
+  planes.push_back( Half_plane_p( cones[0], cones[2], cones[3] ) );
+  planes.push_back( Half_plane_p( cones[0], cones[3], cones[4] ) );
+
+  // supporting point for drawing is a normalized cone, since infinity cannot be represented
+  points = std::vector<Vec3>( &cones[0], &cones[0] + 5 );
+}
+
+Frustum::Frustum
+(
+  const int w,
+  const int h,
+  const Mat3 & K,
+  const Mat3 & R,
+  const Vec3 & C,
+  const double zNear,
+  const double zFar
+)
+{
+  *this = Frustum( w, h, K, R, C );
+
+  // update near & far planes & clear set points
+  z_near = zNear;
+  z_far = zFar;
+  points.clear();
+  assert( zFar > zNear );
+
+  // Add Znear and ZFar half plane using the cam looking direction
+  const Vec3 camLookDirection_n = R.row( 2 ).normalized();
+  const double d_near = - zNear - camLookDirection_n.dot( C );
+  planes.push_back( Half_plane( camLookDirection_n, d_near ) );
+
+  const double d_Far = zFar + camLookDirection_n.dot( C );
+  planes.push_back( Half_plane( -camLookDirection_n, d_Far ) );
+
+  // supporting point are the points defined by the truncated cone
+  const Mat3 Kinv = K.inverse();
+  const Mat3 Rt = R.transpose();
+  points.push_back( Rt * ( z_near * ( Kinv * Vec3( 0, 0, 1.0 ) ) ) + C );
+  points.push_back( Rt * ( z_near * ( Kinv * Vec3( w, 0, 1.0 ) ) ) + C );
+  points.push_back( Rt * ( z_near * ( Kinv * Vec3( w, h, 1.0 ) ) ) + C );
+  points.push_back( Rt * ( z_near * ( Kinv * Vec3( 0, h, 1.0 ) ) ) + C );
+
+  points.push_back( Rt * ( z_far * ( Kinv * Vec3( 0, 0, 1.0 ) ) ) + C );
+  points.push_back( Rt * ( z_far * ( Kinv * Vec3( w, 0, 1.0 ) ) ) + C );
+  points.push_back( Rt * ( z_far * ( Kinv * Vec3( w, h, 1.0 ) ) ) + C );
+  points.push_back( Rt * ( z_far * ( Kinv * Vec3( 0, h, 1.0 ) ) ) + C );
+}
+
+bool Frustum::isInfinite() const
+{
+  return planes.size() == 4;
+}
+
+bool Frustum::isTruncated() const
+{
+  return planes.size() == 6;
+}
+
+const std::vector<Vec3> & Frustum::frustum_points() const
+{
+  return points;
+}
+
+bool Frustum::export_Ply
+(
+  const Frustum & frustum,
+  const std::string & filename
+)
+{
+  std::ofstream of(filename.c_str());
+  if (!of.is_open())
+    return false;
+
+  // Vertex count evaluation
+  const size_t vertex_count = frustum.frustum_points().size();
+  // Faces count evaluation
+  const size_t face_count = frustum.isInfinite() ? 4 : 6;
+
+  of << std::fixed << std::setprecision (std::numeric_limits<double>::digits10 + 1);
+  of << "ply" << '\n'
+    << "format ascii 1.0" << '\n'
+    << "element vertex " << vertex_count << '\n'
+    << "property double x" << '\n'
+    << "property double y" << '\n'
+    << "property double z" << '\n'
+    << "element face " << face_count << '\n'
+    << "property list uchar int vertex_index" << '\n'
+    << "end_header" << '\n';
+
+  // Export frustums points
+  {
+    const std::vector<Vec3> & points = frustum.frustum_points();
+    for (size_t i = 0; i < points.size(); ++i)
+      of << points[i].transpose() << '\n';
+  }
+
+  // Export frustums faces
+  {
+    if (frustum.isInfinite())
+    {
+      // infinite frustum: drawn normalized cone: 4 faces
+      of
+        << "3 0 4 1\n"
+        << "3 0 1 2\n"
+        << "3 0 2 3\n"
+        << "3 0 3 4\n";
+    }
+    else
+    {
+      of
+        << "4 0 1 2 3\n"
+        << "4 0 1 5 4\n"
+        << "4 1 5 6 2\n"
+        << "4 3 7 6 2\n"
+        << "4 0 4 7 3\n"
+        << "4 4 5 6 7\n";
+    }
+  }
+  of.flush();
+  const bool bOk = of.good();
+  of.close();
+  return bOk;
+}
+
+} // namespace geometry
+} // namespace openMVG

--- a/src/openMVG/geometry/frustum.hpp
+++ b/src/openMVG/geometry/frustum.hpp
@@ -9,9 +9,6 @@
 #ifndef OPENMVG_GEOMETRY_FRUSTUM_HPP
 #define OPENMVG_GEOMETRY_FRUSTUM_HPP
 
-#include <fstream>
-#include <iomanip>
-#include <limits>
 #include <string>
 #include <vector>
 
@@ -51,12 +48,7 @@ struct Frustum : public HalfPlaneObject
   /**
   * @brief Default constructor
   */
-  Frustum()
-    : z_near( -1. ),
-      z_far ( -1. )
-  {
-
-  }
+  Frustum();
 
   /**
   * @brief Build a frustum from the image size, camera intrinsic and pose
@@ -73,29 +65,7 @@ struct Frustum : public HalfPlaneObject
     const Mat3 & K,
     const Mat3 & R,
     const Vec3 & C
-  )
-    : z_near( -1. ),
-      z_far ( -1. )
-  {
-    const Mat3 Kinv = K.inverse();
-    const Mat3 Rt = R.transpose();
-
-    // Definition of the frustum with the supporting points
-    cones[0] = C;
-    cones[1] = Rt * ( ( Kinv * Vec3( 0, 0, 1.0 ) ) ) + C;
-    cones[2] = Rt * ( ( Kinv * Vec3( w, 0, 1.0 ) ) ) + C;
-    cones[3] = Rt * ( ( Kinv * Vec3( w, h, 1.0 ) ) ) + C;
-    cones[4] = Rt * ( ( Kinv * Vec3( 0, h, 1.0 ) ) ) + C;
-
-    // Definition of the supporting planes
-    planes.push_back( Half_plane_p( cones[0], cones[4], cones[1] ) );
-    planes.push_back( Half_plane_p( cones[0], cones[1], cones[2] ) );
-    planes.push_back( Half_plane_p( cones[0], cones[2], cones[3] ) );
-    planes.push_back( Half_plane_p( cones[0], cones[3], cones[4] ) );
-
-    // supporting point for drawing is a normalized cone, since infinity cannot be represented
-    points = std::vector<Vec3>( &cones[0], &cones[0] + 5 );
-  }
+  );
 
   /**
   * @brief Build a frustum from the image size, camera intrinsic and pose
@@ -114,29 +84,7 @@ struct Frustum : public HalfPlaneObject
     const Mat3 & R,
     const Vec3 & C ,
     const double zFar
-  )
-    : z_near( -1. ),
-      z_far ( zFar )
-  {
-    const Mat3 Kinv = K.inverse();
-    const Mat3 Rt = R.transpose();
-
-    // Definition of the frustum with the supporting points
-    cones[0] = C;
-    cones[1] = Rt * ( z_far * ( Kinv * Vec3( 0, 0, 1.0 ) ) ) + C;
-    cones[2] = Rt * ( z_far * ( Kinv * Vec3( w, 0, 1.0 ) ) ) + C;
-    cones[3] = Rt * ( z_far * ( Kinv * Vec3( w, h, 1.0 ) ) ) + C;
-    cones[4] = Rt * ( z_far * ( Kinv * Vec3( 0, h, 1.0 ) ) ) + C;
-
-    // Definition of the supporting planes
-    planes.push_back( Half_plane_p( cones[0], cones[4], cones[1] ) );
-    planes.push_back( Half_plane_p( cones[0], cones[1], cones[2] ) );
-    planes.push_back( Half_plane_p( cones[0], cones[2], cones[3] ) );
-    planes.push_back( Half_plane_p( cones[0], cones[3], cones[4] ) );
-
-    // supporting point for drawing is a normalized cone, since infinity cannot be represented
-    points = std::vector<Vec3>( &cones[0], &cones[0] + 5 );
-  }
+  );
 
   /**
   * @brief Build a frustum from image size, camera intrinsics, pose and clip planes
@@ -157,57 +105,21 @@ struct Frustum : public HalfPlaneObject
     const Vec3 & C,
     const double zNear,
     const double zFar
-  )
-  {
-    *this = Frustum( w, h, K, R, C );
-
-    // update near & far planes & clear set points
-    z_near = zNear;
-    z_far = zFar;
-    points.clear();
-    assert( zFar > zNear );
-
-    // Add Znear and ZFar half plane using the cam looking direction
-    const Vec3 camLookDirection_n = R.row( 2 ).normalized();
-    const double d_near = - zNear - camLookDirection_n.dot( C );
-    planes.push_back( Half_plane( camLookDirection_n, d_near ) );
-
-    const double d_Far = zFar + camLookDirection_n.dot( C );
-    planes.push_back( Half_plane( -camLookDirection_n, d_Far ) );
-
-    // supporting point are the points defined by the truncated cone
-    const Mat3 Kinv = K.inverse();
-    const Mat3 Rt = R.transpose();
-    points.push_back( Rt * ( z_near * ( Kinv * Vec3( 0, 0, 1.0 ) ) ) + C );
-    points.push_back( Rt * ( z_near * ( Kinv * Vec3( w, 0, 1.0 ) ) ) + C );
-    points.push_back( Rt * ( z_near * ( Kinv * Vec3( w, h, 1.0 ) ) ) + C );
-    points.push_back( Rt * ( z_near * ( Kinv * Vec3( 0, h, 1.0 ) ) ) + C );
-
-    points.push_back( Rt * ( z_far * ( Kinv * Vec3( 0, 0, 1.0 ) ) ) + C );
-    points.push_back( Rt * ( z_far * ( Kinv * Vec3( w, 0, 1.0 ) ) ) + C );
-    points.push_back( Rt * ( z_far * ( Kinv * Vec3( w, h, 1.0 ) ) ) + C );
-    points.push_back( Rt * ( z_far * ( Kinv * Vec3( 0, h, 1.0 ) ) ) + C );
-  }
+  );
 
   /**
   * @brief Tells if the Frustum is an infinite one
   * @retval true If frustum is infinite
   * @retval false If frustum is not infinite
   */
-  bool isInfinite() const
-  {
-    return planes.size() == 4;
-  }
+  bool isInfinite() const;
 
   /**
   * @brief Tells if the Frustum is truncated
   * @retval true If frustum is truncated
   * @retval false If frustum is not truncated
   */
-  bool isTruncated() const
-  {
-    return planes.size() == 6;
-  }
+  bool isTruncated() const;
 
   /**
   * @brief Return the supporting frustum points
@@ -215,10 +127,7 @@ struct Frustum : public HalfPlaneObject
   * @note 5 points for infinite frustum
   * @note 8 points for truncated frustum
   */
-  const std::vector<Vec3> & frustum_points() const
-  {
-    return points;
-  }
+  const std::vector<Vec3> & frustum_points() const;
 
   /**
   * @brief Export the Frustum as a PLY file (infinite frustum as exported as a normalized cone)
@@ -226,64 +135,9 @@ struct Frustum : public HalfPlaneObject
   */
   static bool export_Ply
   (
-    const Frustum & frustum,
-    const std::string & filename
-  )
-  {
-    std::ofstream of(filename.c_str());
-    if (!of.is_open())
-      return false;
-
-    // Vertex count evaluation
-    const size_t vertex_count = frustum.frustum_points().size();
-    // Faces count evaluation
-    const size_t face_count = frustum.isInfinite() ? 4 : 6;
-
-    of << std::fixed << std::setprecision (std::numeric_limits<double>::digits10 + 1);
-    of << "ply" << '\n'
-      << "format ascii 1.0" << '\n'
-      << "element vertex " << vertex_count << '\n'
-      << "property double x" << '\n'
-      << "property double y" << '\n'
-      << "property double z" << '\n'
-      << "element face " << face_count << '\n'
-      << "property list uchar int vertex_index" << '\n'
-      << "end_header" << '\n';
-
-    // Export frustums points
-    {
-      const std::vector<Vec3> & points = frustum.frustum_points();
-      for (size_t i = 0; i < points.size(); ++i)
-        of << points[i].transpose() << '\n';
-    }
-
-    // Export frustums faces
-    {
-      if (frustum.isInfinite())
-      {
-        // infinite frustum: drawn normalized cone: 4 faces
-        of
-          << "3 0 4 1\n"
-          << "3 0 1 2\n"
-          << "3 0 2 3\n"
-          << "3 0 3 4\n";
-      }
-      else
-      {
-        of
-          << "4 0 1 2 3\n"
-          << "4 0 1 5 4\n"
-          << "4 1 5 6 2\n"
-          << "4 3 7 6 2\n"
-          << "4 0 4 7 3\n"
-          << "4 4 5 6 7\n";
-      }
-    }
-    of.flush();
-    const bool bOk = of.good();
-    of.close();
-    return bOk;
-  }
+	  const Frustum & frustum,
+	  const std::string & filename
+  );
 
 }; // struct Frustum
 

--- a/src/openMVG/geometry/half_space_intersection.cpp
+++ b/src/openMVG/geometry/half_space_intersection.cpp
@@ -1,0 +1,118 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+#include "openMVG/geometry/half_space_intersection.hpp"
+#include "openMVG/linearProgramming/linearProgrammingOSI_X.hpp"
+
+namespace openMVG{
+namespace geometry{
+namespace halfPlane{
+
+Half_plane Half_plane_p
+(
+  const Vec3 & p,
+  const Vec3 & q,
+  const Vec3 & r
+)
+{
+  return Half_plane::Through(r,q,p);
+}
+
+bool isNotEmpty
+(
+  const Half_planes & hplanes
+)
+{
+  // Check if it exists a point on all positive side of the half plane thanks to a Linear Program formulation [1].
+  // => If a point exists: there is a common subspace defined and so intersections.
+  // The LP formulation consists in set the Half_plane as constraint and check if a point can fit the equations.
+
+  using namespace openMVG;
+  using namespace openMVG::linearProgramming;
+
+  LP_Constraints cstraint;
+  {
+    cstraint.nbParams_ = 3; // {X,Y,Z}
+    cstraint.vec_bounds_.resize( cstraint.nbParams_ );
+    std::fill( cstraint.vec_bounds_.begin(), cstraint.vec_bounds_.end(),
+               std::make_pair( std::numeric_limits<double>::lowest(),
+                               std::numeric_limits<double>::max() )); // [X,Y,Z] => -inf, +inf
+    cstraint.bminimize_ = true;
+
+    // Configure constraints
+    const size_t nbConstraints = hplanes.size();
+    cstraint.constraint_mat_.resize( nbConstraints, 3 );
+    cstraint.vec_sign_.resize( nbConstraints );
+    cstraint.constraint_objective_.resize( nbConstraints );
+
+    // Fill the constrains (half-space equations)
+    for ( unsigned char i = 0; i < hplanes.size(); ++i )
+    {
+      const Vec & half_plane_coeff = hplanes[i].coeffs();
+      // add the half plane equation to the system
+      cstraint.constraint_mat_.row( i ) <<
+        half_plane_coeff( 0 ),
+        half_plane_coeff( 1 ),
+        half_plane_coeff( 2 );
+      cstraint.vec_sign_[i] = LP_Constraints::LP_GREATER_OR_EQUAL;
+      cstraint.constraint_objective_( i ) = - half_plane_coeff( 3 );
+    }
+  }
+
+  // Solve in order to see if a point exists within the half spaces positive side?
+  OSI_CLP_SolverWrapper solver( cstraint.nbParams_ );
+  solver.setup( cstraint );
+  const bool bIntersect = solver.solve(); // Status of the solver tell if there is an intersection or not
+  return bIntersect;
+}
+
+bool HalfPlaneObject::intersect(const HalfPlaneObject & rhs) const
+{
+  // Concatenate the Half Planes and see if an intersection exists
+  Half_planes vec_planes(planes.size() + rhs.planes.size());
+  std::copy(&planes[0], &planes[0] + planes.size(), &vec_planes[0]);
+  std::copy(&rhs.planes[0], &rhs.planes[0] + rhs.planes.size(), &vec_planes[planes.size()]);
+
+  return halfPlane::isNotEmpty(vec_planes);
+}
+
+bool HalfPlaneObject::contains(const Vec3 & rhs) const
+{
+  unsigned int count_positive = 0;
+  for (const Half_plane & hp : planes)
+  {
+    count_positive += (hp.signedDistance(rhs) > 0) ? 1 : 0;
+  }
+  return (count_positive == planes.size()) && !planes.empty();
+}
+
+bool intersect
+(
+  const std::vector<HalfPlaneObject> & hplanes
+)
+{
+  // Compute the total number of half-planes
+  std::size_t s = 0;
+  std::for_each(hplanes.cbegin(), hplanes.cend(),
+                [&s](const HalfPlaneObject & hp) { s += hp.planes.size(); });
+
+  // Concatenate the half-planes and see if an intersection exists
+  Half_planes vec_planes;
+  vec_planes.reserve(s);
+  for (const HalfPlaneObject & hp : hplanes)
+  {
+    vec_planes.insert(vec_planes.end(), hp.planes.cbegin(), hp.planes.cend());
+  }
+
+  return halfPlane::isNotEmpty(vec_planes);
+}
+
+} // namespace halfPlane
+} // namespace geometry
+} // namespace openMVG

--- a/src/openMVG/geometry/half_space_intersection.hpp
+++ b/src/openMVG/geometry/half_space_intersection.hpp
@@ -9,12 +9,8 @@
 #ifndef OPENMVG_GEOMETRY_HALF_SPACE_INTERSECTION_HPP
 #define OPENMVG_GEOMETRY_HALF_SPACE_INTERSECTION_HPP
 
-#include <Eigen/Geometry>
-#include <algorithm>
-#include <limits>
-#include <vector>
+#include "openMVG/numeric/eigen_alias_definition.hpp"
 
-#include "openMVG/linearProgramming/linearProgrammingOSI_X.hpp"
 
 namespace openMVG
 {
@@ -38,16 +34,13 @@ using Half_planes = std::vector<Half_plane, Eigen::aligned_allocator<Half_plane>
 * @return Plane formed by p,q,r
 * @note The plane is oriented such that p, q and r are oriented in a positive sense (that is counterclockwise).
 */
-inline Half_plane
+Half_plane
 Half_plane_p
 (
   const Vec3 & p,
   const Vec3 & q,
   const Vec3 & r
-)
-{
-  return Half_plane::Through(r,q,p);
-}
+);
 
 /**
 * @brief Test if half-planes defines a non empty volume
@@ -62,54 +55,11 @@ Half_plane_p
  Year: 1979
  More: ISSN 0304-3975, http://dx.doi.org/10.1016/0304-3975(79)90055-0.
 */
-inline bool
+bool
 isNotEmpty
 (
-  const Half_planes & hplanes
-)
-{
-  // Check if it exists a point on all positive side of the half plane thanks to a Linear Program formulation [1].
-  // => If a point exists: there is a common subspace defined and so intersections.
-  // The LP formulation consists in set the Half_plane as constraint and check if a point can fit the equations.
-
-  using namespace openMVG;
-  using namespace openMVG::linearProgramming;
-
-  LP_Constraints cstraint;
-  {
-    cstraint.nbParams_ = 3; // {X,Y,Z}
-    cstraint.vec_bounds_.resize( cstraint.nbParams_ );
-    std::fill( cstraint.vec_bounds_.begin(), cstraint.vec_bounds_.end(),
-               std::make_pair( std::numeric_limits<double>::lowest(),
-                               std::numeric_limits<double>::max() )); // [X,Y,Z] => -inf, +inf
-    cstraint.bminimize_ = true;
-
-    // Configure constraints
-    const size_t nbConstraints = hplanes.size();
-    cstraint.constraint_mat_.resize( nbConstraints, 3 );
-    cstraint.vec_sign_.resize( nbConstraints );
-    cstraint.constraint_objective_.resize( nbConstraints );
-
-    // Fill the constrains (half-space equations)
-    for ( unsigned char i = 0; i < hplanes.size(); ++i )
-    {
-      const Vec & half_plane_coeff = hplanes[i].coeffs();
-      // add the half plane equation to the system
-      cstraint.constraint_mat_.row( i ) <<
-        half_plane_coeff( 0 ),
-        half_plane_coeff( 1 ),
-        half_plane_coeff( 2 );
-      cstraint.vec_sign_[i] = LP_Constraints::LP_GREATER_OR_EQUAL;
-      cstraint.constraint_objective_( i ) = - half_plane_coeff( 3 );
-    }
-  }
-
-  // Solve in order to see if a point exists within the half spaces positive side?
-  OSI_CLP_SolverWrapper solver( cstraint.nbParams_ );
-  solver.setup( cstraint );
-  const bool bIntersect = solver.solve(); // Status of the solver tell if there is an intersection or not
-  return bIntersect;
-}
+	const Half_planes & hplanes
+);
 
 /**
 * @brief Define a Volume 'object' thanks to a series of half_plane:
@@ -125,30 +75,14 @@ struct HalfPlaneObject
   * @retval true If an none empty intersection exists
   * @retval false If there's no intersection
   */
-  bool intersect(const HalfPlaneObject & rhs) const
-  {
-    // Concatenate the Half Planes and see if an intersection exists
-    Half_planes vec_planes(planes.size() + rhs.planes.size());
-    std::copy(&planes[0], &planes[0] + planes.size(), &vec_planes[0]);
-    std::copy(&rhs.planes[0], &rhs.planes[0] + rhs.planes.size(), &vec_planes[planes.size()]);
-
-    return halfPlane::isNotEmpty(vec_planes);
-  }
+  bool intersect(const HalfPlaneObject & rhs) const;
 
   /**
   * @brief Test if a point is on the positive side of the HalfPlanes
   * @param rhs The 3D point to test
   * @retval true If The point is in the half plane defined 'volume'
   */
-  bool contains(const Vec3 & rhs) const
-  {
-    unsigned int count_positive = 0;
-    for (const Half_plane & hp : planes)
-    {
-      count_positive += (hp.signedDistance(rhs) > 0) ? 1 : 0;
-    }
-    return (count_positive == planes.size()) && !planes.empty();
-  }
+  bool contains(const Vec3 & rhs) const;
 };
 
 /**
@@ -157,27 +91,11 @@ struct HalfPlaneObject
 * @retval true If a non-empty intersection exists
 * @retval false If there's no intersection
 */
-inline bool
+bool
 intersect
 (
   const std::vector<HalfPlaneObject> & hplanes
-)
-{
-  // Compute the total number of half-planes
-  std::size_t s = 0;
-  std::for_each(hplanes.cbegin(), hplanes.cend(),
-                [&s](const HalfPlaneObject & hp) { s += hp.planes.size(); });
-
-  // Concatenate the half-planes and see if an intersection exists
-  Half_planes vec_planes;
-  vec_planes.reserve(s);
-  for (const HalfPlaneObject & hp : hplanes)
-  {
-    vec_planes.insert(vec_planes.end(), hp.planes.cbegin(), hp.planes.cend());
-  }
-
-  return halfPlane::isNotEmpty(vec_planes);
-}
+);
 
 } // namespace halfPlane
 } // namespace geometry

--- a/src/openMVG/geometry/pose3.cpp
+++ b/src/openMVG/geometry/pose3.cpp
@@ -1,0 +1,77 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+#include "openMVG/geometry/pose3.hpp"
+#include "openMVG/multiview/projection.hpp"
+
+#include <vector>
+
+namespace openMVG{
+namespace geometry{
+
+    Pose3::Pose3
+    (
+      const Mat3& r,
+      const Vec3& c
+    )
+    : rotation_( r ), center_( c ) {}
+
+    const Mat3& Pose3::rotation() const
+    {
+      return rotation_;
+    }
+
+    Mat3& Pose3::rotation()
+    {
+      return rotation_;
+    }
+
+    const Vec3& Pose3::center() const
+    {
+      return center_;
+    }
+
+    Vec3& Pose3::center()
+    {
+      return center_;
+    }
+
+    Vec3 Pose3::translation() const
+    {
+      return -( rotation_ * center_ );
+    }
+
+
+    Mat3X Pose3::operator () ( const Mat3X& p ) const
+    {
+      return rotation_ * ( p.colwise() - center_ );
+    }
+
+
+    Pose3 Pose3::operator * ( const Pose3& P ) const
+    {
+      return Pose3( rotation_ * P.rotation_, P.center_ + P.rotation_.transpose() * center_ );
+    }
+
+
+    Pose3 Pose3::inverse() const
+    {
+      return Pose3( rotation_.transpose(),  -( rotation_ * center_ ) );
+    }
+
+
+    double Pose3::depth( const Vec3 &X ) const
+    {
+      return ( rotation_ * ( X - center_ ) )[2];
+    }
+
+} // namespace geometry
+} // namespace openMVG
+
+

--- a/src/openMVG/geometry/pose3.cpp
+++ b/src/openMVG/geometry/pose3.cpp
@@ -10,67 +10,137 @@
 #include "openMVG/geometry/pose3.hpp"
 #include "openMVG/multiview/projection.hpp"
 
+#include <cereal/types/vector.hpp>
+#include <cereal/cereal.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
 #include <vector>
 
 namespace openMVG{
 namespace geometry{
 
-    Pose3::Pose3
-    (
-      const Mat3& r,
-      const Vec3& c
-    )
-    : rotation_( r ), center_( c ) {}
+Pose3::Pose3
+(
+  const Mat3& r,
+  const Vec3& c
+)
+: rotation_( r ), center_( c ) {}
 
-    const Mat3& Pose3::rotation() const
-    {
-      return rotation_;
-    }
+const Mat3& Pose3::rotation() const
+{
+  return rotation_;
+}
 
-    Mat3& Pose3::rotation()
-    {
-      return rotation_;
-    }
+Mat3& Pose3::rotation()
+{
+  return rotation_;
+}
 
-    const Vec3& Pose3::center() const
-    {
-      return center_;
-    }
+const Vec3& Pose3::center() const
+{
+  return center_;
+}
 
-    Vec3& Pose3::center()
-    {
-      return center_;
-    }
+Vec3& Pose3::center()
+{
+  return center_;
+}
 
-    Vec3 Pose3::translation() const
-    {
-      return -( rotation_ * center_ );
-    }
-
-
-    Mat3X Pose3::operator () ( const Mat3X& p ) const
-    {
-      return rotation_ * ( p.colwise() - center_ );
-    }
+Vec3 Pose3::translation() const
+{
+  return -( rotation_ * center_ );
+}
 
 
-    Pose3 Pose3::operator * ( const Pose3& P ) const
-    {
-      return Pose3( rotation_ * P.rotation_, P.center_ + P.rotation_.transpose() * center_ );
-    }
+Mat3X Pose3::operator () ( const Mat3X& p ) const
+{
+  return rotation_ * ( p.colwise() - center_ );
+}
 
 
-    Pose3 Pose3::inverse() const
-    {
-      return Pose3( rotation_.transpose(),  -( rotation_ * center_ ) );
-    }
+Pose3 Pose3::operator * ( const Pose3& P ) const
+{
+  return Pose3( rotation_ * P.rotation_, P.center_ + P.rotation_.transpose() * center_ );
+}
 
 
-    double Pose3::depth( const Vec3 &X ) const
-    {
-      return ( rotation_ * ( X - center_ ) )[2];
-    }
+Pose3 Pose3::inverse() const
+{
+  return Pose3( rotation_.transpose(),  -( rotation_ * center_ ) );
+}
 
+
+double Pose3::depth( const Vec3 &X ) const
+{
+  return ( rotation_ * ( X - center_ ) )[2];
+}
+
+template <class Archive>
+void Pose3::save( Archive & ar ) const
+{
+  const std::vector<std::vector<double>> mat =
+  {
+    { rotation_( 0, 0 ), rotation_( 0, 1 ), rotation_( 0, 2 ) },
+    { rotation_( 1, 0 ), rotation_( 1, 1 ), rotation_( 1, 2 ) },
+    { rotation_( 2, 0 ), rotation_( 2, 1 ), rotation_( 2, 2 ) }
+  };
+
+  ar( cereal::make_nvp( "rotation", mat ) );
+
+  const std::vector<double> vec = { center_( 0 ), center_( 1 ), center_( 2 ) };
+  ar( cereal::make_nvp( "center", vec ) );
+}
+
+template <class Archive>
+void Pose3::load( Archive & ar )
+{
+  std::vector<std::vector<double>> mat( 3, std::vector<double>( 3 ) );
+  ar( cereal::make_nvp( "rotation", mat ) );
+  // copy back to the rotation
+  rotation_.row( 0 ) = Eigen::Map<const Vec3>( &( mat[0][0] ) );
+  rotation_.row( 1 ) = Eigen::Map<const Vec3>( &( mat[1][0] ) );
+  rotation_.row( 2 ) = Eigen::Map<const Vec3>( &( mat[2][0] ) );
+
+  std::vector<double> vec( 3 );
+  ar( cereal::make_nvp( "center", vec ) );
+  center_ = Eigen::Map<const Vec3>( &vec[0] );
+}
+
+template void Pose3::load
+<cereal::JSONInputArchive>
+( cereal::JSONInputArchive & ar );
+
+template void Pose3::save
+<cereal::JSONOutputArchive>
+(cereal::JSONOutputArchive & ar) const;
+
+template void Pose3::load
+<cereal::XMLInputArchive>
+( cereal::XMLInputArchive & ar );
+
+template void Pose3::save
+<cereal::XMLOutputArchive>
+(cereal::XMLOutputArchive & ar) const;
+
+template void Pose3::load
+<cereal::BinaryInputArchive>
+( cereal::BinaryInputArchive & ar );
+
+template void Pose3::save
+<cereal::BinaryOutputArchive>
+(cereal::BinaryOutputArchive & ar) const;
+
+template void Pose3::load
+<cereal::PortableBinaryInputArchive>
+( cereal::PortableBinaryInputArchive & ar );
+
+template void Pose3::save
+<cereal::PortableBinaryOutputArchive>
+(cereal::PortableBinaryOutputArchive & ar) const;
+    
 } // namespace geometry
 } // namespace openMVG
 

--- a/src/openMVG/geometry/pose3.hpp
+++ b/src/openMVG/geometry/pose3.hpp
@@ -9,10 +9,8 @@
 #ifndef OPENMVG_GEOMETRY_POSE3_HPP
 #define OPENMVG_GEOMETRY_POSE3_HPP
 
-#include <vector>
-
-#include "openMVG/multiview/projection.hpp"
 #include <cereal/cereal.hpp> // Serialization
+#include "openMVG/numeric/eigen_alias_definition.hpp"
 
 namespace openMVG
 {
@@ -45,54 +43,38 @@ class Pose3
     (
       const Mat3& r = std::move(Mat3::Identity()),
       const Vec3& c = std::move(Vec3::Zero())
-    )
-    : rotation_( r ), center_( c ) {}
+    );
 
     /**
     * @brief Get Rotation matrix
     * @return Rotation matrix
     */
-    const Mat3& rotation() const
-    {
-      return rotation_;
-    }
+	const Mat3& rotation() const;
 
     /**
     * @brief Get Rotation matrix
     * @return Rotation matrix
     */
-    Mat3& rotation()
-    {
-      return rotation_;
-    }
+	Mat3& rotation();
 
     /**
     * @brief Get center of rotation
     * @return center of rotation
     */
-    const Vec3& center() const
-    {
-      return center_;
-    }
+	const Vec3& center() const;
 
     /**
     * @brief Get center of rotation
     * @return Center of rotation
     */
-    Vec3& center()
-    {
-      return center_;
-    }
+	Vec3& center();
 
     /**
     * @brief Get translation vector
     * @return translation vector
     * @note t = -RC
     */
-    inline Vec3 translation() const
-    {
-      return -( rotation_ * center_ );
-    }
+	Vec3 translation() const;
 
 
     /**
@@ -100,10 +82,7 @@ class Pose3
     * @param p Point
     * @return transformed point
     */
-    inline Mat3X operator () ( const Mat3X& p ) const
-    {
-      return rotation_ * ( p.colwise() - center_ );
-    }
+	Mat3X operator () (const Mat3X& p) const;
 
 
     /**
@@ -111,20 +90,14 @@ class Pose3
     * @param P a Pose
     * @return Composition of current pose and parameter pose
     */
-    Pose3 operator * ( const Pose3& P ) const
-    {
-      return Pose3( rotation_ * P.rotation_, P.center_ + P.rotation_.transpose() * center_ );
-    }
+	Pose3 operator * (const Pose3& P) const;
 
 
     /**
     * @brief Get inverse of the pose
     * @return Inverse of the pose
     */
-    Pose3 inverse() const
-    {
-      return Pose3( rotation_.transpose(),  -( rotation_ * center_ ) );
-    }
+	Pose3 inverse() const;
 
 
     /**
@@ -132,10 +105,7 @@ class Pose3
     * @param X Input point
     * @return Distance to center
     */
-    double depth( const Vec3 &X ) const
-    {
-      return ( rotation_ * ( X - center_ ) )[2];
-    }
+	double depth(const Vec3 &X) const;
 
     /**
     * Serialization out

--- a/src/openMVG/geometry/pose3.hpp
+++ b/src/openMVG/geometry/pose3.hpp
@@ -9,7 +9,6 @@
 #ifndef OPENMVG_GEOMETRY_POSE3_HPP
 #define OPENMVG_GEOMETRY_POSE3_HPP
 
-#include <cereal/cereal.hpp> // Serialization
 #include "openMVG/numeric/eigen_alias_definition.hpp"
 
 namespace openMVG
@@ -112,39 +111,14 @@ class Pose3
     * @param ar Archive
     */
     template <class Archive>
-    void save( Archive & ar ) const
-    {
-      const std::vector<std::vector<double>> mat =
-      {
-        { rotation_( 0, 0 ), rotation_( 0, 1 ), rotation_( 0, 2 ) },
-        { rotation_( 1, 0 ), rotation_( 1, 1 ), rotation_( 1, 2 ) },
-        { rotation_( 2, 0 ), rotation_( 2, 1 ), rotation_( 2, 2 ) }
-      };
-
-      ar( cereal::make_nvp( "rotation", mat ) );
-
-      const std::vector<double> vec = { center_( 0 ), center_( 1 ), center_( 2 ) };
-      ar( cereal::make_nvp( "center", vec ) );
-    }
+    void save( Archive & ar ) const;
 
     /**
     * @brief Serialization in
     * @param ar Archive
     */
     template <class Archive>
-    void load( Archive & ar )
-    {
-      std::vector<std::vector<double>> mat( 3, std::vector<double>( 3 ) );
-      ar( cereal::make_nvp( "rotation", mat ) );
-      // copy back to the rotation
-      rotation_.row( 0 ) = Eigen::Map<const Vec3>( &( mat[0][0] ) );
-      rotation_.row( 1 ) = Eigen::Map<const Vec3>( &( mat[1][0] ) );
-      rotation_.row( 2 ) = Eigen::Map<const Vec3>( &( mat[2][0] ) );
-
-      std::vector<double> vec( 3 );
-      ar( cereal::make_nvp( "center", vec ) );
-      center_ = Eigen::Map<const Vec3>( &vec[0] );
-    }
+    void load( Archive & ar );
 };
 } // namespace geometry
 } // namespace openMVG

--- a/src/openMVG/geometry/rigid_transformation3D_srt.cpp
+++ b/src/openMVG/geometry/rigid_transformation3D_srt.cpp
@@ -1,0 +1,193 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2012, 2013 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/geometry/rigid_transformation3D_srt.hpp"
+
+#include <unsupported/Eigen/NonLinearOptimization>
+#include <unsupported/Eigen/NumericalDiff>
+
+namespace openMVG{
+namespace geometry{
+
+bool FindRTS
+(
+  const Mat &x1,
+  const Mat &x2,
+  double * S,
+  Vec3 * t,
+  Mat3 * R
+)
+{
+  if ( x1.cols() < 3 || x2.cols() < 3 )
+  {
+    return false;
+  }
+
+  assert( 3 == x1.rows() );
+  assert( 3 <= x1.cols() );
+  assert( x1.rows() == x2.rows() );
+  assert( x1.cols() == x2.cols() );
+
+  // Get the transformation via Umeyama's least squares algorithm. This returns
+  // a matrix of the form:
+  // [ s * R t]
+  // [ 0 1]
+  // from which we can extract the scale, rotation, and translation.
+  const Eigen::Matrix4d transform = Eigen::umeyama( x1, x2, true );
+
+  // Check critical cases
+  *R = transform.topLeftCorner<3, 3>();
+  if ( R->determinant() < 0 )
+  {
+    return false;
+  }
+  *S = pow( R->determinant(), 1.0 / 3.0 );
+  // Check for degenerate case (if all points have the same value...)
+  if ( *S < std::numeric_limits<double>::epsilon() )
+  {
+    return false;
+  }
+
+  // Extract transformation parameters
+  *S = pow( R->determinant(), 1.0 / 3.0 );
+  *R /= *S;
+  *t = transform.topRightCorner<3, 1>();
+
+  return true;
+}
+
+lm_SRTRefine_functor::lm_SRTRefine_functor( int inputs, int values,
+                      const Mat &x1, const Mat &x2,
+                      const double &S, const Mat3 & R, const Vec &t ): Functor<double>( inputs, values ),
+  x1_( x1 ), x2_( x2 ), t_( t ), R_( R ), S_( S ) { }
+
+int lm_SRTRefine_functor::operator()( const Vec &x, Vec &fvec ) const
+{
+  // convert x to rotation matrix and a translation vector and a Scale factor
+  // x = {tx,ty,tz,anglex,angley,anglez,S}
+  Vec3 transAdd = x.block<3, 1>( 0, 0 );
+  Vec3 rot = x.block<3, 1>( 3, 0 );
+  double Sadd = x( 6 );
+
+  //Build the rotation matrix
+  Mat3 Rcor =
+    ( Eigen::AngleAxis<double>( rot( 0 ), Vec3::UnitX() )
+      * Eigen::AngleAxis<double>( rot( 1 ), Vec3::UnitY() )
+      * Eigen::AngleAxis<double>( rot( 2 ), Vec3::UnitZ() ) ).toRotationMatrix();
+
+  const Mat3 nR  = R_ * Rcor;
+  const Vec3 nt = t_ + transAdd;
+  const double nS = S_ + Sadd;
+
+  // Evaluate re-projection errors
+  Vec3 proj;
+  for ( Mat::Index i = 0; i < x1_.cols(); ++i )
+  {
+    proj = x2_.col( i ) -  ( nS *  nR * ( x1_.col( i ) ) + nt );
+    fvec[i * 3]   = proj( 0 );
+    fvec[i * 3 + 1] = proj( 1 );
+    fvec[i * 3 + 2] = proj( 2 );
+  }
+  return 0;
+}
+
+
+lm_RRefine_functor::lm_RRefine_functor( int inputs, int values,
+                    const Mat &x1, const Mat &x2,
+                    const double &S, const Mat3 & R, const Vec &t ): Functor<double>( inputs, values ),
+  x1_( x1 ), x2_( x2 ), t_( t ), R_( R ), S_( S ) { }
+
+int lm_RRefine_functor::operator()( const Vec &x, Vec &fvec ) const
+{
+  // convert x to rotation matrix
+  // x = {anglex,angley,anglez}
+  Vec3 rot = x.block<3, 1>( 0, 0 );
+
+  //Build the rotation matrix
+  Mat3 Rcor =
+    ( Eigen::AngleAxis<double>( rot( 0 ), Vec3::UnitX() )
+      * Eigen::AngleAxis<double>( rot( 1 ), Vec3::UnitY() )
+      * Eigen::AngleAxis<double>( rot( 2 ), Vec3::UnitZ() ) ).toRotationMatrix();
+
+  const Mat3 nR  = R_ * Rcor;
+  const Vec3 nt = t_;
+  const double nS = S_;
+
+  // Evaluate re-projection errors
+  Vec3 proj;
+  for ( Mat::Index i = 0; i < x1_.cols(); ++i )
+  {
+    proj = x2_.col( i ) -  ( nS *  nR * ( x1_.col( i ) ) + nt );
+    fvec[i * 3]   = proj( 0 );
+    fvec[i * 3 + 1] = proj( 1 );
+    fvec[i * 3 + 2] = proj( 2 );
+  }
+  return 0;
+}
+
+void Refine_RTS
+(
+  const Mat &x1,
+  const Mat &x2,
+  double * S,
+  Vec3 * t,
+  Mat3 * R
+)
+{
+  {
+    lm_SRTRefine_functor functor( 7, 3 * x1.cols(), x1, x2, *S, *R, *t );
+
+    Eigen::NumericalDiff<lm_SRTRefine_functor> numDiff( functor );
+
+    Eigen::LevenbergMarquardt<Eigen::NumericalDiff<lm_SRTRefine_functor> > lm( numDiff );
+    lm.parameters.maxfev = 1000;
+    Vec xlm = Vec::Zero( 7 ); // The deviation vector {tx,ty,tz,rotX,rotY,rotZ,S}
+
+    lm.minimize( xlm );
+
+    const Vec3 transAdd = xlm.block<3, 1>( 0, 0 );
+    const Vec3 rot = xlm.block<3, 1>( 3, 0 );
+    const double SAdd = xlm( 6 );
+
+    //Build the rotation matrix
+    const Mat3 Rcor =
+      ( Eigen::AngleAxis<double>( rot( 0 ), Vec3::UnitX() )
+        * Eigen::AngleAxis<double>( rot( 1 ), Vec3::UnitY() )
+        * Eigen::AngleAxis<double>( rot( 2 ), Vec3::UnitZ() ) ).toRotationMatrix();
+
+    *R = ( *R ) * Rcor;
+    *t = ( *t ) + transAdd;
+    *S = ( *S ) + SAdd;
+  }
+
+  // Refine rotation
+  {
+    lm_RRefine_functor functor( 3, 3 * x1.cols(), x1, x2, *S, *R, *t );
+
+    Eigen::NumericalDiff<lm_RRefine_functor> numDiff( functor );
+
+    Eigen::LevenbergMarquardt<Eigen::NumericalDiff<lm_RRefine_functor> > lm( numDiff );
+    lm.parameters.maxfev = 1000;
+    Vec xlm = Vec::Zero( 3 ); // The deviation vector {rotX,rotY,rotZ}
+
+    lm.minimize( xlm );
+
+    const Vec3 rot = xlm.block<3, 1>( 0, 0 );
+
+    //Build the rotation matrix
+    const Mat3 Rcor =
+      ( Eigen::AngleAxis<double>( rot( 0 ), Vec3::UnitX() )
+        * Eigen::AngleAxis<double>( rot( 1 ), Vec3::UnitY() )
+        * Eigen::AngleAxis<double>( rot( 2 ), Vec3::UnitZ() ) ).toRotationMatrix();
+
+    *R = ( *R ) * Rcor;
+  }
+}
+
+} // namespace geometry
+} // namespace openMVG

--- a/src/openMVG/geometry/rigid_transformation3D_srt.hpp
+++ b/src/openMVG/geometry/rigid_transformation3D_srt.hpp
@@ -9,7 +9,6 @@
 #ifndef OPENMVG_GEOMETRY_RIGID_TRANSFORMATION_3D_SRT_HPP
 #define OPENMVG_GEOMETRY_RIGID_TRANSFORMATION_3D_SRT_HPP
 
-#include <limits>
 #include "openMVG/numeric/lm.hpp"
 #include "openMVG/numeric/eigen_alias_definition.hpp"
 
@@ -35,52 +34,14 @@ namespace geometry
  *
  * \note Need at least 3 points
  */
-inline bool FindRTS
-(
-  const Mat &x1,
-  const Mat &x2,
-  double * S,
-  Vec3 * t,
-  Mat3 * R
-)
-{
-  if ( x1.cols() < 3 || x2.cols() < 3 )
-  {
-    return false;
-  }
-
-  assert( 3 == x1.rows() );
-  assert( 3 <= x1.cols() );
-  assert( x1.rows() == x2.rows() );
-  assert( x1.cols() == x2.cols() );
-
-  // Get the transformation via Umeyama's least squares algorithm. This returns
-  // a matrix of the form:
-  // [ s * R t]
-  // [ 0 1]
-  // from which we can extract the scale, rotation, and translation.
-  const Eigen::Matrix4d transform = Eigen::umeyama( x1, x2, true );
-
-  // Check critical cases
-  *R = transform.topLeftCorner<3, 3>();
-  if ( R->determinant() < 0 )
-  {
-    return false;
-  }
-  *S = pow( R->determinant(), 1.0 / 3.0 );
-  // Check for degenerate case (if all points have the same value...)
-  if ( *S < std::numeric_limits<double>::epsilon() )
-  {
-    return false;
-  }
-
-  // Extract transformation parameters
-  *S = pow( R->determinant(), 1.0 / 3.0 );
-  *R /= *S;
-  *t = transform.topRightCorner<3, 1>();
-
-  return true;
-}
+  bool FindRTS
+  (
+    const Mat &x1,
+    const Mat &x2,
+    double * S,
+    Vec3 * t,
+    Mat3 * R
+  );
 
 /**
 * @brief Eigen Levemberg-Marquardt functor to refine translation, Rotation and Scale parameter.
@@ -99,43 +60,14 @@ struct lm_SRTRefine_functor : Functor<double>
   */
   lm_SRTRefine_functor( int inputs, int values,
                         const Mat &x1, const Mat &x2,
-                        const double &S, const Mat3 & R, const Vec &t ): Functor<double>( inputs, values ),
-    x1_( x1 ), x2_( x2 ), t_( t ), R_( R ), S_( S ) { }
+                        const double &S, const Mat3 & R, const Vec &t );
 
   /**
   * @brief Computes error given a sample
   * @param x a Sample
   * @param[out] fvec Error for each values
   */
-  int operator()( const Vec &x, Vec &fvec ) const
-  {
-    // convert x to rotation matrix and a translation vector and a Scale factor
-    // x = {tx,ty,tz,anglex,angley,anglez,S}
-    Vec3 transAdd = x.block<3, 1>( 0, 0 );
-    Vec3 rot = x.block<3, 1>( 3, 0 );
-    double Sadd = x( 6 );
-
-    //Build the rotation matrix
-    Mat3 Rcor =
-      ( Eigen::AngleAxis<double>( rot( 0 ), Vec3::UnitX() )
-        * Eigen::AngleAxis<double>( rot( 1 ), Vec3::UnitY() )
-        * Eigen::AngleAxis<double>( rot( 2 ), Vec3::UnitZ() ) ).toRotationMatrix();
-
-    const Mat3 nR  = R_ * Rcor;
-    const Vec3 nt = t_ + transAdd;
-    const double nS = S_ + Sadd;
-
-    // Evaluate re-projection errors
-    Vec3 proj;
-    for ( Mat::Index i = 0; i < x1_.cols(); ++i )
-    {
-      proj = x2_.col( i ) -  ( nS *  nR * ( x1_.col( i ) ) + nt );
-      fvec[i * 3]   = proj( 0 );
-      fvec[i * 3 + 1] = proj( 1 );
-      fvec[i * 3 + 2] = proj( 2 );
-    }
-    return 0;
-  }
+  int operator()( const Vec &x, Vec &fvec ) const;
 
   Mat x1_, x2_;
   Vec3 t_;
@@ -161,41 +93,14 @@ struct lm_RRefine_functor : Functor<double>
   */
   lm_RRefine_functor( int inputs, int values,
                       const Mat &x1, const Mat &x2,
-                      const double &S, const Mat3 & R, const Vec &t ): Functor<double>( inputs, values ),
-    x1_( x1 ), x2_( x2 ), t_( t ), R_( R ), S_( S ) { }
+                      const double &S, const Mat3 & R, const Vec &t );
 
   /**
    * @brief Computes error given a sample
    * @param x a Sample
    * @param[out] fvec Error for each values
    */
-  int operator()( const Vec &x, Vec &fvec ) const
-  {
-    // convert x to rotation matrix
-    // x = {anglex,angley,anglez}
-    Vec3 rot = x.block<3, 1>( 0, 0 );
-
-    //Build the rotation matrix
-    Mat3 Rcor =
-      ( Eigen::AngleAxis<double>( rot( 0 ), Vec3::UnitX() )
-        * Eigen::AngleAxis<double>( rot( 1 ), Vec3::UnitY() )
-        * Eigen::AngleAxis<double>( rot( 2 ), Vec3::UnitZ() ) ).toRotationMatrix();
-
-    const Mat3 nR  = R_ * Rcor;
-    const Vec3 nt = t_;
-    const double nS = S_;
-
-    // Evaluate re-projection errors
-    Vec3 proj;
-    for ( Mat::Index i = 0; i < x1_.cols(); ++i )
-    {
-      proj = x2_.col( i ) -  ( nS *  nR * ( x1_.col( i ) ) + nt );
-      fvec[i * 3]   = proj( 0 );
-      fvec[i * 3 + 1] = proj( 1 );
-      fvec[i * 3 + 2] = proj( 2 );
-    }
-    return 0;
-  }
+  int operator()( const Vec &x, Vec &fvec ) const;
 
   Mat x1_, x2_;
   Vec3 t_;
@@ -215,64 +120,14 @@ struct lm_RRefine_functor : Functor<double>
  *
  * \return none
  */
-inline void Refine_RTS
+void Refine_RTS
 (
   const Mat &x1,
   const Mat &x2,
   double * S,
   Vec3 * t,
   Mat3 * R
-)
-{
-  {
-    lm_SRTRefine_functor functor( 7, 3 * x1.cols(), x1, x2, *S, *R, *t );
-
-    Eigen::NumericalDiff<lm_SRTRefine_functor> numDiff( functor );
-
-    Eigen::LevenbergMarquardt<Eigen::NumericalDiff<lm_SRTRefine_functor> > lm( numDiff );
-    lm.parameters.maxfev = 1000;
-    Vec xlm = Vec::Zero( 7 ); // The deviation vector {tx,ty,tz,rotX,rotY,rotZ,S}
-
-    lm.minimize( xlm );
-
-    const Vec3 transAdd = xlm.block<3, 1>( 0, 0 );
-    const Vec3 rot = xlm.block<3, 1>( 3, 0 );
-    const double SAdd = xlm( 6 );
-
-    //Build the rotation matrix
-    const Mat3 Rcor =
-      ( Eigen::AngleAxis<double>( rot( 0 ), Vec3::UnitX() )
-        * Eigen::AngleAxis<double>( rot( 1 ), Vec3::UnitY() )
-        * Eigen::AngleAxis<double>( rot( 2 ), Vec3::UnitZ() ) ).toRotationMatrix();
-
-    *R = ( *R ) * Rcor;
-    *t = ( *t ) + transAdd;
-    *S = ( *S ) + SAdd;
-  }
-
-  // Refine rotation
-  {
-    lm_RRefine_functor functor( 3, 3 * x1.cols(), x1, x2, *S, *R, *t );
-
-    Eigen::NumericalDiff<lm_RRefine_functor> numDiff( functor );
-
-    Eigen::LevenbergMarquardt<Eigen::NumericalDiff<lm_RRefine_functor> > lm( numDiff );
-    lm.parameters.maxfev = 1000;
-    Vec xlm = Vec::Zero( 3 ); // The deviation vector {rotX,rotY,rotZ}
-
-    lm.minimize( xlm );
-
-    const Vec3 rot = xlm.block<3, 1>( 0, 0 );
-
-    //Build the rotation matrix
-    const Mat3 Rcor =
-      ( Eigen::AngleAxis<double>( rot( 0 ), Vec3::UnitX() )
-        * Eigen::AngleAxis<double>( rot( 1 ), Vec3::UnitY() )
-        * Eigen::AngleAxis<double>( rot( 2 ), Vec3::UnitZ() ) ).toRotationMatrix();
-
-    *R = ( *R ) * Rcor;
-  }
-}
+);
 
 } // namespace geometry
 } // namespace openMVG

--- a/src/openMVG/matching/indMatch.hpp
+++ b/src/openMVG/matching/indMatch.hpp
@@ -9,15 +9,9 @@
 #ifndef OPENMVG_MATCHING_IND_MATCH_HPP
 #define OPENMVG_MATCHING_IND_MATCH_HPP
 
-#include <iostream>
-#include <map>
-#include <set>
-#include <utility>
-#include <vector>
-
 #include "openMVG/types.hpp"
 
-#include <cereal/cereal.hpp> // Serialization
+#include <iostream>
 
 namespace openMVG {
 namespace matching {
@@ -40,6 +34,14 @@ struct IndMatch
   friend bool operator<(const IndMatch& m1, const IndMatch& m2)  {
     return (m1.i_ < m2.i_ || (m1.i_ == m2.i_ && m1.j_ < m2.j_));
   }
+  
+  friend std::ostream& operator<<(std::ostream & out, const IndMatch & obj) {
+    return out << obj.i_ << " " << obj.j_;
+  }
+
+  friend std::istream& operator>>(std::istream & in, IndMatch & obj) {
+    return in >> obj.i_ >> obj.j_;
+  }
 
   /// Remove duplicates ((i_, j_) that appears multiple times)
   static bool getDeduplicated(std::vector<IndMatch> & vec_match)  {
@@ -59,13 +61,6 @@ struct IndMatch
   IndexT i_, j_;  // Left, right index
 };
 
-inline std::ostream& operator<<(std::ostream & out, const IndMatch & obj) {
-  return out << obj.i_ << " " << obj.j_;
-}
-
-inline std::istream& operator>>(std::istream & in, IndMatch & obj) {
-  return in >> obj.i_ >> obj.j_;
-}
 
 using IndMatches = std::vector<matching::IndMatch>;
 
@@ -108,16 +103,5 @@ inline Pair_Set getPairs(const PairWiseMatches & matches)
 
 }  // namespace matching
 }  // namespace openMVG
-
-namespace cereal
-{
-  // This struct specialization will tell cereal which is the right way to serialize PairWiseMatches
-  template <class Archive>
-  struct specialize<
-    Archive,
-    openMVG::matching::PairWiseMatches,
-    cereal::specialization::member_serialize>
-  {};
-} // namespace cereal
 
 #endif // OPENMVG_MATCHING_IND_MATCH_HPP

--- a/src/openMVG/matching/indMatch_utils.cpp
+++ b/src/openMVG/matching/indMatch_utils.cpp
@@ -21,6 +21,17 @@
 #include <cereal/types/utility.hpp>
 #include <cereal/types/vector.hpp>
 
+namespace cereal
+{
+  // This struct specialization will tell cereal which is the right way to serialize PairWiseMatches
+  template <class Archive>
+  struct specialize<
+    Archive,
+    openMVG::matching::PairWiseMatches,
+    cereal::specialization::member_serialize>
+  {};
+} // namespace cereal
+
 namespace openMVG {
 namespace matching {
 

--- a/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions.cpp
+++ b/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions.cpp
@@ -13,6 +13,7 @@
 #include "openMVG/matching/matching_filters.hpp"
 #include "openMVG/matching/indMatchDecoratorXY.hpp"
 #include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
+#include "openMVG/numeric/numeric.h"
 #include "openMVG/types.hpp"
 
 #include "third_party/progress/progress.hpp"

--- a/src/openMVG/numeric/lm.hpp
+++ b/src/openMVG/numeric/lm.hpp
@@ -10,8 +10,7 @@
 #define OPENMVG_NUMERIC_LM_HPP
 
 // Levenberg Marquardt Non Linear Optimization
-#include <unsupported/Eigen/NonLinearOptimization>
-#include <unsupported/Eigen/NumericalDiff>
+#include <Eigen/Core>
 
 namespace openMVG
 {

--- a/src/openMVG/numeric/lm_test.cpp
+++ b/src/openMVG/numeric/lm_test.cpp
@@ -12,6 +12,9 @@
 #include "testing/testing.h"
 #include "third_party/vectorGraphics/svgDrawer.hpp"
 
+#include <unsupported/Eigen/NonLinearOptimization>
+#include <unsupported/Eigen/NumericalDiff>
+
 #include <fstream>
 #include <iostream>
 #include <string>

--- a/src/openMVG/sfm/CMakeLists.txt
+++ b/src/openMVG/sfm/CMakeLists.txt
@@ -19,7 +19,7 @@ list(REMOVE_ITEM sfm_files_header ${REMOVEFILESUNITTEST})
 add_library(openMVG_sfm ${sfm_files_header} ${sfm_files_cpp})
 target_link_libraries(
   openMVG_sfm
-  openMVG_geometry
+  openMVG_cameras
   openMVG_multiview
   stlplus
   ${CERES_LIBRARIES}

--- a/src/openMVG/sfm/CMakeLists.txt
+++ b/src/openMVG/sfm/CMakeLists.txt
@@ -19,6 +19,7 @@ list(REMOVE_ITEM sfm_files_header ${REMOVEFILESUNITTEST})
 add_library(openMVG_sfm ${sfm_files_header} ${sfm_files_cpp})
 target_link_libraries(
   openMVG_sfm
+  openMVG_geometry
   openMVG_multiview
   stlplus
   ${CERES_LIBRARIES}

--- a/src/openMVG/sfm/pipelines/global/sfm_global_engine_relative_motions.cpp
+++ b/src/openMVG/sfm/pipelines/global/sfm_global_engine_relative_motions.cpp
@@ -14,6 +14,7 @@
 #include "openMVG/matching/indMatch.hpp"
 #include "openMVG/multiview/essential.hpp"
 #include "openMVG/multiview/triangulation.hpp"
+#include "openMVG/numeric/numeric.h"
 #include "openMVG/sfm/pipelines/global/GlobalSfM_rotation_averaging.hpp"
 #include "openMVG/sfm/pipelines/sfm_features_provider.hpp"
 #include "openMVG/sfm/pipelines/sfm_matches_provider.hpp"

--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
@@ -9,7 +9,9 @@
 
 #include "openMVG/sfm/pipelines/sequential/sequential_SfM.hpp"
 #include "openMVG/geometry/pose3.hpp"
+#include "openMVG/numeric/numeric.h"
 #include "openMVG/multiview/triangulation.hpp"
+#include "openMVG/multiview/projection.hpp"
 #include "openMVG/numeric/eigen_alias_definition.hpp"
 #include "openMVG/sfm/pipelines/sfm_features_provider.hpp"
 #include "openMVG/sfm/pipelines/sfm_matches_provider.hpp"

--- a/src/openMVG/sfm/pipelines/sfm_features_provider.hpp
+++ b/src/openMVG/sfm/pipelines/sfm_features_provider.hpp
@@ -19,6 +19,7 @@
 #include "openMVG/types.hpp"
 
 #include "third_party/progress/progress_display.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 namespace openMVG {
 namespace sfm {

--- a/src/openMVG/sfm/pipelines/sfm_regions_provider.cpp
+++ b/src/openMVG/sfm/pipelines/sfm_regions_provider.cpp
@@ -1,0 +1,125 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
+#include "openMVG/sfm/sfm_data.hpp"
+
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+namespace openMVG {
+namespace sfm {
+
+std::string Regions_Provider::Type_id()
+{
+  if (region_type_)
+    return region_type_->Type_id();
+  else
+  {
+    return std::string("initialized regions type");
+  }
+}
+
+bool Regions_Provider::IsScalar()
+{
+  if (region_type_)
+    return region_type_->IsScalar();
+  else
+  {
+    std::cerr << "Invalid region type" << std::endl;
+    return false;
+  }
+}
+
+bool Regions_Provider::IsBinary()
+{
+  if (region_type_)
+    return region_type_->IsBinary();
+  else
+  {
+    std::cerr << "Invalid region type" << std::endl;
+    return false;
+  }
+}
+
+const openMVG::features::Regions* Regions_Provider::getRegionsType() const
+{
+  if (region_type_)
+    return &(*region_type_);
+  else
+    return nullptr;
+}
+
+std::shared_ptr<features::Regions> Regions_Provider::get(const IndexT x) const
+{
+  auto it = cache_.find(x);
+  std::shared_ptr<features::Regions> ret;
+
+  if (it != end(cache_))
+  {
+    ret = it->second;
+  }
+  // else Invalid ressource
+  return ret;
+}
+
+// Load Regions related to a provided SfM_Data View container
+bool Regions_Provider::load(
+  const SfM_Data & sfm_data,
+  const std::string & feat_directory,
+  std::unique_ptr<features::Regions>& region_type,
+  C_Progress *  my_progress_bar)
+{
+  if (!my_progress_bar)
+    my_progress_bar = &C_Progress::dummy();
+  region_type_.reset(region_type->EmptyClone());
+
+  my_progress_bar->restart(sfm_data.GetViews().size(), "\n- Regions Loading -\n");
+  // Read for each view the corresponding regions and store them
+  std::atomic<bool> bContinue(true);
+#ifdef OPENMVG_USE_OPENMP
+  #pragma omp parallel
+#endif
+  for (Views::const_iterator iter = sfm_data.GetViews().begin();
+    iter != sfm_data.GetViews().end() && bContinue; ++iter)
+  {
+      if (my_progress_bar->hasBeenCanceled())
+      {
+        bContinue = false;
+        continue;
+      }
+#ifdef OPENMVG_USE_OPENMP
+  #pragma omp single nowait
+#endif
+    {
+      const std::string sImageName = stlplus::create_filespec(sfm_data.s_root_path, iter->second->s_Img_path);
+      const std::string basename = stlplus::basename_part(sImageName);
+      const std::string featFile = stlplus::create_filespec(feat_directory, basename, ".feat");
+      const std::string descFile = stlplus::create_filespec(feat_directory, basename, ".desc");
+
+      std::unique_ptr<features::Regions> regions_ptr(region_type->EmptyClone());
+      if (!regions_ptr->Load(featFile, descFile))
+      {
+        std::cerr << "Invalid regions files for the view: " << sImageName << std::endl;
+        bContinue = false;
+      }
+      //else
+#ifdef OPENMVG_USE_OPENMP
+      #pragma omp critical
+#endif
+      {
+        cache_[iter->second->id_view] = std::move(regions_ptr);
+      }
+      ++(*my_progress_bar);
+    }
+  }
+  return bContinue;
+}
+
+
+} // namespace sfm
+} // namespace openMVG

--- a/src/openMVG/sfm/pipelines/sfm_regions_provider.hpp
+++ b/src/openMVG/sfm/pipelines/sfm_regions_provider.hpp
@@ -9,19 +9,16 @@
 #ifndef OPENMVG_SFM_SFM_REGIONS_PROVIDER_HPP
 #define OPENMVG_SFM_SFM_REGIONS_PROVIDER_HPP
 
-#include <atomic>
+#include "openMVG/features/regions.hpp"
+#include "openMVG/types.hpp"
+#include "third_party/progress/progress.hpp"
+
 #include <memory>
 #include <string>
 
-#include "openMVG/features/image_describer.hpp"
-#include "openMVG/features/regions_factory.hpp"
-#include "openMVG/sfm/sfm_data.hpp"
-#include "openMVG/types.hpp"
-
-#include "third_party/progress/progress.hpp"
-
 namespace openMVG {
 namespace sfm {
+struct SfM_Data;
 
 /// Abstract Regions provider
 /// Allow to load and return the regions related to a view
@@ -31,112 +28,23 @@ public:
 
   virtual ~Regions_Provider() = default;
 
-  std::string Type_id()
-  {
-    if (region_type_)
-      return region_type_->Type_id();
-    else
-    {
-      return std::string("initialized regions type");
-    }
-  }
+  std::string Type_id();
 
-  bool IsScalar()
-  {
-    if (region_type_)
-      return region_type_->IsScalar();
-    else
-    {
-      std::cerr << "Invalid region type" << std::endl;
-      return false;
-    }
-  }
+  bool IsScalar();
 
-  bool IsBinary()
-  {
-    if (region_type_)
-      return region_type_->IsBinary();
-    else
-    {
-      std::cerr << "Invalid region type" << std::endl;
-      return false;
-    }
-  }
+  bool IsBinary();
 
-  const openMVG::features::Regions* getRegionsType() const
-  {
-    if (region_type_)
-      return &(*region_type_);
-    else
-      return nullptr;
-  }
+  const openMVG::features::Regions* getRegionsType() const;
 
-  virtual std::shared_ptr<features::Regions> get(const IndexT x) const
-  {
-    auto it = cache_.find(x);
-    std::shared_ptr<features::Regions> ret;
-
-    if (it != end(cache_))
-    {
-      ret = it->second;
-    }
-    // else Invalid ressource
-    return ret;
-  }
+  virtual std::shared_ptr<features::Regions> get(const IndexT x) const;
 
   // Load Regions related to a provided SfM_Data View container
   virtual bool load(
     const SfM_Data & sfm_data,
     const std::string & feat_directory,
     std::unique_ptr<features::Regions>& region_type,
-    C_Progress *  my_progress_bar = nullptr)
-  {
-    if (!my_progress_bar)
-      my_progress_bar = &C_Progress::dummy();
-    region_type_.reset(region_type->EmptyClone());
-
-    my_progress_bar->restart(sfm_data.GetViews().size(), "\n- Regions Loading -\n");
-    // Read for each view the corresponding regions and store them
-    std::atomic<bool> bContinue(true);
-#ifdef OPENMVG_USE_OPENMP
-    #pragma omp parallel
-#endif
-    for (Views::const_iterator iter = sfm_data.GetViews().begin();
-      iter != sfm_data.GetViews().end() && bContinue; ++iter)
-    {
-        if (my_progress_bar->hasBeenCanceled())
-        {
-          bContinue = false;
-          continue;
-        }
-#ifdef OPENMVG_USE_OPENMP
-    #pragma omp single nowait
-#endif
-      {
-        const std::string sImageName = stlplus::create_filespec(sfm_data.s_root_path, iter->second->s_Img_path);
-        const std::string basename = stlplus::basename_part(sImageName);
-        const std::string featFile = stlplus::create_filespec(feat_directory, basename, ".feat");
-        const std::string descFile = stlplus::create_filespec(feat_directory, basename, ".desc");
-
-        std::unique_ptr<features::Regions> regions_ptr(region_type->EmptyClone());
-        if (!regions_ptr->Load(featFile, descFile))
-        {
-          std::cerr << "Invalid regions files for the view: " << sImageName << std::endl;
-          bContinue = false;
-        }
-        //else
-#ifdef OPENMVG_USE_OPENMP
-        #pragma omp critical
-#endif
-        {
-          cache_[iter->second->id_view] = std::move(regions_ptr);
-        }
-        ++(*my_progress_bar);
-      }
-    }
-    return bContinue;
-  }
-
+    C_Progress *  my_progress_bar = nullptr);
+  
 protected:
   /// Regions per ViewId of the considered SfM_Data container
   mutable Hash_Map<IndexT, std::shared_ptr<features::Regions> > cache_;

--- a/src/openMVG/sfm/pipelines/sfm_regions_provider_cache.cpp
+++ b/src/openMVG/sfm/pipelines/sfm_regions_provider_cache.cpp
@@ -1,0 +1,109 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2016 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/sfm/pipelines/sfm_regions_provider_cache.hpp"
+#include "openMVG/sfm/sfm_data.hpp"
+
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+namespace openMVG {
+namespace sfm {
+
+Regions_Provider_Cache::Regions_Provider_Cache (const unsigned int max_cache_size)
+  : Regions_Provider(), max_cache_size_(max_cache_size)
+{
+}
+
+std::shared_ptr<features::Regions> Regions_Provider_Cache::get(const IndexT x) const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = cache_.find(x);
+  std::shared_ptr<features::Regions> ret;
+
+  if (it == end(cache_))
+  {
+    // Load the ressource link to this ID
+    const std::string id =
+      stlplus::create_filespec(feat_directory_, map_id_string_.at(x));
+    const std::string featFile = id + ".feat";
+    const std::string descFile = id + ".desc";
+    ret.reset(region_type_->EmptyClone());
+    if (ret->Load(featFile, descFile))
+    {
+      cache_[x] = ret;
+    }
+    else
+    {
+      // Invalid ressource
+    }
+  }
+  else
+  {
+    ret = it->second;
+  }
+  // If the cache is too large:
+  //  - try to prune elements that are no longer used
+  if (size() > max_cache_size_)
+  {
+    prune(true); // Prune only one cached object
+  }
+  return ret;
+}
+
+// Initialize the regions_provider_cache
+bool Regions_Provider_Cache::load
+(
+  const SfM_Data & sfm_data,
+  const std::string & feat_directory,
+  std::unique_ptr<features::Regions>& region_type,
+  C_Progress * 
+)
+{
+  std::cout << "Initialization of the Regions_Provider_Cache. #Elements in the cache: "<< max_cache_size_ << std::endl;
+
+  feat_directory_ = feat_directory;
+  region_type_.reset(region_type->EmptyClone());
+
+  // Build an association table from view id to feature & descriptor files
+  for (const auto & iterViews : sfm_data.GetViews())
+  {
+    const openMVG::IndexT id = iterViews.second->id_view;
+    assert( id == iterViews.first);
+    map_id_string_[id] = stlplus::basename_part(iterViews.second->s_Img_path);
+  }
+
+  return true;
+}
+
+std::size_t Regions_Provider_Cache::prune(bool bPruneOnlyOne) const
+{
+  std::size_t count = 0;
+  for (auto it = begin(cache_); it != end(cache_);)
+  {
+    if (it->second.use_count() == 1)
+    {
+      cache_.erase(it++);
+      ++count;
+      if (bPruneOnlyOne)
+      {
+        break;
+      }
+    }
+    else
+    {
+      ++it;
+    }
+  }
+  return count;
+}
+
+std::size_t Regions_Provider_Cache::size() const { return cache_.size(); }
+
+
+} // namespace sfm
+} // namespace openMVG

--- a/src/openMVG/sfm/pipelines/sfm_regions_provider_cache.hpp
+++ b/src/openMVG/sfm/pipelines/sfm_regions_provider_cache.hpp
@@ -11,12 +11,9 @@
 
 #include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
 
-#include <atomic>
-#include <chrono>
-#include <map>
 #include <mutex>
+#include <map>
 #include <string>
-#include <thread>
 
 namespace openMVG {
 namespace sfm {
@@ -27,46 +24,9 @@ struct Regions_Provider_Cache : public Regions_Provider
 {
 public:
 
-  Regions_Provider_Cache (const unsigned int max_cache_size)
-    : Regions_Provider(), max_cache_size_(max_cache_size)
-  {
-  }
+  Regions_Provider_Cache (const unsigned int max_cache_size);
 
-  std::shared_ptr<features::Regions> get(const IndexT x) const override
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = cache_.find(x);
-    std::shared_ptr<features::Regions> ret;
-
-    if (it == end(cache_))
-    {
-      // Load the ressource link to this ID
-      const std::string id =
-        stlplus::create_filespec(feat_directory_, map_id_string_.at(x));
-      const std::string featFile = id + ".feat";
-      const std::string descFile = id + ".desc";
-      ret.reset(region_type_->EmptyClone());
-      if (ret->Load(featFile, descFile))
-      {
-        cache_[x] = ret;
-      }
-      else
-      {
-        // Invalid ressource
-      }
-    }
-    else
-    {
-      ret = it->second;
-    }
-    // If the cache is too large:
-    //  - try to prune elements that are no longer used
-    if (size() > max_cache_size_)
-    {
-      prune(true); // Prune only one cached object
-    }
-    return ret;
-  }
+  std::shared_ptr<features::Regions> get(const IndexT x) const override;
 
   // Initialize the regions_provider_cache
   bool load
@@ -75,23 +35,7 @@ public:
     const std::string & feat_directory,
     std::unique_ptr<features::Regions>& region_type,
     C_Progress * 
-  ) override
-  {
-    std::cout << "Initialization of the Regions_Provider_Cache. #Elements in the cache: "<< max_cache_size_ << std::endl;
-
-    feat_directory_ = feat_directory;
-    region_type_.reset(region_type->EmptyClone());
-
-    // Build an association table from view id to feature & descriptor files
-    for (const auto & iterViews : sfm_data.GetViews())
-    {
-      const openMVG::IndexT id = iterViews.second->id_view;
-      assert( id == iterViews.first);
-      map_id_string_[id] = stlplus::basename_part(iterViews.second->s_Img_path);
-    }
-
-    return true;
-  }
+  ) override;
 
 private:
 
@@ -105,29 +49,9 @@ private:
 
   /// @brief Prune smart_ptr that are only referenced into the cache (not longer used externally)
   /// @return the number of removed elements
-  std::size_t prune(bool bPruneOnlyOne = false) const
-  {
-    std::size_t count = 0;
-    for (auto it = begin(cache_); it != end(cache_);)
-    {
-      if (it->second.use_count() == 1)
-      {
-        cache_.erase(it++);
-        ++count;
-        if (bPruneOnlyOne)
-        {
-          break;
-        }
-      }
-      else
-      {
-        ++it;
-      }
-    }
-    return count;
-  }
+  std::size_t prune(bool bPruneOnlyOne = false) const;
 
-  std::size_t size() const { return cache_.size(); }
+  std::size_t size() const;
 
 }; // Regions_Provider_Cache
 

--- a/src/openMVG/sfm/pipelines/structure_from_known_poses/structure_estimator.cpp
+++ b/src/openMVG/sfm/pipelines/structure_from_known_poses/structure_estimator.cpp
@@ -13,6 +13,7 @@
 #include "openMVG/graph/graph.hpp"
 #include "openMVG/geometry/pose3.hpp"
 //#include "openMVG/matching/defines.hpp"
+#include "openMVG/multiview/projection.hpp"
 #include "openMVG/multiview/solver_fundamental_kernel.hpp"
 #include "openMVG/multiview/triangulation_nview.hpp"
 #include "openMVG/numeric/eigen_alias_definition.hpp"

--- a/src/openMVG/sfm/sfm_data_BA_ceres.cpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.cpp
@@ -10,6 +10,7 @@
 
 #include "ceres/problem.h"
 #include "ceres/solver.h"
+#include "openMVG/numeric/numeric.h"
 #include "openMVG/cameras/Camera_Common.hpp"
 #include "openMVG/cameras/Camera_Intrinsics.hpp"
 #include "openMVG/geometry/Similarity3.hpp"

--- a/src/openMVG/sfm/sfm_data_filters.cpp
+++ b/src/openMVG/sfm/sfm_data_filters.cpp
@@ -12,6 +12,7 @@
 #include "openMVG/tracks/union_find.hpp"
 
 #include <utility>
+#include <iterator>
 
 namespace openMVG {
 namespace sfm {

--- a/src/openMVG/sfm/sfm_data_filters_frustum.cpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.cpp
@@ -15,6 +15,9 @@
 
 #include "third_party/progress/progress_display.hpp"
 
+#include <fstream>
+#include <iomanip>
+
 namespace openMVG {
 namespace sfm {
 

--- a/src/openMVG/sfm/sfm_data_filters_frustum.cpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.cpp
@@ -17,6 +17,7 @@
 
 #include <fstream>
 #include <iomanip>
+#include <iterator>
 
 namespace openMVG {
 namespace sfm {

--- a/src/openMVG/sfm/sfm_data_io.cpp
+++ b/src/openMVG/sfm/sfm_data_io.cpp
@@ -70,6 +70,8 @@ bool ValidIds(const SfM_Data & sfm_data, ESfM_Data flags_part)
 
 bool Load(SfM_Data & sfm_data, const std::string & filename, ESfM_Data flags_part)
 {
+  static bool initCameras = openMVG::cameras::IntrinsicBase::registerCameraTypes();
+
   bool bStatus = false;
   const std::string ext = stlplus::extension_part(filename);
   if (ext == "json")

--- a/src/openMVG/sfm/sfm_data_io.cpp
+++ b/src/openMVG/sfm/sfm_data_io.cpp
@@ -15,6 +15,10 @@
 #include "openMVG/types.hpp"
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/portable_binary.hpp>
+#include <cereal/archives/xml.hpp>
+
 namespace openMVG {
 namespace sfm {
 

--- a/src/openMVG/sfm/sfm_data_io_baf.cpp
+++ b/src/openMVG/sfm/sfm_data_io_baf.cpp
@@ -7,9 +7,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-//#include <algorithm>
 #include <fstream>
-//#include <vector>
+#include <iterator>
 
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/sfm/sfm_data_io_baf.hpp"

--- a/src/openMVG/sfm/sfm_data_io_baf.cpp
+++ b/src/openMVG/sfm/sfm_data_io_baf.cpp
@@ -1,0 +1,123 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+//#include <algorithm>
+#include <fstream>
+//#include <vector>
+
+#include "openMVG/sfm/sfm_data.hpp"
+#include "openMVG/sfm/sfm_data_io_baf.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+namespace openMVG {
+namespace sfm {
+
+bool Save_BAF(
+  const SfM_Data & sfm_data,
+  const std::string & filename,
+  ESfM_Data flags_part)
+{
+  std::ofstream stream(filename.c_str());
+  if (!stream.is_open())
+    return false;
+
+  bool bOk = false;
+  {
+    stream
+      << sfm_data.GetIntrinsics().size() << '\n'
+      << sfm_data.GetViews().size() << '\n'
+      << sfm_data.GetLandmarks().size() << '\n';
+
+    const Intrinsics & intrinsics = sfm_data.GetIntrinsics();
+    for (const auto & iterIntrinsic : intrinsics )
+    {
+      //get params
+      const std::vector<double> intrinsicsParams = iterIntrinsic.second->getParams();
+      std::copy(intrinsicsParams.begin(), intrinsicsParams.end(),
+        std::ostream_iterator<double>(stream, " "));
+      stream << '\n';
+    }
+
+    const Poses & poses = sfm_data.GetPoses();
+    for ( const auto & iterV : sfm_data.GetViews() )
+    {
+      const View * view = iterV.second.get();
+      if (!sfm_data.IsPoseAndIntrinsicDefined(view))
+      {
+        const Mat3 R = Mat3::Identity();
+        const double * rotation = R.data();
+        std::copy(rotation, rotation+9, std::ostream_iterator<double>(stream, " "));
+        const Vec3 C = Vec3::Zero();
+        const double * center = C.data();
+        std::copy(center, center+3, std::ostream_iterator<double>(stream, " "));
+        stream << '\n';
+      }
+      else
+      {
+        // [Rotation col major 3x3; camera center 3x1]
+        const double * rotation = poses.at(view->id_pose).rotation().data();
+        std::copy(rotation, rotation+9, std::ostream_iterator<double>(stream, " "));
+        const double * center = poses.at(view->id_pose).center().data();
+        std::copy(center, center+3, std::ostream_iterator<double>(stream, " "));
+        stream << '\n';
+      }
+    }
+
+    const Landmarks & landmarks = sfm_data.GetLandmarks();
+    for (const auto & iterLandmarks : landmarks )
+    {
+      // Export visibility information
+      // X Y Z #observations id_cam id_pose x y ...
+      const double * X = iterLandmarks.second.X.data();
+      std::copy(X, X+3, std::ostream_iterator<double>(stream, " "));
+      const Observations & obs = iterLandmarks.second.obs;
+      stream << obs.size() << " ";
+      for ( const auto & iterOb : obs )
+      {
+        const IndexT id_view = iterOb.first;
+        const View * v = sfm_data.GetViews().at(id_view).get();
+        stream
+          << v->id_intrinsic << ' '
+          << v->id_pose << ' '
+          << iterOb.second.x(0) << ' ' << iterOb.second.x(1) << ' ';
+      }
+      stream << '\n';
+    }
+
+    stream.flush();
+    bOk = stream.good();
+    stream.close();
+  }
+
+  // Export View filenames & ids as an imgList.txt file
+  {
+    const std::string sFile = stlplus::create_filespec(
+      stlplus::folder_part(filename), stlplus::basename_part(filename) + std::string("_imgList"), "txt");
+
+    stream.open(sFile.c_str());
+    if (!stream.is_open())
+      return false;
+    for ( const auto & iterV : sfm_data.GetViews() )
+    {
+      const std::string sView_filename = stlplus::create_filespec(sfm_data.s_root_path,
+        iterV.second->s_Img_path);
+      stream
+        << sView_filename
+        << ' ' << iterV.second->id_intrinsic
+        << ' ' << iterV.second->id_pose << "\n";
+    }
+    stream.flush();
+    bOk = stream.good();
+    stream.close();
+  }
+  return bOk;
+}
+
+} // namespace sfm
+} // namespace openMVG

--- a/src/openMVG/sfm/sfm_data_io_baf.hpp
+++ b/src/openMVG/sfm/sfm_data_io_baf.hpp
@@ -9,10 +9,7 @@
 #ifndef OPENMVG_SFM_SFM_DATA_IO_BAF_HPP
 #define OPENMVG_SFM_SFM_DATA_IO_BAF_HPP
 
-#include <algorithm>
-#include <fstream>
 #include <string>
-#include <vector>
 
 #include "openMVG/sfm/sfm_data_io.hpp"
 
@@ -34,106 +31,10 @@ namespace sfm {
 // The ids allow to establish a link between 3D point observations & the corresponding views
 //--
 // Export missing poses as Identity pose to keep tracking of the original id_pose indexes
-inline bool Save_BAF(
+bool Save_BAF(
   const SfM_Data & sfm_data,
   const std::string & filename,
-  ESfM_Data flags_part)
-{
-  std::ofstream stream(filename.c_str());
-  if (!stream.is_open())
-    return false;
-
-  bool bOk = false;
-  {
-    stream
-      << sfm_data.GetIntrinsics().size() << '\n'
-      << sfm_data.GetViews().size() << '\n'
-      << sfm_data.GetLandmarks().size() << '\n';
-
-    const Intrinsics & intrinsics = sfm_data.GetIntrinsics();
-    for (const auto & iterIntrinsic : intrinsics )
-    {
-      //get params
-      const std::vector<double> intrinsicsParams = iterIntrinsic.second->getParams();
-      std::copy(intrinsicsParams.begin(), intrinsicsParams.end(),
-        std::ostream_iterator<double>(stream, " "));
-      stream << '\n';
-    }
-
-    const Poses & poses = sfm_data.GetPoses();
-    for ( const auto & iterV : sfm_data.GetViews() )
-    {
-      const View * view = iterV.second.get();
-      if (!sfm_data.IsPoseAndIntrinsicDefined(view))
-      {
-        const Mat3 R = Mat3::Identity();
-        const double * rotation = R.data();
-        std::copy(rotation, rotation+9, std::ostream_iterator<double>(stream, " "));
-        const Vec3 C = Vec3::Zero();
-        const double * center = C.data();
-        std::copy(center, center+3, std::ostream_iterator<double>(stream, " "));
-        stream << '\n';
-      }
-      else
-      {
-        // [Rotation col major 3x3; camera center 3x1]
-        const double * rotation = poses.at(view->id_pose).rotation().data();
-        std::copy(rotation, rotation+9, std::ostream_iterator<double>(stream, " "));
-        const double * center = poses.at(view->id_pose).center().data();
-        std::copy(center, center+3, std::ostream_iterator<double>(stream, " "));
-        stream << '\n';
-      }
-    }
-
-    const Landmarks & landmarks = sfm_data.GetLandmarks();
-    for (const auto & iterLandmarks : landmarks )
-    {
-      // Export visibility information
-      // X Y Z #observations id_cam id_pose x y ...
-      const double * X = iterLandmarks.second.X.data();
-      std::copy(X, X+3, std::ostream_iterator<double>(stream, " "));
-      const Observations & obs = iterLandmarks.second.obs;
-      stream << obs.size() << " ";
-      for ( const auto & iterOb : obs )
-      {
-        const IndexT id_view = iterOb.first;
-        const View * v = sfm_data.GetViews().at(id_view).get();
-        stream
-          << v->id_intrinsic << ' '
-          << v->id_pose << ' '
-          << iterOb.second.x(0) << ' ' << iterOb.second.x(1) << ' ';
-      }
-      stream << '\n';
-    }
-
-    stream.flush();
-    bOk = stream.good();
-    stream.close();
-  }
-
-  // Export View filenames & ids as an imgList.txt file
-  {
-    const std::string sFile = stlplus::create_filespec(
-      stlplus::folder_part(filename), stlplus::basename_part(filename) + std::string("_imgList"), "txt");
-
-    stream.open(sFile.c_str());
-    if (!stream.is_open())
-      return false;
-    for ( const auto & iterV : sfm_data.GetViews() )
-    {
-      const std::string sView_filename = stlplus::create_filespec(sfm_data.s_root_path,
-        iterV.second->s_Img_path);
-      stream
-        << sView_filename
-        << ' ' << iterV.second->id_intrinsic
-        << ' ' << iterV.second->id_pose << "\n";
-    }
-    stream.flush();
-    bOk = stream.good();
-    stream.close();
-  }
-  return bOk;
-}
+  ESfM_Data flags_part);
 
 } // namespace sfm
 } // namespace openMVG

--- a/src/openMVG/sfm/sfm_data_io_cereal.cpp
+++ b/src/openMVG/sfm/sfm_data_io_cereal.cpp
@@ -24,6 +24,7 @@
 #include <cereal/types/string.hpp>
 #include <cereal/types/unordered_map.hpp>
 #include <cereal/types/vector.hpp>
+#include <cereal/types/polymorphic.hpp>
 
 namespace openMVG {
 namespace sfm {

--- a/src/openMVG/sfm/sfm_data_io_cereal.cpp
+++ b/src/openMVG/sfm/sfm_data_io_cereal.cpp
@@ -11,6 +11,7 @@
 #include "openMVG/cameras/cameras.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/types.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <fstream>
 #include <string>

--- a/src/openMVG/sfm/sfm_data_triangulation.cpp
+++ b/src/openMVG/sfm/sfm_data_triangulation.cpp
@@ -12,6 +12,7 @@
 
 #include "openMVG/geometry/pose3.hpp"
 #include "openMVG/multiview/triangulation_nview.hpp"
+#include "openMVG/numeric/numeric.h"
 #include "openMVG/robust_estimation/rand_sampling.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/sfm/sfm_landmark.hpp"

--- a/src/openMVG/sfm/sfm_landmark.cpp
+++ b/src/openMVG/sfm/sfm_landmark.cpp
@@ -1,0 +1,131 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre Moulon.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/sfm/sfm_landmark.hpp"
+
+#include <cereal/types/vector.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
+namespace openMVG {
+namespace sfm {
+
+Observation::Observation():id_feat(UndefinedIndexT)
+{ 
+}
+
+Observation::Observation(const Vec2 & p, IndexT idFeat): x(p), id_feat(idFeat) 
+{
+}
+
+// Serialization
+template <class Archive>
+void Observation::save( Archive & ar) const
+{
+  ar(cereal::make_nvp("id_feat", id_feat ));
+  const std::vector<double> pp = { x(0), x(1) };
+  ar(cereal::make_nvp("x", pp));
+}
+
+// Serialization
+template <class Archive>
+void Observation::load( Archive & ar)
+{
+  ar(cereal::make_nvp("id_feat", id_feat ));
+  std::vector<double> p(2);
+  ar(cereal::make_nvp("x", p));
+  x = Eigen::Map<const Vec2>(&p[0]);
+}
+
+template void Observation::load
+<cereal::JSONInputArchive>
+( cereal::JSONInputArchive & ar );
+
+template void Observation::save
+<cereal::JSONOutputArchive>
+(cereal::JSONOutputArchive & ar) const;
+
+template void Observation::load
+<cereal::XMLInputArchive>
+( cereal::XMLInputArchive & ar );
+
+template void Observation::save
+<cereal::XMLOutputArchive>
+(cereal::XMLOutputArchive & ar) const;
+
+template void Observation::load
+<cereal::BinaryInputArchive>
+( cereal::BinaryInputArchive & ar );
+
+template void Observation::save
+<cereal::BinaryOutputArchive>
+(cereal::BinaryOutputArchive & ar) const;
+
+template void Observation::load
+<cereal::PortableBinaryInputArchive>
+(cereal::PortableBinaryInputArchive & ar );
+
+template void Observation::save
+<cereal::PortableBinaryOutputArchive>
+(cereal::PortableBinaryOutputArchive & ar) const;
+
+// Serialization
+template <class Archive>
+void Landmark::save( Archive & ar) const
+{
+  const std::vector<double> point = { X(0), X(1), X(2) };
+  ar(cereal::make_nvp("X", point ));
+  //ar(cereal::make_nvp("observations", obs));
+}
+
+template <class Archive>
+void Landmark::load( Archive & ar)
+{
+  std::vector<double> point(3);
+  ar(cereal::make_nvp("X", point ));
+  X = Eigen::Map<const Vec3>(&point[0]);
+  //ar(cereal::make_nvp("observations", obs));
+}
+
+template void Landmark::load
+<cereal::JSONInputArchive>
+( cereal::JSONInputArchive & ar );
+
+template void Landmark::save
+<cereal::JSONOutputArchive>
+(cereal::JSONOutputArchive & ar) const;
+
+template void Landmark::load
+<cereal::XMLInputArchive>
+( cereal::XMLInputArchive & ar );
+
+template void Landmark::save
+<cereal::XMLOutputArchive>
+(cereal::XMLOutputArchive & ar) const;
+
+template void Landmark::load
+<cereal::BinaryInputArchive>
+( cereal::BinaryInputArchive & ar );
+
+template void Landmark::save
+<cereal::BinaryOutputArchive>
+(cereal::BinaryOutputArchive & ar) const;
+
+template void Landmark::load
+<cereal::PortableBinaryInputArchive>
+(cereal::PortableBinaryInputArchive & ar );
+
+template void Landmark::save
+<cereal::PortableBinaryOutputArchive>
+(cereal::PortableBinaryOutputArchive & ar) const;
+
+} // namespace sfm
+} // namespace openMVG

--- a/src/openMVG/sfm/sfm_landmark.hpp
+++ b/src/openMVG/sfm/sfm_landmark.hpp
@@ -9,11 +9,8 @@
 #ifndef OPENMVG_SFM_SFM_LANDMARK_HPP
 #define OPENMVG_SFM_SFM_LANDMARK_HPP
 
-#include <vector>
-
 #include "openMVG/types.hpp"
-
-#include <cereal/cereal.hpp> // Serialization
+#include "openMVG/numeric/eigen_alias_definition.hpp"
 
 namespace openMVG {
 namespace sfm {
@@ -21,31 +18,21 @@ namespace sfm {
 /// Define 3D-2D tracking data: 3D landmark with it's 2D observations
 struct Observation
 {
-  Observation():id_feat(UndefinedIndexT) {  }
-  Observation(const Vec2 & p, IndexT idFeat): x(p), id_feat(idFeat) {}
+  Observation();
+  Observation(const Vec2 & p, IndexT idFeat);
 
   Vec2 x;
   IndexT id_feat;
 
   // Serialization
   template <class Archive>
-  void save( Archive & ar) const
-  {
-    ar(cereal::make_nvp("id_feat", id_feat ));
-    const std::vector<double> pp = { x(0), x(1) };
-    ar(cereal::make_nvp("x", pp));
-  }
+  void save( Archive & ar) const;
 
   // Serialization
   template <class Archive>
-  void load( Archive & ar)
-  {
-    ar(cereal::make_nvp("id_feat", id_feat ));
-    std::vector<double> p(2);
-    ar(cereal::make_nvp("x", p));
-    x = Eigen::Map<const Vec2>(&p[0]);
-  }
+  void load( Archive & ar);
 };
+
 /// Observations are indexed by their View_id
 using Observations = Hash_Map<IndexT, Observation>;
 
@@ -57,21 +44,10 @@ struct Landmark
 
   // Serialization
   template <class Archive>
-  void save( Archive & ar) const
-  {
-    const std::vector<double> point = { X(0), X(1), X(2) };
-    ar(cereal::make_nvp("X", point ));
-    ar(cereal::make_nvp("observations", obs));
-  }
+  void save( Archive & ar) const;
 
   template <class Archive>
-  void load( Archive & ar)
-  {
-    std::vector<double> point(3);
-    ar(cereal::make_nvp("X", point ));
-    X = Eigen::Map<const Vec3>(&point[0]);
-    ar(cereal::make_nvp("observations", obs));
-  }
+  void load( Archive & ar);
 };
 
 /// Define a collection of landmarks are indexed by their TrackId

--- a/src/openMVG/sfm/sfm_report.hpp
+++ b/src/openMVG/sfm/sfm_report.hpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "openMVG/numeric/numeric.h"
 #include "openMVG/sfm/sfm_data.hpp"
 
 #include "third_party/histogram/histogram.hpp"

--- a/src/openMVG/sfm/sfm_view.cpp
+++ b/src/openMVG/sfm/sfm_view.cpp
@@ -1,0 +1,101 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre Moulon.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/sfm/sfm_view.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
+namespace openMVG {
+namespace sfm {
+
+View::View(
+  const std::string & sImgPath,
+  IndexT view_id,
+  IndexT intrinsic_id,
+  IndexT pose_id,
+  IndexT width, 
+  IndexT height)
+  : s_Img_path(sImgPath)
+  , id_view(view_id)
+  , id_intrinsic(intrinsic_id)
+  , id_pose(pose_id)
+  , ui_width(width)
+  , ui_height(height)
+  {
+  }
+
+template <class Archive>
+void View::save( Archive & ar ) const
+{
+  ar(cereal::make_nvp("local_path", stlplus::folder_part(s_Img_path)),
+     cereal::make_nvp("filename", stlplus::filename_part(s_Img_path)),
+     cereal::make_nvp("width", ui_width),
+     cereal::make_nvp("height", ui_height),
+     cereal::make_nvp("id_view", id_view),
+     cereal::make_nvp("id_intrinsic", id_intrinsic),
+     cereal::make_nvp("id_pose", id_pose));
+}
+
+template <class Archive>
+void View::load( Archive & ar )
+{
+  //Define a view with two string (base_path & basename)
+  std::string local_path = s_Img_path;
+  std::string filename = s_Img_path;
+
+  ar(cereal::make_nvp("local_path", local_path),
+     cereal::make_nvp("filename", filename),
+     cereal::make_nvp("width", ui_width),
+     cereal::make_nvp("height", ui_height),
+     cereal::make_nvp("id_view", id_view),
+     cereal::make_nvp("id_intrinsic", id_intrinsic),
+     cereal::make_nvp("id_pose", id_pose));
+
+  s_Img_path = stlplus::create_filespec(local_path, filename);
+}
+
+template void View::load
+<cereal::JSONInputArchive>
+( cereal::JSONInputArchive & ar );
+
+template void View::save
+<cereal::JSONOutputArchive>
+(cereal::JSONOutputArchive & ar) const;
+
+template void View::load
+<cereal::XMLInputArchive>
+( cereal::XMLInputArchive & ar );
+
+template void View::save
+<cereal::XMLOutputArchive>
+(cereal::XMLOutputArchive & ar) const;
+
+template void View::load
+<cereal::BinaryInputArchive>
+( cereal::BinaryInputArchive & ar );
+
+template void View::save
+<cereal::BinaryOutputArchive>
+(cereal::BinaryOutputArchive & ar) const;
+
+template void View::load
+<cereal::PortableBinaryInputArchive>
+( cereal::PortableBinaryInputArchive & ar );
+
+template void View::save
+<cereal::PortableBinaryOutputArchive>
+(cereal::PortableBinaryOutputArchive & ar) const;
+
+
+} // namespace sfm
+} // namespace openMVG

--- a/src/openMVG/sfm/sfm_view.hpp
+++ b/src/openMVG/sfm/sfm_view.hpp
@@ -10,15 +10,9 @@
 #define OPENMVG_SFM_SFM_VIEW_HPP
 
 #include <string>
+#include <memory>
 
 #include "openMVG/types.hpp"
-
-#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
-
-#include <cereal/archives/json.hpp>
-#include <cereal/archives/portable_binary.hpp>
-#include <cereal/archives/xml.hpp>
-#include <cereal/types/polymorphic.hpp>
 
 namespace openMVG {
 namespace sfm {
@@ -44,10 +38,7 @@ struct View
     IndexT view_id = UndefinedIndexT,
     IndexT intrinsic_id = UndefinedIndexT,
     IndexT pose_id = UndefinedIndexT,
-    IndexT width = UndefinedIndexT, IndexT height = UndefinedIndexT)
-    :s_Img_path(sImgPath), id_view(view_id), id_intrinsic(intrinsic_id),
-    id_pose(pose_id), ui_width(width), ui_height(height)
-    {}
+    IndexT width = UndefinedIndexT, IndexT height = UndefinedIndexT);
 
   virtual ~View() = default;
 
@@ -56,38 +47,14 @@ struct View
   * @param ar Archive
   */
   template <class Archive>
-  void save( Archive & ar ) const
-  {
-    ar(cereal::make_nvp("local_path", stlplus::folder_part(s_Img_path)),
-       cereal::make_nvp("filename", stlplus::filename_part(s_Img_path)),
-       cereal::make_nvp("width", ui_width),
-       cereal::make_nvp("height", ui_height),
-       cereal::make_nvp("id_view", id_view),
-       cereal::make_nvp("id_intrinsic", id_intrinsic),
-       cereal::make_nvp("id_pose", id_pose));
-  }
+  void save( Archive & ar ) const;
 
   /**
   * @brief Serialization in
   * @param ar Archive
   */
   template <class Archive>
-  void load( Archive & ar )
-  {
-    //Define a view with two string (base_path & basename)
-    std::string local_path = s_Img_path;
-    std::string filename = s_Img_path;
-
-    ar(cereal::make_nvp("local_path", local_path),
-       cereal::make_nvp("filename", filename),
-       cereal::make_nvp("width", ui_width),
-       cereal::make_nvp("height", ui_height),
-       cereal::make_nvp("id_view", id_view),
-       cereal::make_nvp("id_intrinsic", id_intrinsic),
-       cereal::make_nvp("id_pose", id_pose));
-
-    s_Img_path = stlplus::create_filespec(local_path, filename);
-  }
+  void load( Archive & ar );
 };
 
 /// Define a collection of View

--- a/src/openMVG/sfm/sfm_view_priors.cpp
+++ b/src/openMVG/sfm/sfm_view_priors.cpp
@@ -1,0 +1,140 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2016 Pierre Moulon.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/sfm/sfm_view_priors.hpp"
+
+#include <cereal/types/polymorphic.hpp>
+
+namespace openMVG {
+namespace sfm {
+
+ViewPriors::ViewPriors
+(
+  const std::string & sImgPath,
+  IndexT view_id,
+  IndexT intrinsic_id,
+  IndexT pose_id,
+  IndexT width,
+  IndexT height
+)
+: View
+  (
+    sImgPath,
+    view_id,
+    intrinsic_id,
+    pose_id,
+    width,
+    height
+  ),
+  b_use_pose_center_(false),
+  b_use_pose_rotation_(false)
+{
+}
+
+void ViewPriors::SetPoseCenterPrior
+(
+  const Vec3 & center,
+  const Vec3 & weight
+)
+{
+  b_use_pose_center_  = true;
+  center_weight_      = weight;
+  pose_center_        = center;
+}
+
+void ViewPriors::SetPoseRotationPrior
+(
+  const Mat3 & rotation,
+  const double weight
+)
+{
+  rotation_weight_ = weight;
+  pose_rotation_   = rotation;
+}
+
+template <class Archive>
+void ViewPriors::save( Archive & ar ) const
+{
+  View::save(ar);
+
+  // Pose center prior
+  if (b_use_pose_center_)
+  {
+    ar( cereal::make_nvp( "use_pose_center_prior", b_use_pose_center_ ) );
+    const std::vector<double> vec_weights = { center_weight_( 0 ), center_weight_( 1 ), center_weight_( 2 ) };
+    ar( cereal::make_nvp( "center_weight", vec_weights ) );
+    const std::vector<double> vec = { pose_center_( 0 ), pose_center_( 1 ), pose_center_( 2 ) };
+    ar( cereal::make_nvp( "center", vec ) );
+  }
+
+  // Pose rotation prior
+  /*
+  if (b_use_pose_rotation_)
+  {
+    ar( cereal::make_nvp( "use_pose_rotation_prior", b_use_pose_rotation_ ) );
+    ar( cereal::make_nvp( "rotation_weight", rotation_weight_ ) );
+    const std::vector<std::vector<double>> mat =
+    {
+      { pose_rotation_( 0, 0 ), pose_rotation_( 0, 1 ), pose_rotation_( 0, 2 ) },
+      { pose_rotation_( 1, 0 ), pose_rotation_( 1, 1 ), pose_rotation_( 1, 2 ) },
+      { pose_rotation_( 2, 0 ), pose_rotation_( 2, 1 ), pose_rotation_( 2, 2 ) }
+    };
+    ar( cereal::make_nvp( "rotation", mat ) );
+  }
+  */
+}
+
+template <class Archive>
+void ViewPriors::load( Archive & ar )
+{
+  View::load(ar);
+
+  // Pose center prior
+  try
+  {
+    ar( cereal::make_nvp( "use_pose_center_prior", b_use_pose_center_ ) );
+    std::vector<double> vec( 3 );
+    ar( cereal::make_nvp( "center_weight", vec ) );
+    center_weight_ = Eigen::Map<const Vec3>( &vec[0] );
+    ar( cereal::make_nvp( "center", vec ) );
+    pose_center_ = Eigen::Map<const Vec3>( &vec[0] );
+  }
+  catch( cereal::Exception e )
+  {
+    // if it fails just use a default settings
+    b_use_pose_center_ = false;
+  }
+
+  // Pose rotation prior
+  /*
+  try
+  {
+    ar( cereal::make_nvp( "use_pose_rotation_prior", b_use_pose_rotation_ ) );
+    ar( cereal::make_nvp( "rotation_weight", rotation_weight_ ) );
+    std::vector<std::vector<double>> mat( 3, std::vector<double>( 3 ) );
+    ar( cereal::make_nvp( "rotation", mat ) );
+    // copy back to the rotation
+    pose_rotation_.row( 0 ) = Eigen::Map<const Vec3>( &( mat[0][0] ) );
+    pose_rotation_.row( 1 ) = Eigen::Map<const Vec3>( &( mat[1][0] ) );
+    pose_rotation_.row( 2 ) = Eigen::Map<const Vec3>( &( mat[2][0] ) );
+  }
+  catch( const cereal::Exception & e )
+  {
+    // if it fails just use a default settings
+    b_use_pose_rotation_ = false;
+  }
+  */
+}
+
+} // namespace sfm
+} // namespace openMVG
+
+#include <cereal/types/vector.hpp>
+
+CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::sfm::ViewPriors, "view_priors" );
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::sfm::View, openMVG::sfm::ViewPriors);

--- a/src/openMVG/sfm/sfm_view_priors.hpp
+++ b/src/openMVG/sfm/sfm_view_priors.hpp
@@ -9,17 +9,11 @@
 #ifndef OPENMVG_SFM_SFM_VIEW_PRIORS_HPP
 #define OPENMVG_SFM_SFM_VIEW_PRIORS_HPP
 
-#include <string>
-#include <vector>
-
+#include "openMVG/sfm/sfm_view.hpp"
 #include "openMVG/geometry/pose3.hpp"
-
-#include <cereal/types/polymorphic.hpp>
 
 namespace openMVG {
 namespace sfm {
-
-struct View;
 
 using namespace openMVG::geometry;
 
@@ -36,20 +30,7 @@ struct ViewPriors : public View
     IndexT pose_id = UndefinedIndexT,
     IndexT width = UndefinedIndexT,
     IndexT height = UndefinedIndexT
-  )
-  : View
-    (
-      sImgPath,
-      view_id,
-      intrinsic_id,
-      pose_id,
-      width,
-      height
-    ),
-    b_use_pose_center_(false),
-    b_use_pose_rotation_(false)
-  {
-  }
+  );
 
   ~ViewPriors() override = default;
 
@@ -57,104 +38,27 @@ struct ViewPriors : public View
   (
     const Vec3 & center,
     const Vec3 & weight
-  )
-  {
-    b_use_pose_center_  = true;
-    center_weight_      = weight;
-    pose_center_        = center;
-  }
+  );
 
   void SetPoseRotationPrior
   (
     const Mat3 & rotation,
     const double weight
-  )
-  {
-    rotation_weight_ = weight;
-    pose_rotation_   = rotation;
-  }
+  );
 
   /**
   * Serialization out
   * @param ar Archive
   */
   template <class Archive>
-  void save( Archive & ar ) const
-  {
-    View::save(ar);
-
-    // Pose center prior
-    if (b_use_pose_center_)
-    {
-      ar( cereal::make_nvp( "use_pose_center_prior", b_use_pose_center_ ) );
-      const std::vector<double> vec_weights = { center_weight_( 0 ), center_weight_( 1 ), center_weight_( 2 ) };
-      ar( cereal::make_nvp( "center_weight", vec_weights ) );
-      const std::vector<double> vec = { pose_center_( 0 ), pose_center_( 1 ), pose_center_( 2 ) };
-      ar( cereal::make_nvp( "center", vec ) );
-    }
-
-    // Pose rotation prior
-    /*
-    if (b_use_pose_rotation_)
-    {
-      ar( cereal::make_nvp( "use_pose_rotation_prior", b_use_pose_rotation_ ) );
-      ar( cereal::make_nvp( "rotation_weight", rotation_weight_ ) );
-      const std::vector<std::vector<double>> mat =
-      {
-        { pose_rotation_( 0, 0 ), pose_rotation_( 0, 1 ), pose_rotation_( 0, 2 ) },
-        { pose_rotation_( 1, 0 ), pose_rotation_( 1, 1 ), pose_rotation_( 1, 2 ) },
-        { pose_rotation_( 2, 0 ), pose_rotation_( 2, 1 ), pose_rotation_( 2, 2 ) }
-      };
-      ar( cereal::make_nvp( "rotation", mat ) );
-    }
-    */
-  }
+  void save( Archive & ar ) const;
 
   /**
   * @brief Serialization in
   * @param ar Archive
   */
   template <class Archive>
-  void load( Archive & ar )
-  {
-    View::load(ar);
-
-    // Pose center prior
-    try
-    {
-      ar( cereal::make_nvp( "use_pose_center_prior", b_use_pose_center_ ) );
-      std::vector<double> vec( 3 );
-      ar( cereal::make_nvp( "center_weight", vec ) );
-      center_weight_ = Eigen::Map<const Vec3>( &vec[0] );
-      ar( cereal::make_nvp( "center", vec ) );
-      pose_center_ = Eigen::Map<const Vec3>( &vec[0] );
-    }
-    catch( cereal::Exception e )
-    {
-      // if it fails just use a default settings
-      b_use_pose_center_ = false;
-    }
-
-    // Pose rotation prior
-    /*
-    try
-    {
-      ar( cereal::make_nvp( "use_pose_rotation_prior", b_use_pose_rotation_ ) );
-      ar( cereal::make_nvp( "rotation_weight", rotation_weight_ ) );
-      std::vector<std::vector<double>> mat( 3, std::vector<double>( 3 ) );
-      ar( cereal::make_nvp( "rotation", mat ) );
-      // copy back to the rotation
-      pose_rotation_.row( 0 ) = Eigen::Map<const Vec3>( &( mat[0][0] ) );
-      pose_rotation_.row( 1 ) = Eigen::Map<const Vec3>( &( mat[1][0] ) );
-      pose_rotation_.row( 2 ) = Eigen::Map<const Vec3>( &( mat[2][0] ) );
-    }
-    catch( const cereal::Exception & e )
-    {
-      // if it fails just use a default settings
-      b_use_pose_rotation_ = false;
-    }
-    */
-  }
+  void load( Archive & ar );
 
   // Pose center prior
   bool b_use_pose_center_ = false; // Tell if the pose prior must be used
@@ -169,10 +73,5 @@ struct ViewPriors : public View
 
 } // namespace sfm
 } // namespace openMVG
-
-#include <cereal/types/vector.hpp>
-
-CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::sfm::ViewPriors, "view_priors" );
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::sfm::View, openMVG::sfm::ViewPriors);
 
 #endif // OPENMVG_SFM_SFM_VIEW_PRIORS_HPP

--- a/src/openMVG_Samples/cameras_undisto_Brown/CMakeLists.txt
+++ b/src/openMVG_Samples/cameras_undisto_Brown/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 add_executable(openMVG_sample_cameras_undistoBrown undistoBrown.cpp)
 target_link_libraries(openMVG_sample_cameras_undistoBrown
+  openMVG_geometry
   openMVG_image
   openMVG_multiview
   stlplus

--- a/src/openMVG_Samples/cameras_undisto_Brown/CMakeLists.txt
+++ b/src/openMVG_Samples/cameras_undisto_Brown/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_executable(openMVG_sample_cameras_undistoBrown undistoBrown.cpp)
 target_link_libraries(openMVG_sample_cameras_undistoBrown
-  openMVG_geometry
+  openMVG_cameras
   openMVG_image
   openMVG_multiview
   stlplus

--- a/src/openMVG_Samples/features_kvld_filter/kvld_filter.cpp
+++ b/src/openMVG_Samples/features_kvld_filter/kvld_filter.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "openMVG/features/svg_features.hpp"
+#include "openMVG/features/regions_factory.hpp"
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/image/image_concat.hpp"
 #include "openMVG/matching/kvld/kvld.h"

--- a/src/openMVG_Samples/features_siftPutativeMatches/siftmatch.cpp
+++ b/src/openMVG_Samples/features_siftPutativeMatches/siftmatch.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "openMVG/features/feature.hpp"
+#include "openMVG/features/regions_factory.hpp"
 #include "openMVG/features/svg_features.hpp"
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/image/image_concat.hpp"

--- a/src/openMVG_Samples/image_undistort_gui/CMakeLists.txt
+++ b/src/openMVG_Samples/image_undistort_gui/CMakeLists.txt
@@ -10,7 +10,7 @@ if( Qt5Widgets_FOUND )
   set( OPENMVG_SAMPLE_IMAGE_UNDISTORT_HDRS MainWindow.hh QImageInterface.hh )
 
   add_executable( openMVG_sample_image_undistort ${OPENMVG_SAMPLE_IMAGE_UNDISTORT_SRCS} ${OPENMVG_SAMPLE_IMAGE_UNDISTORT_HDRS})
-  target_link_libraries( openMVG_sample_image_undistort Qt5::Widgets openMVG_image openMVG_multiview )
+  target_link_libraries( openMVG_sample_image_undistort Qt5::Widgets openMVG_image openMVG_multiview openMVG_geometry )
 
-   set_property(TARGET openMVG_sample_image_undistort PROPERTY CXX_STANDARD 11)
+  set_property(TARGET openMVG_sample_image_undistort PROPERTY CXX_STANDARD 11)
 endif( Qt5Widgets_FOUND)

--- a/src/openMVG_Samples/image_undistort_gui/CMakeLists.txt
+++ b/src/openMVG_Samples/image_undistort_gui/CMakeLists.txt
@@ -10,7 +10,7 @@ if( Qt5Widgets_FOUND )
   set( OPENMVG_SAMPLE_IMAGE_UNDISTORT_HDRS MainWindow.hh QImageInterface.hh )
 
   add_executable( openMVG_sample_image_undistort ${OPENMVG_SAMPLE_IMAGE_UNDISTORT_SRCS} ${OPENMVG_SAMPLE_IMAGE_UNDISTORT_HDRS})
-  target_link_libraries( openMVG_sample_image_undistort Qt5::Widgets openMVG_image openMVG_multiview openMVG_geometry )
+  target_link_libraries( openMVG_sample_image_undistort Qt5::Widgets openMVG_image openMVG_multiview openMVG_cameras openMVG_image)
 
   set_property(TARGET openMVG_sample_image_undistort PROPERTY CXX_STANDARD 11)
 endif( Qt5Widgets_FOUND)

--- a/src/openMVG_Samples/multiview_robust_essential/CMakeLists.txt
+++ b/src/openMVG_Samples/multiview_robust_essential/CMakeLists.txt
@@ -7,6 +7,7 @@ target_link_libraries(openMVG_sample_multiview_robustEssential
   openMVG_multiview
   openMVG_system
   openMVG_features
+  openMVG_geometry
   openMVG_matching
   openMVG_sfm
   vlsift)

--- a/src/openMVG_Samples/multiview_robust_essential/robust_essential.cpp
+++ b/src/openMVG_Samples/multiview_robust_essential/robust_essential.cpp
@@ -8,6 +8,7 @@
 
 #include "openMVG/cameras/Camera_Pinhole.hpp"
 #include "openMVG/features/feature.hpp"
+#include "openMVG/features/regions_factory.hpp"
 #include "openMVG/features/svg_features.hpp"
 #include "openMVG/geometry/pose3.hpp"
 #include "openMVG/image/image_io.hpp"

--- a/src/openMVG_Samples/multiview_robust_essential_ba/robust_essential_ba.cpp
+++ b/src/openMVG_Samples/multiview_robust_essential_ba/robust_essential_ba.cpp
@@ -9,6 +9,7 @@
 #include "openMVG/cameras/Camera_Pinhole.hpp"
 #include "openMVG/cameras/Camera_Pinhole_Radial.hpp"
 #include "openMVG/features/feature.hpp"
+#include "openMVG/features/regions_factory.hpp"
 #include "openMVG/features/svg_features.hpp"
 #include "openMVG/geometry/pose3.hpp"
 #include "openMVG/image/image_io.hpp"

--- a/src/openMVG_Samples/multiview_robust_essential_spherical/robust_essential_spherical.cpp
+++ b/src/openMVG_Samples/multiview_robust_essential_spherical/robust_essential_spherical.cpp
@@ -9,6 +9,7 @@
 
 #include "openMVG/cameras/Camera_Spherical.hpp"
 #include "openMVG/features/feature.hpp"
+#include "openMVG/features/regions_factory.hpp"
 #include "openMVG/features/svg_features.hpp"
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/image/image_concat.hpp"

--- a/src/openMVG_Samples/multiview_robust_estimation_tutorial/robust_estimation_tutorial_homography.cpp
+++ b/src/openMVG_Samples/multiview_robust_estimation_tutorial/robust_estimation_tutorial_homography.cpp
@@ -9,6 +9,7 @@
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/image/image_concat.hpp"
 #include "openMVG/features/feature.hpp"
+#include "openMVG/features/regions_factory.hpp"
 #include "openMVG/features/svg_features.hpp"
 #include "openMVG/matching/regions_matcher.hpp"
 #include "openMVG/matching/svg_matches.hpp"

--- a/src/openMVG_Samples/multiview_robust_fundamental/robust_fundamental.cpp
+++ b/src/openMVG_Samples/multiview_robust_fundamental/robust_fundamental.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "openMVG/features/svg_features.hpp"
+#include "openMVG/features/regions_factory.hpp"
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/image/image_concat.hpp"
 #include "openMVG/matching/regions_matcher.hpp"

--- a/src/openMVG_Samples/multiview_robust_fundamental_guided/robust_fundamental_guided.cpp
+++ b/src/openMVG_Samples/multiview_robust_fundamental_guided/robust_fundamental_guided.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "openMVG/features/feature.hpp"
+#include "openMVG/features/regions_factory.hpp"
 #include "openMVG/features/svg_features.hpp"
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/image/image_concat.hpp"

--- a/src/openMVG_Samples/multiview_robust_homography/robust_homography.cpp
+++ b/src/openMVG_Samples/multiview_robust_homography/robust_homography.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "openMVG/features/feature.hpp"
+#include "openMVG/features/regions_factory.hpp"
 #include "openMVG/features/svg_features.hpp"
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/image/image_concat.hpp"

--- a/src/openMVG_Samples/multiview_robust_homography_guided/robust_homography_guided.cpp
+++ b/src/openMVG_Samples/multiview_robust_homography_guided/robust_homography_guided.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "openMVG/features/feature.hpp"
+#include "openMVG/features/regions_factory.hpp"
 #include "openMVG/features/svg_features.hpp"
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/image/image_concat.hpp"

--- a/src/software/Geodesy/registration_to_exif_gps_position.cpp
+++ b/src/software/Geodesy/registration_to_exif_gps_position.cpp
@@ -8,6 +8,7 @@
 
 #include "openMVG/geometry/Similarity3.hpp"
 #include "openMVG/geometry/Similarity3_Kernel.hpp"
+#include "openMVG/geometry/rigid_transformation3D_srt.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/sfm/sfm_data_io.hpp"
 #include "openMVG/sfm/sfm_data_transform.hpp"

--- a/src/software/Localization/main_SfM_Localization.cpp
+++ b/src/software/Localization/main_SfM_Localization.cpp
@@ -22,6 +22,8 @@ using namespace openMVG::sfm;
 #include "third_party/cmdLine/cmdLine.h"
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
+#include <cereal/archives/json.hpp>
+
 #include <cstdlib>
 
 // Naive function for finding the biggest common root dir from two paths

--- a/src/software/Localization/main_SfM_Localization.cpp
+++ b/src/software/Localization/main_SfM_Localization.cpp
@@ -10,6 +10,7 @@
 #include <openMVG/features/feature.hpp>
 #include <openMVG/features/io_regions_type.hpp>
 #include <openMVG/image/image_io.hpp>
+#include <openMVG/multiview/projection.hpp>
 #include <software/SfM/SfMPlyHelper.hpp>
 
 #include <openMVG/system/timer.hpp>
@@ -23,6 +24,7 @@ using namespace openMVG::sfm;
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <cereal/archives/json.hpp>
+#include <cereal/types/polymorphic.hpp>
 
 #include <cstdlib>
 

--- a/src/software/SfM/main_ComputeFeatures.cpp
+++ b/src/software/SfM/main_ComputeFeatures.cpp
@@ -20,6 +20,7 @@
 
 #include "nonFree/sift/SIFT_describer.hpp"
 
+#include <cereal/types/polymorphic.hpp>
 #include <cereal/archives/json.hpp>
 #include <cereal/details/helpers.hpp>
 

--- a/src/software/SfM/main_ExportUndistortedImages.cpp
+++ b/src/software/SfM/main_ExportUndistortedImages.cpp
@@ -14,6 +14,7 @@
 
 #include "third_party/cmdLine/cmdLine.h"
 #include "third_party/progress/progress_display.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <cstdlib>
 #include <string>

--- a/src/software/SfM/main_exportKeypoints.cpp
+++ b/src/software/SfM/main_exportKeypoints.cpp
@@ -24,7 +24,6 @@
 #include <string>
 
 using namespace openMVG;
-using namespace openMVG::matching;
 using namespace openMVG::sfm;
 
 int main(int argc, char ** argv)

--- a/src/software/SfM/main_openMVG2CMPMVS.cpp
+++ b/src/software/SfM/main_openMVG2CMPMVS.cpp
@@ -19,6 +19,7 @@ using namespace openMVG::sfm;
 
 #include "third_party/cmdLine/cmdLine.h"
 #include "third_party/progress/progress_display.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <cstdlib>
 #include <cmath>

--- a/src/software/SfM/main_openMVG2MESHLAB.cpp
+++ b/src/software/SfM/main_openMVG2MESHLAB.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "openMVG/image/image_io.hpp"
+#include "openMVG/multiview/projection.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/sfm/sfm_data_io.hpp"
 

--- a/src/software/SfMWebGLViewer/openMVG_main_openMVG2WebGL.cpp
+++ b/src/software/SfMWebGLViewer/openMVG_main_openMVG2WebGL.cpp
@@ -20,6 +20,7 @@
 #include "third_party/progress/progress_display.hpp"
 
 #include <iostream>
+#include <fstream>
 
 using namespace openMVG;
 using namespace openMVG::sfm;

--- a/src/software/SfMWebGLViewer/openMVG_main_openMVG2WebGL.cpp
+++ b/src/software/SfMWebGLViewer/openMVG_main_openMVG2WebGL.cpp
@@ -21,6 +21,7 @@
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <iostream>
+#include <iterator>
 #include <fstream>
 
 using namespace openMVG;

--- a/src/software/SfMWebGLViewer/openMVG_main_openMVG2WebGL.cpp
+++ b/src/software/SfMWebGLViewer/openMVG_main_openMVG2WebGL.cpp
@@ -18,6 +18,7 @@
 
 #include "third_party/cmdLine/cmdLine.h"
 #include "third_party/progress/progress_display.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <iostream>
 #include <fstream>

--- a/src/software/VO/Monocular_VO.hpp
+++ b/src/software/VO/Monocular_VO.hpp
@@ -11,6 +11,7 @@
 
 #include <deque>
 #include <set>
+#include <numeric>
 
 #include "openMVG/features/feature.hpp"
 #include "openMVG/image/image_container.hpp"

--- a/src/software/ui/SfM/control_points_registration/document.hpp
+++ b/src/software/ui/SfM/control_points_registration/document.hpp
@@ -12,8 +12,6 @@
 #include "openMVG/sfm/sfm_data_io.hpp"
 
 #include <fstream>
-#include <cereal/archives/json.hpp>
-#include <cereal/types/map.hpp>
 
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 

--- a/src/software/ui/SfM/control_points_registration/mainLayout.cpp
+++ b/src/software/ui/SfM/control_points_registration/mainLayout.cpp
@@ -10,6 +10,7 @@
 #include <QtGui>
 #include <QDebug>
 
+#include <iostream>
 #include <algorithm>
 #include <clocale>
 


### PR DESCRIPTION
This PR tries to move as much code as possible away from header files. It specifically removes all references to cereal from public includes. Here are some results:
- Travis build time for all tests, samples and exes has gone from [1h44](https://travis-ci.org/bjornpiltz/openMVG/builds/228716984) to [53m](https://travis-ci.org/bjornpiltz/openMVG/builds/229157648).
- The real elapsed time went from 46 min to 20 min

More importantly the usability of openMVG has gone up. Before, a file containing the line `#include <openMVG/sfm/sfm.hpp>` took 29 s to compile. This is now down to 2.5 seconds.

Some of the main_*.cpp compiles significantly faster. Here are some examples:
![image](https://cloud.githubusercontent.com/assets/1873764/25751766/5f313a6e-31b6-11e7-849b-49080a9377ba.png)

