### PR TITLE
fixing sfm_data.hpp include error when using openMVG as a third_party

### DIFF
--- a/src/openMVG/sfm/pipelines/global/sfm_global_engine_relative_motions.cpp
+++ b/src/openMVG/sfm/pipelines/global/sfm_global_engine_relative_motions.cpp
@@ -31,6 +31,7 @@
 
 #include "third_party/histogram/histogram.hpp"
 #include "third_party/htmlDoc/htmlDoc.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <ceres/types.h>
 

--- a/src/openMVG/sfm/pipelines/sfm_features_provider.hpp
+++ b/src/openMVG/sfm/pipelines/sfm_features_provider.hpp
@@ -19,6 +19,7 @@
 #include "openMVG/types.hpp"
 
 #include "third_party/progress/progress_display.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 namespace openMVG {
 namespace sfm {

--- a/src/openMVG/sfm/pipelines/sfm_matches_provider.hpp
+++ b/src/openMVG/sfm/pipelines/sfm_matches_provider.hpp
@@ -16,6 +16,8 @@
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/types.hpp"
 
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
 namespace openMVG {
 namespace sfm {
 

--- a/src/openMVG/sfm/pipelines/sfm_regions_provider.hpp
+++ b/src/openMVG/sfm/pipelines/sfm_regions_provider.hpp
@@ -19,6 +19,7 @@
 #include "openMVG/types.hpp"
 
 #include "third_party/progress/progress.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 namespace openMVG {
 namespace sfm {

--- a/src/openMVG/sfm/sfm_data_io_baf.hpp
+++ b/src/openMVG/sfm/sfm_data_io_baf.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "openMVG/sfm/sfm_data_io.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 namespace openMVG {
 namespace sfm {

--- a/src/openMVG/sfm/sfm_data_io_cereal.cpp
+++ b/src/openMVG/sfm/sfm_data_io_cereal.cpp
@@ -21,6 +21,7 @@
 #include "openMVG/sfm/sfm_view_io.hpp"
 #include "openMVG/sfm/sfm_view_priors_io.hpp"
 #include "openMVG/types.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <fstream>
 #include <string>

--- a/src/openMVG/sfm/sfm_view.hpp
+++ b/src/openMVG/sfm/sfm_view.hpp
@@ -13,7 +13,6 @@
 
 #include "openMVG/types.hpp"
 
-#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 namespace openMVG {
 namespace sfm {

--- a/src/openMVG/sfm/sfm_view_io.hpp
+++ b/src/openMVG/sfm/sfm_view_io.hpp
@@ -10,6 +10,7 @@
 #define OPENMVG_SFM_SFM_VIEW_IO_HPP
 
 #include "openMVG/sfm/sfm_view.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <cereal/types/polymorphic.hpp>
 

--- a/src/software/SfM/main_ExportUndistortedImages.cpp
+++ b/src/software/SfM/main_ExportUndistortedImages.cpp
@@ -14,6 +14,7 @@
 
 #include "third_party/cmdLine/cmdLine.h"
 #include "third_party/progress/progress_display.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <cstdlib>
 #include <string>

--- a/src/software/SfM/main_openMVG2CMPMVS.cpp
+++ b/src/software/SfM/main_openMVG2CMPMVS.cpp
@@ -19,6 +19,7 @@ using namespace openMVG::sfm;
 
 #include "third_party/cmdLine/cmdLine.h"
 #include "third_party/progress/progress_display.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <cstdlib>
 #include <cmath>

--- a/src/software/SfMWebGLViewer/openMVG_main_openMVG2WebGL.cpp
+++ b/src/software/SfMWebGLViewer/openMVG_main_openMVG2WebGL.cpp
@@ -18,6 +18,7 @@
 
 #include "third_party/cmdLine/cmdLine.h"
 #include "third_party/progress/progress_display.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
Hi,
This PR request corresponds to my issue #1092 where I wasn't able to include sfm_data.hpp header because it loads a header that includes a third_party library header which can't be found.

So to fix this problem, I decided to move the inclusion of "file_system.hpp" to source files that are compiled in libraries.

I also found that many source files didn't include the header because they were available in sfm_view.hpp.
I think this could cause problems when such API files are changed.

This PR helps in cleaning up the API headers such as "sfm_data.hpp" and "sfm_data_io.hpp" which can be used without any problems.

Thanks for your time :D