### PR TITLE
Forward declare cereal(speedup compilation)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,13 +65,13 @@ before_script:
       -DCMAKE_CXX_COMPILER=$COMPILER \
       -DCMAKE_BUILD_TYPE=release \
       -DOpenMVG_BUILD_TESTS=ON \
-      -DOpenMVG_BUILD_EXAMPLES=OFF \
-      -DOpenMVG_BUILD_SOFTWARES=OFF \
+      -DOpenMVG_BUILD_EXAMPLES=ON \
+      -DOpenMVG_BUILD_SOFTWARES=ON \
       -DSCHUR_SPECIALIZATIONS=OFF \
       . $OPENMVG_SOURCE
 
 script:
 # limit GCC builds to a reduced number of thread for the virtual machine
-  - make -j 2
+  - time make all -j 2
   - make test
 

--- a/src/nonFree/sift/SIFT_describer.hpp
+++ b/src/nonFree/sift/SIFT_describer.hpp
@@ -66,16 +66,7 @@ public:
       _root_sift(root_sift) {}
 
     template<class Archive>
-    void serialize( Archive & ar )
-    {
-      ar(
-        cereal::make_nvp("first_octave", _first_octave),
-        cereal::make_nvp("num_octaves",_num_octaves),
-        cereal::make_nvp("num_scales",_num_scales),
-        cereal::make_nvp("edge_threshold",_edge_threshold),
-        cereal::make_nvp("peak_threshold",_peak_threshold),
-        cereal::make_nvp("root_sift",_root_sift));
-    }
+    inline void serialize( Archive & ar );
 
     // Parameters
     int _first_octave;      // Use original image, or perform an upscale if == -1
@@ -221,12 +212,7 @@ public:
   }
 
   template<class Archive>
-  void serialize( Archive & ar )
-  {
-    ar(
-     cereal::make_nvp("params", _params),
-     cereal::make_nvp("bOrientation", _bOrientation));
-  }
+  inline void serialize( Archive & ar );
 
 private:
   Params _params;
@@ -235,10 +221,5 @@ private:
 
 } // namespace features
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/archives/json.hpp>
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Image_describer, "SIFT_Image_describer");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::SIFT_Image_describer)
 
 #endif // OPENMVG_PATENTED_SIFT_SIFT_DESCRIBER_HPP

--- a/src/nonFree/sift/SIFT_describer_io.hpp
+++ b/src/nonFree/sift/SIFT_describer_io.hpp
@@ -1,0 +1,39 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_PATENTED_SIFT_SIFT_DESCRIBER_IO_HPP
+#define OPENMVG_PATENTED_SIFT_SIFT_DESCRIBER_IO_HPP
+
+#include "nonFree/sift/SIFT_describer.hpp"
+
+#include <cereal/types/polymorphic.hpp>
+
+template<class Archive>
+void openMVG::features::SIFT_Image_describer::Params::serialize( Archive & ar )
+{
+  ar(
+    cereal::make_nvp("first_octave", _first_octave),
+    cereal::make_nvp("num_octaves",_num_octaves),
+    cereal::make_nvp("num_scales",_num_scales),
+    cereal::make_nvp("edge_threshold",_edge_threshold),
+    cereal::make_nvp("peak_threshold",_peak_threshold),
+    cereal::make_nvp("root_sift",_root_sift));
+}
+
+template<class Archive>
+void openMVG::features::SIFT_Image_describer::serialize( Archive & ar )
+{
+  ar(
+   cereal::make_nvp("params", _params),
+   cereal::make_nvp("bOrientation", _bOrientation));
+}
+
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Image_describer, "SIFT_Image_describer");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::SIFT_Image_describer)
+
+#endif // OPENMVG_PATENTED_SIFT_SIFT_DESCRIBER_IO_HPP

--- a/src/openMVG/cameras/Camera_IO_test.cpp
+++ b/src/openMVG/cameras/Camera_IO_test.cpp
@@ -6,11 +6,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "openMVG/cameras/Camera_IO.hpp"
-
-#include "openMVG/cameras/cameras.hpp"
+// The <cereal/archives> headers are special and must be included first.
 #include <cereal/archives/json.hpp>
-#include <cereal/cereal.hpp>
+
+#include "openMVG/cameras/Camera_IO.hpp"
+#include "openMVG/cameras/cameras_io.hpp"
 
 using namespace openMVG;
 using namespace openMVG::cameras;

--- a/src/openMVG/cameras/Camera_Intrinsics.hpp
+++ b/src/openMVG/cameras/Camera_Intrinsics.hpp
@@ -16,8 +16,6 @@
 #include "openMVG/numeric/numeric.h"
 #include "openMVG/stl/hash.hpp"
 
-#include <cereal/types/polymorphic.hpp>
-
 namespace openMVG
 {
 namespace cameras
@@ -217,28 +215,21 @@ struct IntrinsicBase : public Clonable<IntrinsicBase>
   * @return Concatenation of intrinsic matrix and extrinsic matrix
   */
   virtual Mat34 get_projective_equivalent( const geometry::Pose3 & pose ) const = 0;
-
+  
   /**
   * @brief Serialization out
   * @param ar Archive
   */
   template <class Archive>
-  void save( Archive & ar ) const
-  {
-    ar( cereal::make_nvp( "width", w_ ) );
-    ar( cereal::make_nvp( "height", h_ ) );
-  }
+  void save( Archive & ar ) const;
+
 
   /**
   * @brief  Serialization in
   * @param ar Archive
   */
   template <class Archive>
-  void load( Archive & ar )
-  {
-    ar( cereal::make_nvp( "width", w_ ) );
-    ar( cereal::make_nvp( "height", h_ ) );
-  }
+  void load( Archive & ar );
 
   /**
   * @brief Generate a unique Hash from the camera parameters (used for grouping)

--- a/src/openMVG/cameras/Camera_Intrinsics_io.hpp
+++ b/src/openMVG/cameras/Camera_Intrinsics_io.hpp
@@ -1,0 +1,28 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_CAMERAS_CAMERA_INTRINSICS_IO_HPP
+#define OPENMVG_CAMERAS_CAMERA_INTRINSICS_IO_HPP
+
+#include <cereal/types/polymorphic.hpp>
+
+template <class Archive>
+void openMVG::cameras::IntrinsicBase::save( Archive & ar ) const
+{
+  ar( cereal::make_nvp( "width", w_ ) );
+  ar( cereal::make_nvp( "height", h_ ) );
+}
+
+template <class Archive>
+void openMVG::cameras::IntrinsicBase::load( Archive & ar )
+{
+  ar( cereal::make_nvp( "width", w_ ) );
+  ar( cereal::make_nvp( "height", h_ ) );
+}
+
+#endif // #ifndef OPENMVG_CAMERAS_CAMERA_INTRINSICS_IO_HPP

--- a/src/openMVG/cameras/Camera_Pinhole.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole.hpp
@@ -289,13 +289,7 @@ class Pinhole_Intrinsic : public IntrinsicBase
     * @param ar Archive
     */
     template <class Archive>
-    void save( Archive & ar ) const
-    {
-      IntrinsicBase::save(ar);
-      ar( cereal::make_nvp( "focal_length", K_( 0, 0 ) ) );
-      const std::vector<double> pp = {K_( 0, 2 ), K_( 1, 2 )};
-      ar( cereal::make_nvp( "principal_point", pp ) );
-    }
+    inline void save( Archive & ar ) const;
 
 
     /**
@@ -303,15 +297,7 @@ class Pinhole_Intrinsic : public IntrinsicBase
     * @param ar Archive
     */
     template <class Archive>
-    void load( Archive & ar )
-    {
-      IntrinsicBase::load(ar);
-      double focal_length;
-      ar( cereal::make_nvp( "focal_length", focal_length ) );
-      std::vector<double> pp( 2 );
-      ar( cereal::make_nvp( "principal_point", pp ) );
-      *this = Pinhole_Intrinsic( w_, h_, focal_length, pp[0], pp[1] );
-    }
+    inline void load( Archive & ar );
 
     /**
     * @brief Clone the object
@@ -325,9 +311,5 @@ class Pinhole_Intrinsic : public IntrinsicBase
 
 } // namespace cameras
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic, "pinhole");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic);
 
 #endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_HPP

--- a/src/openMVG/cameras/Camera_Pinhole_Brown.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Brown.hpp
@@ -202,22 +202,14 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
     * @param ar Archive
     */
     template <class Archive>
-    void save( Archive & ar ) const
-    {
-      ar(cereal::base_class<Pinhole_Intrinsic>(this));
-      ar( cereal::make_nvp( "disto_t2", params_ ) );
-    }
+    inline void save( Archive & ar ) const;
 
     /**
     * @brief  Serialization in
     * @param ar Archive
     */
     template <class Archive>
-    void load( Archive & ar )
-    {
-      ar(cereal::base_class<Pinhole_Intrinsic>(this));
-      ar( cereal::make_nvp( "disto_t2", params_ ) );
-    }
+    inline void load( Archive & ar );
 
     /**
     * @brief Clone the object
@@ -254,11 +246,5 @@ class Pinhole_Intrinsic_Brown_T2 : public Pinhole_Intrinsic
 
 } // namespace cameras
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/types/vector.hpp>
-
-CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::cameras::Pinhole_Intrinsic_Brown_T2, "pinhole_brown_t2" );
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Brown_T2)
 
 #endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_BROWN_HPP

--- a/src/openMVG/cameras/Camera_Pinhole_Brown_io.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Brown_io.hpp
@@ -1,0 +1,35 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Sida Li, Pierre Moulon.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_BROWN_IO_HPP
+#define OPENMVG_CAMERAS_CAMERA_PINHOLE_BROWN_IO_HPP
+
+#include "openMVG/cameras/Camera_Pinhole_Brown.hpp"
+
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/vector.hpp>
+
+template <class Archive>
+inline void openMVG::cameras::Pinhole_Intrinsic_Brown_T2::save( Archive & ar ) const
+{
+    ar(cereal::base_class<Pinhole_Intrinsic>(this));
+    ar( cereal::make_nvp( "disto_t2", params_ ) );
+}
+
+template <class Archive>
+inline void openMVG::cameras::Pinhole_Intrinsic_Brown_T2::load( Archive & ar )
+{
+    ar(cereal::base_class<Pinhole_Intrinsic>(this));
+    ar( cereal::make_nvp( "disto_t2", params_ ) );
+}
+
+CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::cameras::Pinhole_Intrinsic_Brown_T2, "pinhole_brown_t2" );
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Brown_T2)
+
+#endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_BROWN_IO_HPP
+

--- a/src/openMVG/cameras/Camera_Pinhole_Fisheye.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Fisheye.hpp
@@ -226,22 +226,14 @@ class Pinhole_Intrinsic_Fisheye : public Pinhole_Intrinsic
     * @param ar Archive
     */
     template <class Archive>
-    void save( Archive & ar ) const
-    {
-      ar(cereal::base_class<Pinhole_Intrinsic>(this));
-      ar( cereal::make_nvp( "fisheye", params_ ) );
-    }
+    inline void save( Archive & ar ) const;
 
     /**
     * @brief  Serialization in
     * @param ar Archive
     */
     template <class Archive>
-    void load( Archive & ar )
-    {
-      ar(cereal::base_class<Pinhole_Intrinsic>(this));
-      ar( cereal::make_nvp( "fisheye", params_ ) );
-    }
+    inline void load( Archive & ar );
 
     /**
     * @brief Clone the object
@@ -256,11 +248,5 @@ class Pinhole_Intrinsic_Fisheye : public Pinhole_Intrinsic
 
 } // namespace cameras
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/types/vector.hpp>
-
-CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::cameras::Pinhole_Intrinsic_Fisheye, "fisheye" );
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Fisheye)
 
 #endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_FISHEYE_HPP

--- a/src/openMVG/cameras/Camera_Pinhole_Fisheye_io.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Fisheye_io.hpp
@@ -1,0 +1,32 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Romain Janvier <romain.janvier~AT~univ-orleans.fr> for the given adaptation
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_FISHEYE_IO_HPP
+#define OPENMVG_CAMERAS_CAMERA_PINHOLE_FISHEYE_IO_HPP
+
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/vector.hpp>
+
+template <class Archive>
+inline void openMVG::cameras::Pinhole_Intrinsic_Fisheye::save( Archive & ar ) const
+{
+    ar(cereal::base_class<Pinhole_Intrinsic>(this));
+    ar( cereal::make_nvp( "fisheye", params_ ) );
+}
+
+template <class Archive>
+inline void openMVG::cameras::Pinhole_Intrinsic_Fisheye::load( Archive & ar )
+{
+    ar(cereal::base_class<Pinhole_Intrinsic>(this));
+    ar( cereal::make_nvp( "fisheye", params_ ) );
+}
+
+CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::cameras::Pinhole_Intrinsic_Fisheye, "fisheye" );
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Fisheye)
+
+#endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_FISHEYE_IO_HPP

--- a/src/openMVG/cameras/Camera_Pinhole_Radial.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Radial.hpp
@@ -245,22 +245,14 @@ class Pinhole_Intrinsic_Radial_K1 : public Pinhole_Intrinsic
     * @param ar Archive
     */
     template <class Archive>
-    void save( Archive & ar ) const
-    {
-      Pinhole_Intrinsic::save( ar );
-      ar( cereal::make_nvp( "disto_k1", params_ ) );
-    }
+    inline void save( Archive & ar ) const;
 
     /**
     * @brief  Serialization in
     * @param ar Archive
     */
     template <class Archive>
-    void load( Archive & ar )
-    {
-      Pinhole_Intrinsic::load(ar);
-      ar( cereal::make_nvp( "disto_k1", params_ ) );
-    }
+    inline void load( Archive & ar );
 
     /**
     * @brief Clone the object
@@ -465,22 +457,14 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
     * @param ar Archive
     */
     template <class Archive>
-    void save( Archive & ar ) const
-    {
-      Pinhole_Intrinsic::save(ar);
-      ar( cereal::make_nvp( "disto_k3", params_ ) );
-    }
+    inline void save( Archive & ar ) const;
 
     /**
     * @brief  Serialization in
     * @param ar Archive
     */
     template <class Archive>
-    void load( Archive & ar )
-    {
-      Pinhole_Intrinsic::load(ar);
-      ar( cereal::make_nvp( "disto_k3", params_ ) );
-    }
+    inline void load( Archive & ar );
 
     /**
     * @brief Clone the object
@@ -509,13 +493,5 @@ class Pinhole_Intrinsic_Radial_K3 : public Pinhole_Intrinsic
 
 } // namespace cameras
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/types/vector.hpp>
-
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic_Radial_K1, "pinhole_radial_k1");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Radial_K1);
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic_Radial_K3, "pinhole_radial_k3");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Radial_K3);
 
 #endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_RADIAL_K_HPP

--- a/src/openMVG/cameras/Camera_Pinhole_Radial_io.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Radial_io.hpp
@@ -1,0 +1,49 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_RADIAL_IO_HPP
+#define OPENMVG_CAMERAS_CAMERA_PINHOLE_RADIAL_IO_HPP
+
+#include "openMVG/cameras/Camera_Pinhole_Radial.hpp"
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/vector.hpp>
+
+template <class Archive>
+inline void openMVG::cameras::Pinhole_Intrinsic_Radial_K1::save( Archive & ar ) const
+{
+    Pinhole_Intrinsic::save( ar );
+    ar( cereal::make_nvp( "disto_k1", params_ ) );
+}
+
+template <class Archive>
+inline void openMVG::cameras::Pinhole_Intrinsic_Radial_K1::load( Archive & ar )
+{
+    Pinhole_Intrinsic::load(ar);
+    ar( cereal::make_nvp( "disto_k1", params_ ) );
+}
+
+template <class Archive>
+inline void openMVG::cameras::Pinhole_Intrinsic_Radial_K3::save( Archive & ar ) const
+{
+    Pinhole_Intrinsic::save(ar);
+    ar( cereal::make_nvp( "disto_k3", params_ ) );
+}
+
+template <class Archive>
+inline void openMVG::cameras::Pinhole_Intrinsic_Radial_K3::load( Archive & ar )
+{
+    Pinhole_Intrinsic::load(ar);
+    ar( cereal::make_nvp( "disto_k3", params_ ) );
+}
+
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic_Radial_K1, "pinhole_radial_k1");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Radial_K1);
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic_Radial_K3, "pinhole_radial_k3");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic_Radial_K3);
+
+#endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_RADIAL_IO_HPP

--- a/src/openMVG/cameras/Camera_Pinhole_io.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_io.hpp
@@ -1,0 +1,44 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_IO_HPP
+#define OPENMVG_CAMERAS_CAMERA_PINHOLE_IO_HPP
+
+#include "openMVG/cameras/Camera_Pinhole.hpp"
+
+#include <cereal/types/polymorphic.hpp>
+
+template <class Archive>
+void openMVG::cameras::Pinhole_Intrinsic::save( Archive & ar ) const
+{
+    IntrinsicBase::save(ar);
+    ar( cereal::make_nvp( "focal_length", K_( 0, 0 ) ) );
+    const std::vector<double> pp = {K_( 0, 2 ), K_( 1, 2 )};
+    ar( cereal::make_nvp( "principal_point", pp ) );
+}
+
+
+/**
+* @brief  Serialization in
+* @param ar Archive
+*/
+template <class Archive>
+void openMVG::cameras::Pinhole_Intrinsic::load( Archive & ar )
+{
+    IntrinsicBase::load(ar);
+    double focal_length;
+    ar( cereal::make_nvp( "focal_length", focal_length ) );
+    std::vector<double> pp( 2 );
+    ar( cereal::make_nvp( "principal_point", pp ) );
+    *this = Pinhole_Intrinsic( w_, h_, focal_length, pp[0], pp[1] );
+}
+
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Pinhole_Intrinsic, "pinhole");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Pinhole_Intrinsic);
+
+#endif // #ifndef OPENMVG_CAMERAS_CAMERA_PINHOLE_IO_HPP

--- a/src/openMVG/cameras/Camera_Spherical.hpp
+++ b/src/openMVG/cameras/Camera_Spherical.hpp
@@ -201,20 +201,14 @@ using  class_type = Intrinsic_Spherical;
   * @param ar Archive
   */
   template <class Archive>
-  void save( Archive & ar ) const
-  {
-    ar(cereal::base_class<IntrinsicBase>(this));
-  }
+  inline void save( Archive & ar ) const;
 
   /**
   * @brief  Serialization in
   * @param ar Archive
   */
   template <class Archive>
-  void load( Archive & ar )
-  {
-    ar(cereal::base_class<IntrinsicBase>(this));
-  }
+  inline void load( Archive & ar );
 
   /**
   * @brief Clone the object
@@ -229,18 +223,5 @@ using  class_type = Intrinsic_Spherical;
 
 } // namespace cameras
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/types/vector.hpp>
-
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Intrinsic_Spherical, "spherical");
-
-namespace cereal
-{
-  // This struct specialization will tell cereal which is the right way to serialize the ambiguity
-  template <class Archive> struct specialize<Archive, openMVG::cameras::Intrinsic_Spherical, cereal::specialization::member_load_save> {};
-}
-
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Intrinsic_Spherical);
 
 #endif // #ifndef OPENMVG_CAMERAS_CAMERA_SPHERICAL_HPP

--- a/src/openMVG/cameras/Camera_Spherical_io.hpp
+++ b/src/openMVG/cameras/Camera_Spherical_io.hpp
@@ -1,0 +1,39 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2017 <Zillow Inc.> Pierre Moulon
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_CAMERAS_CAMERA_SPHERICAL_IO_HPP
+#define OPENMVG_CAMERAS_CAMERA_SPHERICAL_IO_HPP
+
+#include "openMVG/numeric/numeric.h"
+#include "openMVG/cameras/Camera_Intrinsics.hpp"
+
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/vector.hpp>
+
+template <class Archive>
+inline void openMVG::cameras::Intrinsic_Spherical::save( Archive & ar ) const
+{
+  ar(cereal::base_class<IntrinsicBase>(this));
+}
+
+template <class Archive>
+inline void openMVG::cameras::Intrinsic_Spherical::load( Archive & ar )
+{
+  ar(cereal::base_class<IntrinsicBase>(this));
+}
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::cameras::Intrinsic_Spherical, "spherical");
+
+namespace cereal
+{
+  // This struct specialization will tell cereal which is the right way to serialize the ambiguity
+  template <class Archive> struct specialize<Archive, openMVG::cameras::Intrinsic_Spherical, cereal::specialization::member_load_save> {};
+}
+
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::cameras::IntrinsicBase, openMVG::cameras::Intrinsic_Spherical);
+
+#endif // #ifndef OPENMVG_CAMERAS_CAMERA_SPHERICAL_IO_HPP

--- a/src/openMVG/cameras/cameras_io.hpp
+++ b/src/openMVG/cameras/cameras_io.hpp
@@ -1,0 +1,20 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre Moulon.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_CAMERAS_CAMERAS_IO_HPP
+#define OPENMVG_CAMERAS_CAMERAS_IO_HPP
+
+#include "openMVG/cameras/cameras.hpp"
+#include "openMVG/cameras/Camera_Intrinsics_io.hpp"
+#include "openMVG/cameras/Camera_Pinhole_io.hpp"
+#include "openMVG/cameras/Camera_Pinhole_Radial_io.hpp"
+#include "openMVG/cameras/Camera_Pinhole_Brown_io.hpp"
+#include "openMVG/cameras/Camera_Pinhole_Fisheye_io.hpp"
+#include "openMVG/cameras/Camera_Spherical_io.hpp"
+
+#endif // OPENMVG_CAMERAS_CAMERAS_IO_HPP

--- a/src/openMVG/features/akaze/AKAZE.hpp
+++ b/src/openMVG/features/akaze/AKAZE.hpp
@@ -38,8 +38,6 @@
 
 #include "openMVG/image/image_container.hpp"
 
-#include <cereal/cereal.hpp>
-
 namespace openMVG {
 namespace features {
 
@@ -87,15 +85,7 @@ public:
     }
 
     template<class Archive>
-    void serialize(Archive & ar)
-    {
-      ar(
-        cereal::make_nvp("iNbOctave", iNbOctave),
-        cereal::make_nvp("iNbSlicePerOctave", iNbSlicePerOctave),
-        cereal::make_nvp("fSigma0", fSigma0),
-        cereal::make_nvp("fThreshold", fThreshold),
-        cereal::make_nvp("fDesc_factor", fDesc_factor));
-    }
+    void serialize(Archive & ar);
 
     int iNbOctave; ///< Octave to process
     int iNbSlicePerOctave; ///< Levels per octave

--- a/src/openMVG/features/akaze/AKAZE_io.hpp
+++ b/src/openMVG/features/akaze/AKAZE_io.hpp
@@ -1,0 +1,27 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2014 Romuald PERROT, Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_FEATURES_AKAZE_IO_HPP
+#define OPENMVG_FEATURES_AKAZE_IO_HPP
+
+#include "openMVG/features/akaze/AKAZE.hpp"
+
+#include <cereal/cereal.hpp>
+
+template<class Archive>
+void openMVG::features::AKAZE::Params::serialize(Archive & ar)
+{
+  ar(
+    cereal::make_nvp("iNbOctave", iNbOctave),
+    cereal::make_nvp("iNbSlicePerOctave", iNbSlicePerOctave),
+    cereal::make_nvp("fSigma0", fSigma0),
+    cereal::make_nvp("fThreshold", fThreshold),
+    cereal::make_nvp("fDesc_factor", fDesc_factor));
+}
+
+#endif // OPENMVG_FEATURES_AKAZE_HPP

--- a/src/openMVG/features/image_describer_akaze.hpp
+++ b/src/openMVG/features/image_describer_akaze.hpp
@@ -20,8 +20,6 @@
 #include "openMVG/features/liop/liop_descriptor.hpp"
 #include "openMVG/features/regions_factory.hpp"
 
-#include <cereal/cereal.hpp>
-
 namespace openMVG {
 namespace features {
 
@@ -44,10 +42,7 @@ public:
     ):options_(config), eAkazeDescriptor_(eAkazeDescriptor){}
 
     template<class Archive>
-    void serialize(Archive & ar)
-    {
-      ar(options_, eAkazeDescriptor_);
-    }
+    void serialize(Archive & ar);
 
     // Parameters
     features::AKAZE::Params options_;
@@ -267,12 +262,7 @@ public:
   }
 
   template<class Archive>
-  void serialize(Archive & ar)
-  {
-    ar(
-     cereal::make_nvp("params", params_),
-     cereal::make_nvp("bOrientation", bOrientation_));
-  }
+  void serialize(Archive & ar);
 
 private:
   Params params_;
@@ -281,10 +271,5 @@ private:
 
 } // namespace features
 } // namespace openMVG
-
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/archives/json.hpp>
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Image_describer, "AKAZE_Image_describer");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::AKAZE_Image_describer)
 
 #endif // OPENMVG_FEATURES_AKAZE_IMAGE_DESCRIBER_HPP

--- a/src/openMVG/features/image_describer_akaze_io.hpp
+++ b/src/openMVG/features/image_describer_akaze_io.hpp
@@ -1,0 +1,37 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_FEATURES_AKAZE_IMAGE_DESCRIBER_IO_HPP
+#define OPENMVG_FEATURES_AKAZE_IMAGE_DESCRIBER_IO_HPP
+
+#include "openMVG/features/image_describer_akaze.hpp"
+#include "openMVG/features/akaze/AKAZE_io.hpp"
+
+#include <cereal/types/polymorphic.hpp>
+
+template<class Archive>
+void openMVG::features::AKAZE_Image_describer::Params::serialize(Archive & ar)
+{
+    ar(options_, eAkazeDescriptor_);
+}
+
+template<class Archive>
+void openMVG::features::AKAZE_Image_describer::serialize(Archive & ar)
+{
+  ar(
+   cereal::make_nvp("params", params_),
+   cereal::make_nvp("bOrientation", bOrientation_));
+}
+
+
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Image_describer, "AKAZE_Image_describer");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::AKAZE_Image_describer)
+
+#endif // OPENMVG_FEATURES_AKAZE_IMAGE_DESCRIBER_IO_HPP
+
+

--- a/src/openMVG/features/regions.cpp
+++ b/src/openMVG/features/regions.cpp
@@ -6,23 +6,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#ifndef OPENMVG_FEATURES_IO_REGIONS_TYPE_HPP
-#define OPENMVG_FEATURES_IO_REGIONS_TYPE_HPP
+// The <cereal/archives> headers are special and must be included first.
+#include <cereal/archives/json.hpp> 
 
 #include <fstream>
 #include <string>
 #include <vector>
 
-#include "openMVG/features/regions_factory.hpp"
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
-#include <cereal/archives/json.hpp>
+#include "openMVG/features/regions_factory_io.hpp"
 
 namespace openMVG {
 namespace features {
 
 // Init the regions_type from an image describer file (used for regions loading)
-inline std::unique_ptr<features::Regions> Init_region_type_from_file
+std::unique_ptr<features::Regions> Init_region_type_from_file
 (
   const std::string & sImage_describer_file
 )
@@ -47,5 +46,3 @@ inline std::unique_ptr<features::Regions> Init_region_type_from_file
 
 } // namespace features
 } // namespace openMVG
-
-#endif // OPENMVG_FEATURES_IO_REGIONS_TYPE_HPP

--- a/src/openMVG/features/regions.hpp
+++ b/src/openMVG/features/regions.hpp
@@ -78,6 +78,11 @@ public:
 
 };
 
+std::unique_ptr<features::Regions> Init_region_type_from_file
+(
+  const std::string & sImage_describer_file
+);
+
 } // namespace features
 } // namespace openMVG
 

--- a/src/openMVG/features/regions_factory.hpp
+++ b/src/openMVG/features/regions_factory.hpp
@@ -32,19 +32,5 @@ EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_INITIALIZER_LIST(openMVG::features::SIFT_
 EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_INITIALIZER_LIST(openMVG::features::AKAZE_Float_Regions)
 EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_INITIALIZER_LIST(openMVG::features::AKAZE_Liop_Regions)
 EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_INITIALIZER_LIST(openMVG::features::AKAZE_Binary_Regions)
-//--
-// Register region type for serialization
-//--
-#include <cereal/types/array.hpp>
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/types/vector.hpp>
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Regions, "SIFT_Regions");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::SIFT_Regions)
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Float_Regions, "AKAZE_Float_Regions");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Float_Regions)
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Liop_Regions, "AKAZE_Liop_Regions");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Liop_Regions)
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Binary_Regions, "AKAZE_Binary_Regions");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Binary_Regions)
 
 #endif // OPENMVG_FEATURES_REGIONS_FACTORY_HPP

--- a/src/openMVG/features/regions_factory_io.hpp
+++ b/src/openMVG/features/regions_factory_io.hpp
@@ -1,0 +1,29 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_FEATURES_REGIONS_FACTORY_IO_HPP
+#define OPENMVG_FEATURES_REGIONS_FACTORY_IO_HPP
+
+#include "openMVG/features/regions_factory.hpp"
+//--
+// Register region type for serialization
+//--
+#include <cereal/types/array.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/vector.hpp>
+
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Regions, "SIFT_Regions");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::SIFT_Regions)
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Float_Regions, "AKAZE_Float_Regions");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Float_Regions)
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Liop_Regions, "AKAZE_Liop_Regions");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Liop_Regions)
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::AKAZE_Binary_Regions, "AKAZE_Binary_Regions");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Regions, openMVG::features::AKAZE_Binary_Regions)
+
+#endif // OPENMVG_FEATURES_REGIONS_FACTORY_IO_HPP

--- a/src/openMVG/features/sift/SIFT_Anatomy_Image_Describer.hpp
+++ b/src/openMVG/features/sift/SIFT_Anatomy_Image_Describer.hpp
@@ -60,7 +60,6 @@ Changes are:
 #include "openMVG/features/sift/sift_keypoint.hpp"
 #include "openMVG/features/sift/sift_KeypointExtractor.hpp"
 
-#include <cereal/cereal.hpp>
 
 namespace openMVG {
 namespace features {
@@ -86,16 +85,7 @@ public:
       root_sift_(root_sift) {}
 
     template<class Archive>
-    void serialize( Archive & ar )
-    {
-      ar(
-        cereal::make_nvp("first_octave", first_octave_),
-        cereal::make_nvp("num_octaves",num_octaves_),
-        cereal::make_nvp("num_scales",num_scales_),
-        cereal::make_nvp("edge_threshold",edge_threshold_),
-        cereal::make_nvp("peak_threshold",peak_threshold_),
-        cereal::make_nvp("root_sift",root_sift_));
-    }
+    inline void serialize( Archive & ar );
 
     // Parameters
     int first_octave_;      // Use original image, or perform an upscale if == -1
@@ -216,10 +206,7 @@ public:
   }
 
   template<class Archive>
-  void serialize( Archive & ar )
-  {
-    ar(cereal::make_nvp("params", params_));
-  }
+  inline void serialize( Archive & ar );
 
 private:
   Params params_;
@@ -228,9 +215,5 @@ private:
 } // namespace features
 } // namespace openMVG
 
-#include <cereal/types/polymorphic.hpp>
-#include <cereal/archives/json.hpp>
-CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Anatomy_Image_describer, "SIFT_Anatomy_Image_describer");
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::SIFT_Anatomy_Image_describer)
 
 #endif // OPENMVG_FEATURES_SIFT_SIFT_ANATOMY_IMAGE_DESCRIBER_HPP

--- a/src/openMVG/features/sift/SIFT_Anatomy_Image_Describer_io.hpp
+++ b/src/openMVG/features/sift/SIFT_Anatomy_Image_Describer_io.hpp
@@ -1,0 +1,40 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_FEATURES_SIFT_SIFT_ANATOMY_IMAGE_DESCRIBER_IO_HPP
+#define OPENMVG_FEATURES_SIFT_SIFT_ANATOMY_IMAGE_DESCRIBER_IO_HPP
+
+#include "openMVG/features/sift/SIFT_Anatomy_Image_Describer.hpp"
+
+#include <cereal/cereal.hpp>
+#include <cereal/types/polymorphic.hpp>
+
+template<class Archive>
+inline void openMVG::features::SIFT_Anatomy_Image_describer::Params::serialize( Archive & ar )
+{
+  ar(
+    cereal::make_nvp("first_octave", first_octave_),
+    cereal::make_nvp("num_octaves",num_octaves_),
+    cereal::make_nvp("num_scales",num_scales_),
+    cereal::make_nvp("edge_threshold",edge_threshold_),
+    cereal::make_nvp("peak_threshold",peak_threshold_),
+    cereal::make_nvp("root_sift",root_sift_));
+}
+
+
+template<class Archive>
+inline void openMVG::features::SIFT_Anatomy_Image_describer::serialize( Archive & ar )
+{
+  ar(cereal::make_nvp("params", params_));
+}
+
+
+CEREAL_REGISTER_TYPE_WITH_NAME(openMVG::features::SIFT_Anatomy_Image_describer, "SIFT_Anatomy_Image_describer");
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, openMVG::features::SIFT_Anatomy_Image_describer)
+
+#endif // OPENMVG_FEATURES_SIFT_SIFT_ANATOMY_IMAGE_DESCRIBER_IO_HPP

--- a/src/openMVG/geometry/pose3.hpp
+++ b/src/openMVG/geometry/pose3.hpp
@@ -9,10 +9,7 @@
 #ifndef OPENMVG_GEOMETRY_POSE3_HPP
 #define OPENMVG_GEOMETRY_POSE3_HPP
 
-#include <vector>
-
 #include "openMVG/multiview/projection.hpp"
-#include <cereal/cereal.hpp> // Serialization
 
 namespace openMVG
 {
@@ -142,39 +139,14 @@ class Pose3
     * @param ar Archive
     */
     template <class Archive>
-    void save( Archive & ar ) const
-    {
-      const std::vector<std::vector<double>> mat =
-      {
-        { rotation_( 0, 0 ), rotation_( 0, 1 ), rotation_( 0, 2 ) },
-        { rotation_( 1, 0 ), rotation_( 1, 1 ), rotation_( 1, 2 ) },
-        { rotation_( 2, 0 ), rotation_( 2, 1 ), rotation_( 2, 2 ) }
-      };
-
-      ar( cereal::make_nvp( "rotation", mat ) );
-
-      const std::vector<double> vec = { center_( 0 ), center_( 1 ), center_( 2 ) };
-      ar( cereal::make_nvp( "center", vec ) );
-    }
+    inline void save( Archive & ar ) const;
 
     /**
     * @brief Serialization in
     * @param ar Archive
     */
     template <class Archive>
-    void load( Archive & ar )
-    {
-      std::vector<std::vector<double>> mat( 3, std::vector<double>( 3 ) );
-      ar( cereal::make_nvp( "rotation", mat ) );
-      // copy back to the rotation
-      rotation_.row( 0 ) = Eigen::Map<const Vec3>( &( mat[0][0] ) );
-      rotation_.row( 1 ) = Eigen::Map<const Vec3>( &( mat[1][0] ) );
-      rotation_.row( 2 ) = Eigen::Map<const Vec3>( &( mat[2][0] ) );
-
-      std::vector<double> vec( 3 );
-      ar( cereal::make_nvp( "center", vec ) );
-      center_ = Eigen::Map<const Vec3>( &vec[0] );
-    }
+    inline void load( Archive & ar );
 };
 } // namespace geometry
 } // namespace openMVG

--- a/src/openMVG/geometry/pose3_io.hpp
+++ b/src/openMVG/geometry/pose3_io.hpp
@@ -1,0 +1,47 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_GEOMETRY_POSE3_IO_HPP
+#define OPENMVG_GEOMETRY_POSE3_IO_HPP
+
+#include <cereal/cereal.hpp> // Serialization
+
+#include <vector>
+
+template <class Archive>
+inline void openMVG::geometry::Pose3::save( Archive & ar ) const
+{
+    const std::vector<std::vector<double>> mat =
+    {
+    { rotation_( 0, 0 ), rotation_( 0, 1 ), rotation_( 0, 2 ) },
+    { rotation_( 1, 0 ), rotation_( 1, 1 ), rotation_( 1, 2 ) },
+    { rotation_( 2, 0 ), rotation_( 2, 1 ), rotation_( 2, 2 ) }
+    };
+
+    ar( cereal::make_nvp( "rotation", mat ) );
+
+    const std::vector<double> vec = { center_( 0 ), center_( 1 ), center_( 2 ) };
+    ar( cereal::make_nvp( "center", vec ) );
+}
+
+template <class Archive>
+inline void openMVG::geometry::Pose3::load( Archive & ar )
+{
+    std::vector<std::vector<double>> mat( 3, std::vector<double>( 3 ) );
+    ar( cereal::make_nvp( "rotation", mat ) );
+    // copy back to the rotation
+    rotation_.row( 0 ) = Eigen::Map<const Vec3>( &( mat[0][0] ) );
+    rotation_.row( 1 ) = Eigen::Map<const Vec3>( &( mat[1][0] ) );
+    rotation_.row( 2 ) = Eigen::Map<const Vec3>( &( mat[2][0] ) );
+
+    std::vector<double> vec( 3 );
+    ar( cereal::make_nvp( "center", vec ) );
+    center_ = Eigen::Map<const Vec3>( &vec[0] );
+}
+
+#endif  // OPENMVG_GEOMETRY_POSE3_IO_HPP

--- a/src/openMVG/matching/indMatch.hpp
+++ b/src/openMVG/matching/indMatch.hpp
@@ -17,8 +17,6 @@
 
 #include "openMVG/types.hpp"
 
-#include <cereal/cereal.hpp> // Serialization
-
 namespace openMVG {
 namespace matching {
 
@@ -52,9 +50,7 @@ struct IndMatch
 
   // Serialization
   template <class Archive>
-  void serialize( Archive & ar )  {
-    ar(i_, j_);
-  }
+  void serialize( Archive & ar ) ;
 
   IndexT i_, j_;  // Left, right index
 };
@@ -109,15 +105,5 @@ inline Pair_Set getPairs(const PairWiseMatches & matches)
 }  // namespace matching
 }  // namespace openMVG
 
-namespace cereal
-{
-  // This struct specialization will tell cereal which is the right way to serialize PairWiseMatches
-  template <class Archive>
-  struct specialize<
-    Archive,
-    openMVG::matching::PairWiseMatches,
-    cereal::specialization::member_serialize>
-  {};
-} // namespace cereal
 
 #endif // OPENMVG_MATCHING_IND_MATCH_HPP

--- a/src/openMVG/matching/indMatch_io.hpp
+++ b/src/openMVG/matching/indMatch_io.hpp
@@ -1,0 +1,33 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2012, 2013 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_MATCHING_IND_MATCH_IO_HPP
+#define OPENMVG_MATCHING_IND_MATCH_IO_HPP
+
+#include "openMVG/matching/indMatch.hpp"
+
+#include <cereal/cereal.hpp> // Serialization
+
+// Serialization
+template <class Archive>
+void openMVG::matching::IndMatch::serialize( Archive & ar )  {
+  ar(i_, j_);
+}
+
+namespace cereal
+{
+  // This struct specialization will tell cereal which is the right way to serialize PairWiseMatches
+  template <class Archive>
+  struct specialize<
+    Archive,
+    openMVG::matching::PairWiseMatches,
+    cereal::specialization::member_serialize>
+  {};
+} // namespace cereal
+
+#endif // OPENMVG_MATCHING_IND_MATCH_IO_HPP

--- a/src/openMVG/matching/indMatch_utils.cpp
+++ b/src/openMVG/matching/indMatch_utils.cpp
@@ -6,7 +6,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// The <cereal/archives> headers are special and must be included first.
+#include <cereal/archives/portable_binary.hpp>
+
 #include "openMVG/matching/indMatch_utils.hpp"
+#include "openMVG/matching/indMatch_io.hpp"
 
 #include <algorithm>
 #include <fstream>
@@ -16,7 +20,6 @@
 
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
-#include <cereal/archives/portable_binary.hpp>
 #include <cereal/types/map.hpp>
 #include <cereal/types/utility.hpp>
 #include <cereal/types/vector.hpp>

--- a/src/openMVG/sfm/sfm_data_io.cpp
+++ b/src/openMVG/sfm/sfm_data_io.cpp
@@ -6,6 +6,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// The <cereal/archives> headers are special and must be included first.
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/archives/portable_binary.hpp>
+
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/sfm/sfm_data_io.hpp"
 #include "openMVG/sfm/sfm_data_io_baf.hpp"

--- a/src/openMVG/sfm/sfm_data_io_cereal.cpp
+++ b/src/openMVG/sfm/sfm_data_io_cereal.cpp
@@ -6,19 +6,24 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// The <cereal/archives> headers are special and must be included first.
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/portable_binary.hpp>
+#include <cereal/archives/xml.hpp>
+
 #include "openMVG/sfm/sfm_data_io_cereal.hpp"
 
-#include "openMVG/cameras/cameras.hpp"
+#include "openMVG/cameras/cameras_io.hpp"
+#include "openMVG/geometry/pose3_io.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
+#include "openMVG/sfm/sfm_landmark_io.hpp"
+#include "openMVG/sfm/sfm_view_io.hpp"
 #include "openMVG/types.hpp"
 
 #include <fstream>
 #include <string>
 
-#include <cereal/archives/binary.hpp>
-#include <cereal/archives/json.hpp>
-#include <cereal/archives/portable_binary.hpp>
-#include <cereal/archives/xml.hpp>
 #include <cereal/types/map.hpp>
 #include <cereal/types/string.hpp>
 #include <cereal/types/unordered_map.hpp>

--- a/src/openMVG/sfm/sfm_landmark.hpp
+++ b/src/openMVG/sfm/sfm_landmark.hpp
@@ -9,11 +9,7 @@
 #ifndef OPENMVG_SFM_SFM_LANDMARK_HPP
 #define OPENMVG_SFM_SFM_LANDMARK_HPP
 
-#include <vector>
-
 #include "openMVG/types.hpp"
-
-#include <cereal/cereal.hpp> // Serialization
 
 namespace openMVG {
 namespace sfm {
@@ -29,23 +25,13 @@ struct Observation
 
   // Serialization
   template <class Archive>
-  void save( Archive & ar) const
-  {
-    ar(cereal::make_nvp("id_feat", id_feat ));
-    const std::vector<double> pp = { x(0), x(1) };
-    ar(cereal::make_nvp("x", pp));
-  }
+  void save( Archive & ar) const;
 
   // Serialization
   template <class Archive>
-  void load( Archive & ar)
-  {
-    ar(cereal::make_nvp("id_feat", id_feat ));
-    std::vector<double> p(2);
-    ar(cereal::make_nvp("x", p));
-    x = Eigen::Map<const Vec2>(&p[0]);
-  }
+  void load( Archive & ar);
 };
+
 /// Observations are indexed by their View_id
 using Observations = Hash_Map<IndexT, Observation>;
 
@@ -57,21 +43,10 @@ struct Landmark
 
   // Serialization
   template <class Archive>
-  void save( Archive & ar) const
-  {
-    const std::vector<double> point = { X(0), X(1), X(2) };
-    ar(cereal::make_nvp("X", point ));
-    ar(cereal::make_nvp("observations", obs));
-  }
+  void save( Archive & ar) const;
 
   template <class Archive>
-  void load( Archive & ar)
-  {
-    std::vector<double> point(3);
-    ar(cereal::make_nvp("X", point ));
-    X = Eigen::Map<const Vec3>(&point[0]);
-    ar(cereal::make_nvp("observations", obs));
-  }
+  void load( Archive & ar);
 };
 
 /// Define a collection of landmarks are indexed by their TrackId

--- a/src/openMVG/sfm/sfm_landmark_io.hpp
+++ b/src/openMVG/sfm/sfm_landmark_io.hpp
@@ -1,0 +1,55 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre Moulon.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_SFM_SFM_LANDMARK_IO_HPP
+#define OPENMVG_SFM_SFM_LANDMARK_IO_HPP
+
+#include "openMVG/sfm/sfm_landmark.hpp"
+
+#include <cereal/cereal.hpp> // Serialization
+
+#include <vector>
+
+template <class Archive>
+void openMVG::sfm::Observation::save( Archive & ar) const
+{
+  ar(cereal::make_nvp("id_feat", id_feat ));
+  const std::vector<double> pp = { x(0), x(1) };
+  ar(cereal::make_nvp("x", pp));
+}
+
+template <class Archive>
+void openMVG::sfm::Observation::load( Archive & ar)
+{
+  ar(cereal::make_nvp("id_feat", id_feat ));
+  std::vector<double> p(2);
+  ar(cereal::make_nvp("x", p));
+  x = Eigen::Map<const Vec2>(&p[0]);
+}
+
+
+template <class Archive>
+void openMVG::sfm::Landmark::save( Archive & ar) const
+{
+  const std::vector<double> point = { X(0), X(1), X(2) };
+  ar(cereal::make_nvp("X", point ));
+  ar(cereal::make_nvp("observations", obs));
+}
+
+
+template <class Archive>
+void openMVG::sfm::Landmark::load( Archive & ar)
+{
+  std::vector<double> point(3);
+  ar(cereal::make_nvp("X", point ));
+  X = Eigen::Map<const Vec3>(&point[0]);
+  ar(cereal::make_nvp("observations", obs));
+}
+
+#endif // OPENMVG_SFM_SFM_LANDMARK_IO_HPP
+

--- a/src/openMVG/sfm/sfm_view.hpp
+++ b/src/openMVG/sfm/sfm_view.hpp
@@ -15,11 +15,6 @@
 
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
-#include <cereal/archives/json.hpp>
-#include <cereal/archives/portable_binary.hpp>
-#include <cereal/archives/xml.hpp>
-#include <cereal/types/polymorphic.hpp>
-
 namespace openMVG {
 namespace sfm {
 
@@ -56,38 +51,14 @@ struct View
   * @param ar Archive
   */
   template <class Archive>
-  void save( Archive & ar ) const
-  {
-    ar(cereal::make_nvp("local_path", stlplus::folder_part(s_Img_path)),
-       cereal::make_nvp("filename", stlplus::filename_part(s_Img_path)),
-       cereal::make_nvp("width", ui_width),
-       cereal::make_nvp("height", ui_height),
-       cereal::make_nvp("id_view", id_view),
-       cereal::make_nvp("id_intrinsic", id_intrinsic),
-       cereal::make_nvp("id_pose", id_pose));
-  }
+  void save( Archive & ar ) const;
 
   /**
   * @brief Serialization in
   * @param ar Archive
   */
   template <class Archive>
-  void load( Archive & ar )
-  {
-    //Define a view with two string (base_path & basename)
-    std::string local_path = s_Img_path;
-    std::string filename = s_Img_path;
-
-    ar(cereal::make_nvp("local_path", local_path),
-       cereal::make_nvp("filename", filename),
-       cereal::make_nvp("width", ui_width),
-       cereal::make_nvp("height", ui_height),
-       cereal::make_nvp("id_view", id_view),
-       cereal::make_nvp("id_intrinsic", id_intrinsic),
-       cereal::make_nvp("id_pose", id_pose));
-
-    s_Img_path = stlplus::create_filespec(local_path, filename);
-  }
+  void load( Archive & ar );
 };
 
 /// Define a collection of View

--- a/src/openMVG/sfm/sfm_view_io.hpp
+++ b/src/openMVG/sfm/sfm_view_io.hpp
@@ -1,0 +1,48 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre Moulon.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_SFM_SFM_VIEW_IO_HPP
+#define OPENMVG_SFM_SFM_VIEW_IO_HPP
+
+#include "openMVG/sfm/sfm_view.hpp"
+
+#include <cereal/types/polymorphic.hpp>
+
+template <class Archive>
+void openMVG::sfm::View::save( Archive & ar ) const
+{
+  ar(cereal::make_nvp("local_path", stlplus::folder_part(s_Img_path)),
+     cereal::make_nvp("filename", stlplus::filename_part(s_Img_path)),
+     cereal::make_nvp("width", ui_width),
+     cereal::make_nvp("height", ui_height),
+     cereal::make_nvp("id_view", id_view),
+     cereal::make_nvp("id_intrinsic", id_intrinsic),
+     cereal::make_nvp("id_pose", id_pose));
+}
+
+
+template <class Archive>
+void openMVG::sfm::View::load( Archive & ar )
+{
+  //Define a view with two string (base_path & basename)
+  std::string local_path = s_Img_path;
+  std::string filename = s_Img_path;
+
+  ar(cereal::make_nvp("local_path", local_path),
+     cereal::make_nvp("filename", filename),
+     cereal::make_nvp("width", ui_width),
+     cereal::make_nvp("height", ui_height),
+     cereal::make_nvp("id_view", id_view),
+     cereal::make_nvp("id_intrinsic", id_intrinsic),
+     cereal::make_nvp("id_pose", id_pose));
+
+  s_Img_path = stlplus::create_filespec(local_path, filename);
+}
+
+
+#endif // OPENMVG_SFM_SFM_VIEW_IO_HPP

--- a/src/openMVG/sfm/sfm_view_priors.hpp
+++ b/src/openMVG/sfm/sfm_view_priors.hpp
@@ -14,8 +14,6 @@
 
 #include "openMVG/geometry/pose3.hpp"
 
-#include <cereal/types/polymorphic.hpp>
-
 namespace openMVG {
 namespace sfm {
 
@@ -79,82 +77,14 @@ struct ViewPriors : public View
   * @param ar Archive
   */
   template <class Archive>
-  void save( Archive & ar ) const
-  {
-    View::save(ar);
-
-    // Pose center prior
-    if (b_use_pose_center_)
-    {
-      ar( cereal::make_nvp( "use_pose_center_prior", b_use_pose_center_ ) );
-      const std::vector<double> vec_weights = { center_weight_( 0 ), center_weight_( 1 ), center_weight_( 2 ) };
-      ar( cereal::make_nvp( "center_weight", vec_weights ) );
-      const std::vector<double> vec = { pose_center_( 0 ), pose_center_( 1 ), pose_center_( 2 ) };
-      ar( cereal::make_nvp( "center", vec ) );
-    }
-
-    // Pose rotation prior
-    /*
-    if (b_use_pose_rotation_)
-    {
-      ar( cereal::make_nvp( "use_pose_rotation_prior", b_use_pose_rotation_ ) );
-      ar( cereal::make_nvp( "rotation_weight", rotation_weight_ ) );
-      const std::vector<std::vector<double>> mat =
-      {
-        { pose_rotation_( 0, 0 ), pose_rotation_( 0, 1 ), pose_rotation_( 0, 2 ) },
-        { pose_rotation_( 1, 0 ), pose_rotation_( 1, 1 ), pose_rotation_( 1, 2 ) },
-        { pose_rotation_( 2, 0 ), pose_rotation_( 2, 1 ), pose_rotation_( 2, 2 ) }
-      };
-      ar( cereal::make_nvp( "rotation", mat ) );
-    }
-    */
-  }
+  void save( Archive & ar ) const;
 
   /**
   * @brief Serialization in
   * @param ar Archive
   */
   template <class Archive>
-  void load( Archive & ar )
-  {
-    View::load(ar);
-
-    // Pose center prior
-    try
-    {
-      ar( cereal::make_nvp( "use_pose_center_prior", b_use_pose_center_ ) );
-      std::vector<double> vec( 3 );
-      ar( cereal::make_nvp( "center_weight", vec ) );
-      center_weight_ = Eigen::Map<const Vec3>( &vec[0] );
-      ar( cereal::make_nvp( "center", vec ) );
-      pose_center_ = Eigen::Map<const Vec3>( &vec[0] );
-    }
-    catch( cereal::Exception e )
-    {
-      // if it fails just use a default settings
-      b_use_pose_center_ = false;
-    }
-
-    // Pose rotation prior
-    /*
-    try
-    {
-      ar( cereal::make_nvp( "use_pose_rotation_prior", b_use_pose_rotation_ ) );
-      ar( cereal::make_nvp( "rotation_weight", rotation_weight_ ) );
-      std::vector<std::vector<double>> mat( 3, std::vector<double>( 3 ) );
-      ar( cereal::make_nvp( "rotation", mat ) );
-      // copy back to the rotation
-      pose_rotation_.row( 0 ) = Eigen::Map<const Vec3>( &( mat[0][0] ) );
-      pose_rotation_.row( 1 ) = Eigen::Map<const Vec3>( &( mat[1][0] ) );
-      pose_rotation_.row( 2 ) = Eigen::Map<const Vec3>( &( mat[2][0] ) );
-    }
-    catch( const cereal::Exception & e )
-    {
-      // if it fails just use a default settings
-      b_use_pose_rotation_ = false;
-    }
-    */
-  }
+  void load( Archive & ar );
 
   // Pose center prior
   bool b_use_pose_center_ = false; // Tell if the pose prior must be used
@@ -169,10 +99,5 @@ struct ViewPriors : public View
 
 } // namespace sfm
 } // namespace openMVG
-
-#include <cereal/types/vector.hpp>
-
-CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::sfm::ViewPriors, "view_priors" );
-CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::sfm::View, openMVG::sfm::ViewPriors);
 
 #endif // OPENMVG_SFM_SFM_VIEW_PRIORS_HPP

--- a/src/openMVG/sfm/sfm_view_priors_io.hpp
+++ b/src/openMVG/sfm/sfm_view_priors_io.hpp
@@ -1,0 +1,94 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2016 Pierre Moulon.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_SFM_SFM_VIEW_PRIORS_HPP
+#define OPENMVG_SFM_SFM_VIEW_PRIORS_HPP
+
+#include <cereal/types/vector.hpp>
+#include <cereal/types/polymorphic.hpp>
+
+#include "openMVG/sfm/sfm_view_priors_io.hpp"
+
+template <class Archive>
+void openMVG::sfm::ViewPriors::save( Archive & ar ) const
+{
+  View::save(ar);
+
+  // Pose center prior
+  if (b_use_pose_center_)
+  {
+    ar( cereal::make_nvp( "use_pose_center_prior", b_use_pose_center_ ) );
+    const std::vector<double> vec_weights = { center_weight_( 0 ), center_weight_( 1 ), center_weight_( 2 ) };
+    ar( cereal::make_nvp( "center_weight", vec_weights ) );
+    const std::vector<double> vec = { pose_center_( 0 ), pose_center_( 1 ), pose_center_( 2 ) };
+    ar( cereal::make_nvp( "center", vec ) );
+  }
+
+  // Pose rotation prior
+  /*
+  if (b_use_pose_rotation_)
+  {
+    ar( cereal::make_nvp( "use_pose_rotation_prior", b_use_pose_rotation_ ) );
+    ar( cereal::make_nvp( "rotation_weight", rotation_weight_ ) );
+    const std::vector<std::vector<double>> mat =
+    {
+      { pose_rotation_( 0, 0 ), pose_rotation_( 0, 1 ), pose_rotation_( 0, 2 ) },
+      { pose_rotation_( 1, 0 ), pose_rotation_( 1, 1 ), pose_rotation_( 1, 2 ) },
+      { pose_rotation_( 2, 0 ), pose_rotation_( 2, 1 ), pose_rotation_( 2, 2 ) }
+    };
+    ar( cereal::make_nvp( "rotation", mat ) );
+  }
+  */
+}
+
+template <class Archive>
+void openMVG::sfm::ViewPriors::load( Archive & ar )
+{
+  View::load(ar);
+
+  // Pose center prior
+  try
+  {
+    ar( cereal::make_nvp( "use_pose_center_prior", b_use_pose_center_ ) );
+    std::vector<double> vec( 3 );
+    ar( cereal::make_nvp( "center_weight", vec ) );
+    center_weight_ = Eigen::Map<const Vec3>( &vec[0] );
+    ar( cereal::make_nvp( "center", vec ) );
+    pose_center_ = Eigen::Map<const Vec3>( &vec[0] );
+  }
+  catch( cereal::Exception e )
+  {
+    // if it fails just use a default settings
+    b_use_pose_center_ = false;
+  }
+
+  // Pose rotation prior
+  /*
+  try
+  {
+    ar( cereal::make_nvp( "use_pose_rotation_prior", b_use_pose_rotation_ ) );
+    ar( cereal::make_nvp( "rotation_weight", rotation_weight_ ) );
+    std::vector<std::vector<double>> mat( 3, std::vector<double>( 3 ) );
+    ar( cereal::make_nvp( "rotation", mat ) );
+    // copy back to the rotation
+    pose_rotation_.row( 0 ) = Eigen::Map<const Vec3>( &( mat[0][0] ) );
+    pose_rotation_.row( 1 ) = Eigen::Map<const Vec3>( &( mat[1][0] ) );
+    pose_rotation_.row( 2 ) = Eigen::Map<const Vec3>( &( mat[2][0] ) );
+  }
+  catch( const cereal::Exception & e )
+  {
+    // if it fails just use a default settings
+    b_use_pose_rotation_ = false;
+  }
+  */
+}
+
+CEREAL_REGISTER_TYPE_WITH_NAME( openMVG::sfm::ViewPriors, "view_priors" );
+CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::sfm::View, openMVG::sfm::ViewPriors);
+
+#endif // OPENMVG_SFM_SFM_VIEW_PRIORS_HPP

--- a/src/software/Localization/main_SfM_Localization.cpp
+++ b/src/software/Localization/main_SfM_Localization.cpp
@@ -6,9 +6,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// The <cereal/archives> headers are special and must be included first.
+#include <cereal/archives/json.hpp>
+
 #include <openMVG/sfm/sfm.hpp>
 #include <openMVG/features/feature.hpp>
-#include <openMVG/features/io_regions_type.hpp>
+#include <openMVG/features/image_describer.hpp>
 #include <openMVG/image/image_io.hpp>
 #include <software/SfM/SfMPlyHelper.hpp>
 
@@ -18,9 +21,12 @@
 using namespace openMVG;
 using namespace openMVG::sfm;
 
-#include "nonFree/sift/SIFT_describer.hpp"
+#include "nonFree/sift/SIFT_describer_io.hpp"
+#include "openMVG/features/image_describer_akaze_io.hpp"
+
 #include "third_party/cmdLine/cmdLine.h"
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
 
 #include <cstdlib>
 

--- a/src/software/SfM/main_ComputeFeatures.cpp
+++ b/src/software/SfM/main_ComputeFeatures.cpp
@@ -6,9 +6,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "openMVG/features/image_describer_akaze.hpp"
-#include "openMVG/features/io_regions_type.hpp"
-#include "openMVG/features/sift/SIFT_Anatomy_Image_Describer.hpp"
+// The <cereal/archives> headers are special and must be included first.
+#include <cereal/archives/json.hpp>
+
+#include "openMVG/features/image_describer_akaze_io.hpp"
+
+#include "openMVG/features/sift/SIFT_Anatomy_Image_Describer_io.hpp"
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/sfm/sfm_data_io.hpp"
@@ -18,9 +21,8 @@
 #include "third_party/progress/progress_display.hpp"
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
-#include "nonFree/sift/SIFT_describer.hpp"
+#include "nonFree/sift/SIFT_describer_io.hpp"
 
-#include <cereal/archives/json.hpp>
 #include <cereal/details/helpers.hpp>
 
 #include <cstdlib>

--- a/src/software/SfM/main_ComputeFeatures_OpenCV.cpp
+++ b/src/software/SfM/main_ComputeFeatures_OpenCV.cpp
@@ -6,10 +6,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// The <cereal/archives> headers are special and must be included first.
+#include <cereal/archives/json.hpp>
+
 #include "openMVG/features/io_regions_type.hpp"
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/sfm/sfm.hpp"
-#include <cereal/archives/json.hpp>
 #include "openMVG/system/timer.hpp"
 
 #include "third_party/cmdLine/cmdLine.h"
@@ -131,7 +133,6 @@ public:
 };
 #include <cereal/cereal.hpp>
 #include <cereal/types/polymorphic.hpp>
-#include <cereal/archives/json.hpp>
 CEREAL_REGISTER_TYPE_WITH_NAME(AKAZE_OCV_Image_describer, "AKAZE_OCV_Image_describer");
 CEREAL_REGISTER_POLYMORPHIC_RELATION(openMVG::features::Image_describer, AKAZE_OCV_Image_describer)
 

--- a/src/software/SfM/main_ComputeMatches.cpp
+++ b/src/software/SfM/main_ComputeMatches.cpp
@@ -10,7 +10,6 @@
 #include "openMVG/features/descriptor.hpp"
 #include "openMVG/features/feature.hpp"
 #include "openMVG/features/image_describer_akaze.hpp"
-#include "openMVG/features/io_regions_type.hpp"
 #include "openMVG/matching/indMatch.hpp"
 #include "openMVG/matching/indMatch_utils.hpp"
 #include "openMVG/matching_image_collection/Matcher_Regions.hpp"

--- a/src/software/SfM/main_ComputeStructureFromKnownPoses.cpp
+++ b/src/software/SfM/main_ComputeStructureFromKnownPoses.cpp
@@ -8,7 +8,6 @@
 
 #include "openMVG/cameras/Camera_Common.hpp"
 #include "openMVG/features/feature.hpp"
-#include "openMVG/features/io_regions_type.hpp"
 #include "openMVG/features/svg_features.hpp"
 #include "openMVG/geometry/frustum.hpp"
 #include "openMVG/matching/indMatch.hpp"

--- a/src/software/SfM/main_GlobalSfM.cpp
+++ b/src/software/SfM/main_GlobalSfM.cpp
@@ -8,7 +8,6 @@
 
 #include "openMVG/cameras/Camera_Common.hpp"
 #include "openMVG/cameras/Cameras_Common_command_line_helper.hpp"
-#include "openMVG/features/io_regions_type.hpp"
 #include "openMVG/sfm/pipelines/global/GlobalSfM_rotation_averaging.hpp"
 #include "openMVG/sfm/pipelines/global/GlobalSfM_translation_averaging.hpp"
 #include "openMVG/sfm/pipelines/global/sfm_global_engine_relative_motions.hpp"

--- a/src/software/SfM/main_IncrementalSfM.cpp
+++ b/src/software/SfM/main_IncrementalSfM.cpp
@@ -8,7 +8,6 @@
 
 #include "openMVG/cameras/Camera_Common.hpp"
 #include "openMVG/cameras/Cameras_Common_command_line_helper.hpp"
-#include "openMVG/features/io_regions_type.hpp"
 #include "openMVG/sfm/pipelines/sequential/sequential_SfM.hpp"
 #include "openMVG/sfm/pipelines/sfm_features_provider.hpp"
 #include "openMVG/sfm/pipelines/sfm_matches_provider.hpp"

--- a/src/software/SfM/main_exportKeypoints.cpp
+++ b/src/software/SfM/main_exportKeypoints.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "openMVG/features/io_regions_type.hpp"
 #include "openMVG/features/svg_features.hpp"
 #include "openMVG/image/image_io.hpp"
 #include "openMVG/sfm/pipelines/sfm_features_provider.hpp"
@@ -24,7 +23,6 @@
 #include <string>
 
 using namespace openMVG;
-using namespace openMVG::matching;
 using namespace openMVG::sfm;
 
 int main(int argc, char ** argv)

--- a/src/software/SfM/main_exportMatches.cpp
+++ b/src/software/SfM/main_exportMatches.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "openMVG/features/io_regions_type.hpp"
 #include "openMVG/matching/indMatch.hpp"
 #include "openMVG/matching/indMatch_utils.hpp"
 #include "openMVG/matching/svg_matches.hpp"

--- a/src/software/SfM/main_exportTracks.cpp
+++ b/src/software/SfM/main_exportTracks.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "openMVG/features/io_regions_type.hpp"
 #include "openMVG/matching/indMatch.hpp"
 #include "openMVG/matching/indMatch_utils.hpp"
 #include "openMVG/matching/svg_matches.hpp"

--- a/src/software/VO/Monocular_VO.hpp
+++ b/src/software/VO/Monocular_VO.hpp
@@ -11,6 +11,7 @@
 
 #include <deque>
 #include <set>
+#include <numeric>
 
 #include "openMVG/features/feature.hpp"
 #include "openMVG/image/image_container.hpp"


### PR DESCRIPTION
This PR moves all referencences to cereal to separate header files with the name `'<class name>_io.hpp'`. It is a different approach than https://github.com/openMVG/openMVG/pull/903, but seems to achieve a similar improvement in compilation time. ([1h48](https://travis-ci.org/bjornpiltz/openMVG/builds/230309313) -> [56](https://travis-ci.org/bjornpiltz/openMVG/builds/230325788))

Compilation time for all libs, test, examples & exes in minutes (user+sys):
![image](https://cloud.githubusercontent.com/assets/1873764/25852028/48abed92-34c8-11e7-8d9d-9554c12d0572.png)

The new way for developers to serialize openMVG classes is like this:

```
// First include the archive type(s) you need.
#include <cereal/archives/json.hpp>

// Then include the file suffixed '_io.hpp'.
#include "openMVG/cameras/cameras_io.hpp"

// Now you can serialize:
void load()
{
  std::shared_ptr<IntrinsicBase> intrinsic(nullptr);
  std::ifstream stream(filename, std::ios::binary | std::ios::in);
  cereal::JSONInputArchive archive(stream);
  archive(cereal::make_nvp("intrinsics", intrinsic));
}
```
Including 'cameras.hpp' instead of 'cameras_io.hpp' will generate the error `cereal could not find any input serialization functions for the provided type and archive combination.`