### PR TITLE
shorten names of sample programs

### DIFF
--- a/src/openMVG_Samples/cameras_undisto_Brown/CMakeLists.txt
+++ b/src/openMVG_Samples/cameras_undisto_Brown/CMakeLists.txt
@@ -1,9 +1,9 @@
 
-add_executable(openMVG_sample_cameras_undistoBrown undistoBrown.cpp)
-target_link_libraries(openMVG_sample_cameras_undistoBrown
+add_executable(OMVGsmpl_camUndistBrown undistoBrown.cpp)
+target_link_libraries(OMVGsmpl_camUndistBrown
   openMVG_geometry
   openMVG_image
   openMVG_multiview
   stlplus
   ${CERES_LIBRARIES})
-set_property(TARGET openMVG_sample_cameras_undistoBrown PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_camUndistBrown PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/describe_and_match_GUI/CMakeLists.txt
+++ b/src/openMVG_Samples/describe_and_match_GUI/CMakeLists.txt
@@ -14,17 +14,17 @@ if (OpenMVG_BUILD_GUI_SOFTWARES)
     set( FEATURES_PAIR_DEMO_HDRS ImageView.hpp MainWindow.hpp )
 
     if( APPLE )
-      add_executable( openMVG_sample_describe_and_match_GUI MACOSX_BUNDLE ${FEATURES_PAIR_DEMO_SRCS} ${FEATURES_PAIR_DEMO_HDRS} )
-      set_target_properties(openMVG_sample_describe_and_match_GUI PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in)
+      add_executable( OMVGsmpl_descrMatchGUI MACOSX_BUNDLE ${FEATURES_PAIR_DEMO_SRCS} ${FEATURES_PAIR_DEMO_HDRS} )
+      set_target_properties(OMVGsmpl_descrMatchGUI PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in)
     else( APPLE )
-      add_executable( openMVG_sample_describe_and_match_GUI WIN32 ${FEATURES_PAIR_DEMO_SRCS} ${FEATURES_PAIR_DEMO_HDRS} )
+      add_executable( OMVGsmpl_descrMatchGUI WIN32 ${FEATURES_PAIR_DEMO_SRCS} ${FEATURES_PAIR_DEMO_HDRS} )
     endif( APPLE )
 
-    target_link_libraries( openMVG_sample_describe_and_match_GUI Qt5::Widgets openMVG_features openMVG_image openMVG_matching vlsift )
+    target_link_libraries( OMVGsmpl_descrMatchGUI Qt5::Widgets openMVG_features openMVG_image openMVG_matching vlsift )
 
-    set_target_properties( openMVG_sample_describe_and_match_GUI PROPERTIES CXX_STANDARD 11)
+    set_target_properties( OMVGsmpl_descrMatchGUI PROPERTIES CXX_STANDARD 11)
 
-    set_property(TARGET openMVG_sample_describe_and_match_GUI PROPERTY FOLDER OpenMVG/Samples)
+    set_property(TARGET OMVGsmpl_descrMatchGUI PROPERTY FOLDER OpenMVG/Samples)
 
   endif(Qt5Widgets_FOUND)
 

--- a/src/openMVG_Samples/features_affine_demo/CMakeLists.txt
+++ b/src/openMVG_Samples/features_affine_demo/CMakeLists.txt
@@ -1,10 +1,10 @@
 
-add_executable(openMVG_sample_features_affine features_affine_demo.cpp)
-target_link_libraries(openMVG_sample_features_affine
+add_executable(OMVGsmpl_featAffine features_affine_demo.cpp)
+target_link_libraries(OMVGsmpl_featAffine
   openMVG_image
   openMVG_features
   openMVG_system
   stlplus)
-target_compile_definitions(openMVG_sample_features_affine
+target_compile_definitions(OMVGsmpl_featAffine
     PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_features_affine PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_featAffine PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/features_image_matching/CMakeLists.txt
+++ b/src/openMVG_Samples/features_image_matching/CMakeLists.txt
@@ -1,12 +1,12 @@
 
-add_executable(openMVG_sample_image_matching describe_and_match.cpp)
-target_link_libraries(openMVG_sample_image_matching
+add_executable(OMVGsmpl_imgMatching describe_and_match.cpp)
+target_link_libraries(OMVGsmpl_imgMatching
   openMVG_image
   openMVG_features
   openMVG_matching
   stlplus
   vlsift)
-target_compile_definitions(openMVG_sample_image_matching
+target_compile_definitions(OMVGsmpl_imgMatching
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
-set_property(TARGET openMVG_sample_image_matching PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_imgMatching PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/features_kvld_filter/CMakeLists.txt
+++ b/src/openMVG_Samples/features_kvld_filter/CMakeLists.txt
@@ -1,12 +1,12 @@
 
-add_executable(openMVG_sample_features_kvld kvld_filter.cpp)
-target_link_libraries(openMVG_sample_features_kvld
+add_executable(OMVGsmpl_featKvld kvld_filter.cpp)
+target_link_libraries(OMVGsmpl_featKvld
   openMVG_image
   openMVG_multiview
   openMVG_kvld
   openMVG_features
   openMVG_matching
   stlplus)
-target_compile_definitions(openMVG_sample_features_kvld
+target_compile_definitions(OMVGsmpl_featKvld
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_features_kvld PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_featKvld PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/features_repeatability/CMakeLists.txt
+++ b/src/openMVG_Samples/features_repeatability/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-add_executable(openMVG_sample_main_features_repeatability_dataset main_repeatability_dataset.cpp)
-target_link_libraries(openMVG_sample_main_features_repeatability_dataset
+add_executable(OMVGsmpl_mainFeatRepeatDataset main_repeatability_dataset.cpp)
+target_link_libraries(OMVGsmpl_mainFeatRepeatDataset
   openMVG_image
   openMVG_features
   openMVG_matching
@@ -9,4 +9,4 @@ target_link_libraries(openMVG_sample_main_features_repeatability_dataset
   vlsift
   stlplus)
 
-set_property(TARGET openMVG_sample_main_features_repeatability_dataset PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_mainFeatRepeatDataset PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/features_siftPutativeMatches/CMakeLists.txt
+++ b/src/openMVG_Samples/features_siftPutativeMatches/CMakeLists.txt
@@ -1,10 +1,10 @@
 
-add_executable(openMVG_sample_features_siftPutative siftmatch.cpp)
-target_link_libraries(openMVG_sample_features_siftPutative
+add_executable(OMVGsmpl_featSiftPutative siftmatch.cpp)
+target_link_libraries(OMVGsmpl_featSiftPutative
   openMVG_image
   openMVG_features
   openMVG_matching
   stlplus)
-target_compile_definitions(openMVG_sample_features_siftPutative
+target_compile_definitions(OMVGsmpl_featSiftPutative
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_features_siftPutative PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_featSiftPutative PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/geodesy_show_exif_gps_position/CMakeLists.txt
+++ b/src/openMVG_Samples/geodesy_show_exif_gps_position/CMakeLists.txt
@@ -1,8 +1,8 @@
 
-add_executable(openMVG_sample_geodesy_show_exif_gps_position show_exif_gps_position_demo.cpp)
-target_link_libraries(openMVG_sample_geodesy_show_exif_gps_position
+add_executable(OMVGsmpl_geoShowExifGps show_exif_gps_position_demo.cpp)
+target_link_libraries(OMVGsmpl_geoShowExifGps
   easyexif
   stlplus)
-target_compile_definitions(openMVG_sample_geodesy_show_exif_gps_position
+target_compile_definitions(OMVGsmpl_geoShowExifGps
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_geodesy_show_exif_gps_position PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_geoShowExifGps PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/image_spherical_to_pinholes/CMakeLists.txt
+++ b/src/openMVG_Samples/image_spherical_to_pinholes/CMakeLists.txt
@@ -1,8 +1,8 @@
 
-add_executable(openMVG_sample_pano_converter main_pano_converter.cpp)
-target_link_libraries(openMVG_sample_pano_converter
+add_executable(OMVGsampl_panoConv main_pano_converter.cpp)
+target_link_libraries(OMVGsampl_panoConv
   openMVG_numeric
   openMVG_image
   stlplus)
 
-set_property(TARGET openMVG_sample_pano_converter PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsampl_panoConv PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/image_undistort_gui/CMakeLists.txt
+++ b/src/openMVG_Samples/image_undistort_gui/CMakeLists.txt
@@ -9,8 +9,8 @@ if( Qt5Widgets_FOUND )
   set( OPENMVG_SAMPLE_IMAGE_UNDISTORT_SRCS main.cc MainWindow.cc QImageInterface.cc )
   set( OPENMVG_SAMPLE_IMAGE_UNDISTORT_HDRS MainWindow.hh QImageInterface.hh )
 
-  add_executable( openMVG_sample_image_undistort ${OPENMVG_SAMPLE_IMAGE_UNDISTORT_SRCS} ${OPENMVG_SAMPLE_IMAGE_UNDISTORT_HDRS})
-  target_link_libraries( openMVG_sample_image_undistort Qt5::Widgets openMVG_image openMVG_multiview )
+  add_executable( OMVGsampl_imgUndistort ${OPENMVG_SAMPLE_IMAGE_UNDISTORT_SRCS} ${OPENMVG_SAMPLE_IMAGE_UNDISTORT_HDRS})
+  target_link_libraries( OMVGsampl_imgUndistort Qt5::Widgets openMVG_image openMVG_multiview )
 
-   set_property(TARGET openMVG_sample_image_undistort PROPERTY CXX_STANDARD 11)
+   set_property(TARGET OMVGsampl_imgUndistort PROPERTY CXX_STANDARD 11)
 endif( Qt5Widgets_FOUND)

--- a/src/openMVG_Samples/multiview_robust_essential/CMakeLists.txt
+++ b/src/openMVG_Samples/multiview_robust_essential/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-add_executable(openMVG_sample_multiview_robustEssential robust_essential.cpp)
-target_link_libraries(openMVG_sample_multiview_robustEssential
+add_executable(OMVGsmpl_mvRobustEssential robust_essential.cpp)
+target_link_libraries(OMVGsmpl_mvRobustEssential
   openMVG_image
   openMVG_multiview
   openMVG_system
@@ -8,6 +8,6 @@ target_link_libraries(openMVG_sample_multiview_robustEssential
   openMVG_geometry
   openMVG_matching
   openMVG_sfm)
-target_compile_definitions(openMVG_sample_multiview_robustEssential
+target_compile_definitions(OMVGsmpl_mvRobustEssential
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_multiview_robustEssential PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_mvRobustEssential PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/multiview_robust_essential_ba/CMakeLists.txt
+++ b/src/openMVG_Samples/multiview_robust_essential_ba/CMakeLists.txt
@@ -1,12 +1,12 @@
 
-add_executable(openMVG_sample_multiview_robustEssential_ba robust_essential_ba.cpp)
-target_link_libraries(openMVG_sample_multiview_robustEssential_ba
+add_executable(OMVGsmpl_mvRobustEssentialBA robust_essential_ba.cpp)
+target_link_libraries(OMVGsmpl_mvRobustEssentialBA
   openMVG_image
   openMVG_features
   openMVG_matching
   openMVG_system
   openMVG_sfm
   stlplus)
-target_compile_definitions(openMVG_sample_multiview_robustEssential_ba
+target_compile_definitions(OMVGsmpl_mvRobustEssentialBA
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_multiview_robustEssential_ba PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_mvRobustEssentialBA PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/multiview_robust_essential_spherical/CMakeLists.txt
+++ b/src/openMVG_Samples/multiview_robust_essential_spherical/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-add_executable(openMVG_sample_multiview_robustEssential_spherical robust_essential_spherical.cpp)
-target_link_libraries(openMVG_sample_multiview_robustEssential_spherical
+add_executable(OMVGsmpl_mvRobustEssentialSpherical robust_essential_spherical.cpp)
+target_link_libraries(OMVGsmpl_mvRobustEssentialSpherical
   openMVG_image
   openMVG_multiview
   openMVG_features
@@ -8,6 +8,6 @@ target_link_libraries(openMVG_sample_multiview_robustEssential_spherical
   openMVG_system
   openMVG_sfm
   stlplus)
-target_compile_definitions(openMVG_sample_multiview_robustEssential_spherical
+target_compile_definitions(OMVGsmpl_mvRobustEssentialSpherical
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_multiview_robustEssential_spherical PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_mvRobustEssentialSpherical PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/multiview_robust_estimation_tutorial/CMakeLists.txt
+++ b/src/openMVG_Samples/multiview_robust_estimation_tutorial/CMakeLists.txt
@@ -1,11 +1,11 @@
 
-add_executable(openMVG_sample_robust_estimation_Homography robust_estimation_tutorial_homography.cpp)
-target_link_libraries(openMVG_sample_robust_estimation_Homography
+add_executable(OMVGsmpl_robustEstHomography robust_estimation_tutorial_homography.cpp)
+target_link_libraries(OMVGsmpl_robustEstHomography
   openMVG_image
   openMVG_multiview
   openMVG_features
   openMVG_matching
   stlplus)
-target_compile_definitions(openMVG_sample_robust_estimation_Homography
+target_compile_definitions(OMVGsmpl_robustEstHomography
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_robust_estimation_Homography PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_robustEstHomography PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/multiview_robust_fundamental/CMakeLists.txt
+++ b/src/openMVG_Samples/multiview_robust_fundamental/CMakeLists.txt
@@ -1,11 +1,11 @@
 
-add_executable(openMVG_sample_multiview_robustFundamental robust_fundamental.cpp)
-target_link_libraries(openMVG_sample_multiview_robustFundamental
+add_executable(OMVGsmpl_mvRobustFundamental robust_fundamental.cpp)
+target_link_libraries(OMVGsmpl_mvRobustFundamental
   openMVG_image
   openMVG_multiview
   openMVG_features
   openMVG_matching
   stlplus)
-target_compile_definitions(openMVG_sample_multiview_robustFundamental
+target_compile_definitions(OMVGsmpl_mvRobustFundamental
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_multiview_robustFundamental PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_mvRobustFundamental PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/multiview_robust_fundamental_guided/CMakeLists.txt
+++ b/src/openMVG_Samples/multiview_robust_fundamental_guided/CMakeLists.txt
@@ -1,11 +1,11 @@
 
-add_executable(openMVG_sample_multiview_robustFundamental_guided robust_fundamental_guided.cpp)
-target_link_libraries(openMVG_sample_multiview_robustFundamental_guided
+add_executable(OMVGsmpl_mvRobustFundamentalGuided robust_fundamental_guided.cpp)
+target_link_libraries(OMVGsmpl_mvRobustFundamentalGuided
   openMVG_image
   openMVG_multiview
   openMVG_features
   openMVG_matching
   stlplus)
-target_compile_definitions(openMVG_sample_multiview_robustFundamental_guided
+target_compile_definitions(OMVGsmpl_mvRobustFundamentalGuided
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_multiview_robustFundamental_guided PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_mvRobustFundamentalGuided PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/multiview_robust_homography/CMakeLists.txt
+++ b/src/openMVG_Samples/multiview_robust_homography/CMakeLists.txt
@@ -1,11 +1,11 @@
 
-add_executable(openMVG_sample_multiview_robustHomography robust_homography.cpp)
-target_link_libraries(openMVG_sample_multiview_robustHomography
+add_executable(OMVGsmpl_mvRobustHomography robust_homography.cpp)
+target_link_libraries(OMVGsmpl_mvRobustHomography
   openMVG_image
   openMVG_multiview
   openMVG_features
   openMVG_matching
   stlplus)
-target_compile_definitions(openMVG_sample_multiview_robustHomography
+target_compile_definitions(OMVGsmpl_mvRobustHomography
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_multiview_robustHomography PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_mvRobustHomography PROPERTY FOLDER OpenMVG/Samples)

--- a/src/openMVG_Samples/multiview_robust_homography_guided/CMakeLists.txt
+++ b/src/openMVG_Samples/multiview_robust_homography_guided/CMakeLists.txt
@@ -1,11 +1,11 @@
 
-add_executable(openMVG_sample_multiview_robustHomography_guided robust_homography_guided.cpp)
-target_link_libraries(openMVG_sample_multiview_robustHomography_guided
+add_executable(OMVGsmpl_mvRobustHomographyGuided robust_homography_guided.cpp)
+target_link_libraries(OMVGsmpl_mvRobustHomographyGuided
   openMVG_image
   openMVG_multiview
   openMVG_features
   openMVG_matching
   stlplus)
-target_compile_definitions(openMVG_sample_multiview_robustHomography_guided
+target_compile_definitions(OMVGsmpl_mvRobustHomographyGuided
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-set_property(TARGET openMVG_sample_multiview_robustHomography_guided PROPERTY FOLDER OpenMVG/Samples)
+set_property(TARGET OMVGsmpl_mvRobustHomographyGuided PROPERTY FOLDER OpenMVG/Samples)


### PR DESCRIPTION
The long names led to errors about path length when built on Windows.
Shortening the names allows builds even when using non-toplevel root
directories for OpenMVG.

I have to admit that the long names of the sample executables made them both unique and descriptive about what they do. However, given CMake's method of creating file and directory names during the build process led to "path too long" errors on Windows even on rather short build directory paths.

I first tried to set CMAKE_OBJECT_PATH_MAX when configuring and building, but this did not show an effect on the file paths in question.