### PR TITLE
Fix Eigen static assert in InterfaceMVS.h

### DIFF
--- a/src/software/SfM/InterfaceMVS.h
+++ b/src/software/SfM/InterfaceMVS.h
@@ -46,9 +46,9 @@ public:
 	typedef Eigen::Map<const EMat> CEMatMap;
 	typedef Eigen::Map<EMat> EMatMap;
 	template<typename Derived>
-	inline Matx(const Eigen::EigenBase<Derived>& rhs) { operator EMatMap () = rhs; }
+	inline Matx(const Eigen::DenseBase<Derived>& rhs) { operator EMatMap () = rhs; }
 	template<typename Derived>
-	inline Matx& operator = (const Eigen::EigenBase<Derived>& rhs) { operator EMatMap () = rhs; return *this; }
+	inline Matx& operator = (const Eigen::DenseBase<Derived>& rhs) { operator EMatMap () = rhs; return *this; }
 	inline operator CEMatMap() const { return CEMatMap((const Type*)val); }
 	inline operator EMatMap () { return EMatMap((Type*)val); }
 	#endif
@@ -78,9 +78,9 @@ public:
 	typedef Eigen::Matrix<Type,3,1> EVec;
 	typedef Eigen::Map<EVec> EVecMap;
 	template<typename Derived>
-	inline Point3_(const Eigen::EigenBase<Derived>& rhs) { operator EVecMap () = rhs; }
+	inline Point3_(const Eigen::DenseBase<Derived>& rhs) { operator EVecMap () = rhs; }
 	template<typename Derived>
-	inline Point3_& operator = (const Eigen::EigenBase<Derived>& rhs) { operator EVecMap () = rhs; return *this; }
+	inline Point3_& operator = (const Eigen::DenseBase<Derived>& rhs) { operator EVecMap () = rhs; return *this; }
 	inline operator const EVecMap () const { return EVecMap((Type*)this); }
 	inline operator EVecMap () { return EVecMap((Type*)this); }
 	#endif


### PR DESCRIPTION
While attempting to compile openMVG 1.2 with external Eigen 3.2.9, I got the following error:

```
/home/user/dev/include/eigen3/Eigen/src/Core/DenseBase.h: In instantiation of ‘void Eigen::DenseBase<Derived>::evalTo(Dest&) const [with Dest = Eigen::Map<Eigen::Matrix<float, 3, 1>, 0, Eigen::Stride<0, 0> >; Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, float>, const Eigen::Matrix<double, 3, 1> >]’:
/home/user/dev/include/eigen3/Eigen/src/Core/Assign.h:529:101:   required from ‘static Derived& Eigen::internal::assign_selector<Derived, OtherDerived, false, false>::evalTo(ActualDerived&, const ActualOtherDerived&) [with ActualDerived = Eigen::Map<Eigen::Matrix<float, 3, 1>, 0, Eigen::Stride<0, 0> >; ActualOtherDerived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, float>, const Eigen::Matrix<double, 3, 1> >; Derived = Eigen::Map<Eigen::Matrix<float, 3, 1>, 0, Eigen::Stride<0, 0> >; OtherDerived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, float>, const Eigen::Matrix<double, 3, 1> >]’
/home/user/dev/include/eigen3/Eigen/src/Core/Assign.h:578:71:   required from ‘Derived& Eigen::MatrixBase<Derived>::operator=(const Eigen::EigenBase<OtherDerived>&) [with OtherDerived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, float>, const Eigen::Matrix<double, 3, 1> >; Derived = Eigen::Map<Eigen::Matrix<float, 3, 1>, 0, Eigen::Stride<0, 0> >]’
/home/user/src/openmvg/src/software/SfM/InterfaceMVS.h:83:90:   required from ‘cv::Point3_<Type>& cv::Point3_<Type>::operator=(const Eigen::EigenBase<OtherDerived>&) [with Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, float>, const Eigen::Matrix<double, 3, 1> >; Type = float]’
/home/user/src/openmvg/src/software/SfM/main_openMVG2openMVS.cpp:151:12:   required from here
/home/user/dev/include/eigen3/Eigen/src/Core/util/StaticAssert.h:32:40: error: static assertion failed: THE_EVAL_EVALTO_FUNCTION_SHOULD_NEVER_BE_CALLED_FOR_DENSE_OBJECTS
     #define EIGEN_STATIC_ASSERT(X,MSG) static_assert(X,#MSG);
                                        ^
/home/user/dev/include/eigen3/Eigen/src/Core/DenseBase.h:496:7: note: in expansion of macro ‘EIGEN_STATIC_ASSERT’
       EIGEN_STATIC_ASSERT((internal::is_same<Dest,void>::value),THE_EVAL_EVALTO_FUNCTION_SHOULD_NEVER_BE_CALLED_FOR_DENSE_OBJECTS);
       ^
```
This MR solves this, based on [this SO question](https://stackoverflow.com/questions/23544049/compile-time-error-from-eigen-the-eval-evalto-function-should-never-be-called-f).

This is related to #980.