### PR TITLE
Add Incremental Matching

### DIFF
--- a/src/openMVG/matching_image_collection/Pair_Builder.hpp
+++ b/src/openMVG/matching_image_collection/Pair_Builder.hpp
@@ -45,10 +45,10 @@ inline Pair_Set contiguousWithOverlap(const size_t N, const size_t overlapSize)
 }
 
 /// Removes pairs when both indices are contained in matches 
-inline Pair_Set filterAnalyzedPairs(const Pair_Set &pairs, const matching::PairWiseMatches &matches, const size_t N)
+inline Pair_Set filterAnalyzedPairs(const Pair_Set &pairs, const matching::PairWiseMatches &matches)
 {
   Pair_Set filtered_pairs;
-  std::vector<bool> contained(N, false);
+  std::vector<bool> contained(matches.size(), false);
 
   for ( const auto & cur_match : matches ) {
     size_t left = cur_match.first.first;

--- a/src/openMVG/matching_image_collection/Pair_Builder.hpp
+++ b/src/openMVG/matching_image_collection/Pair_Builder.hpp
@@ -51,8 +51,8 @@ inline Pair_Set filterAnalyzedPairs(const Pair_Set &pairs, const matching::PairW
   std::vector<bool> contained(matches.size(), false);
 
   for ( const auto & cur_match : matches ) {
-    size_t left = cur_match.first.first;
-    size_t right = cur_match.first.second;
+    const IndexT left = cur_match.first.first;
+    const IndexT right = cur_match.first.second;
     contained[left] = true;
     contained[right] = true;
   }

--- a/src/openMVG/matching_image_collection/Pair_Builder.hpp
+++ b/src/openMVG/matching_image_collection/Pair_Builder.hpp
@@ -18,6 +18,7 @@
 
 #include "openMVG/types.hpp"
 #include "openMVG/stl/split.hpp"
+#include "openMVG/matching/indMatch.hpp"
 
 namespace openMVG {
 
@@ -41,6 +42,27 @@ inline Pair_Set contiguousWithOverlap(const size_t N, const size_t overlapSize)
     for (IndexT J = I+1; J < I+1+overlapSize && J < static_cast<IndexT>(N); ++J)
       pairs.insert({I,J});
   return pairs;
+}
+
+/// Removes pairs when both indices are contained in matches 
+inline Pair_Set filterAnalyzedPairs(const Pair_Set &pairs, const matching::PairWiseMatches &matches, const size_t N)
+{
+  Pair_Set filtered_pairs;
+  std::vector<bool> contained(N, false);
+
+  for ( const auto & cur_match : matches ) {
+    size_t left = cur_match.first.first;
+    size_t right = cur_match.first.second;
+    contained[left] = true;
+    contained[right] = true;
+  }
+
+  for ( const auto & cur_pair : pairs ) {
+    if (!contained[cur_pair.first] || !contained[cur_pair.second]) {
+      filtered_pairs.insert({cur_pair.first, cur_pair.second});
+    }
+  }
+  return filtered_pairs;
 }
 
 /// Load a set of Pair_Set from a file

--- a/src/software/SfM/main_ComputeMatches.cpp
+++ b/src/software/SfM/main_ComputeMatches.cpp
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
       << "[-f|--force] Force to recompute data]\n"
       << "   0: (default) reload previously computed data\n"
       << "   1: force to recompute matches and save them\n"
-      << "   2: compute matches only with views not present in prevously computed matches\n"
+      << "   2: compute matches only with views not present in previously computed matches\n"
       << "[-r|--ratio] Distance ratio to discard non meaningful matches\n"
       << "   0.8: (default).\n"
       << "[-g|--geometric_model]\n"

--- a/src/software/SfM/main_ComputeMatches.cpp
+++ b/src/software/SfM/main_ComputeMatches.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
   int iMatchingVideoMode = -1;
   std::string sPredefinedPairList = "";
   std::string sNearestMatchingMethod = "AUTO";
-  bool bForce = false;
+  int bForce = 0;
   bool bGuided_matching = false;
   int imax_iteration = 2048;
   unsigned int ui_max_cache_size = 0;
@@ -102,6 +102,9 @@ int main(int argc, char **argv)
       << "[-o|--out_dir path] output path where computed are stored\n"
       << "\n[Optional]\n"
       << "[-f|--force] Force to recompute data]\n"
+      << "   0: (default) reload previously computed data\n"
+      << "   1: force to recompute matches and save them\n"
+      << "   2: compute matches only with views not present in prevously computed matches\n"
       << "[-r|--ratio] Distance ratio to discard non meaningful matches\n"
       << "   0.8: (default).\n"
       << "[-g|--geometric_model]\n"
@@ -360,6 +363,25 @@ int main(int argc, char **argv)
           }
           break;
       }
+
+      // checks incremental matches conditions
+      if (
+        bForce == 2 && (stlplus::file_exists(sMatchesDirectory + "/matches.putative.txt")
+                        || stlplus::file_exists(sMatchesDirectory + "/matches.putative.bin"))
+      )
+      {
+        if (
+          !(Load(map_PutativesMatches, sMatchesDirectory + "/matches.putative.bin") ||
+                          Load(map_PutativesMatches, sMatchesDirectory + "/matches.putative.txt"))
+        )
+        {
+          std::cerr << "Cannot load input matches file, recompute all.";
+        } else {
+          // removes pairs containing views already matched
+          pairs = filterAnalyzedPairs(pairs, map_PutativesMatches, sfm_data.GetViews().size());   // code in Pair_Builder.hpp
+        }
+      }
+
       // Photometric matching of putative pairs
       collectionMatcher->Match(sfm_data, regions_provider, pairs, map_PutativesMatches, &progress);
       //---------------------------------------


### PR DESCRIPTION
Hello,
I add the possibility to compute the matches incrementally.
It starts from a set of matches, otherwise it just computes all of them, and from them it computes the missing ones.
A match is computed only if at least one of the two views involved is not present in any of the pre-computed match.