### PR TITLE
Added camera sensor width for Motorola G4 Plus

### DIFF
--- a/src/openMVG/exif/sensor_width_database/sensor_width_camera_database.txt
+++ b/src/openMVG/exif/sensor_width_database/sensor_width_camera_database.txt
@@ -1585,6 +1585,7 @@ Minox DD1 Diamond;6.4
 Minox DC 3311;7.11
 Minox DC 2111;5.33
 Minox DC 1311;5.33
+Moto G (4);6.06
 XT1033;3.8
 Nikon Coolpix A;23.6
 Nikon Coolpix P330;7.53


### PR DESCRIPTION
Added camera sensor width for Motorola G4 Plus

Reference: http://www.devicespecifications.com/en/model/54ab3c09

Tested this with photos taken from my Moto G4 Plus phone. Works good. The pictures had EXIF data as

    Make: Motorola
    Model: Moto G (4)