### PR TITLE
[travis_ci] add nvidia_cuda_toolkit to the build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ addons:
       - libxxf86vm-dev
       - x11proto-xf86vidmode-dev
       - libxrandr-dev
+      - nvidia-cuda-toolkit
 
 env:
   global:


### PR DESCRIPTION
Adding CUDA to the Travis CI build scripts.

**Warning:** while compiling CUDA code within a virtual machine running on Travis CI proves to be feasible, CUDA code cannot be run due to a lack of hardware.