### PR TITLE
Update geodesy.rst

### DIFF
--- a/docs/sphinx/rst/software/Geodesy/geodesy.rst
+++ b/docs/sphinx/rst/software/Geodesy/geodesy.rst
@@ -30,7 +30,7 @@ To speed up the pairwise feature matching step
 
   .. code-block:: c++
 
-    $ openMVG_main_ListMatchingPairs -G -n 5 -i Dataset/matching/sfm_data.bin -o Dataset/matching/pair_list.txt
+    $ openMVG_main_ListMatchingPairs -G -n 5 -i Dataset/matching/sfm_data.json -o Dataset/matching/pair_list.txt
 
 **Required parameters:**
 


### PR DESCRIPTION
In my test, it seems the openMVG_main_ListMatchingPairs works using sfm_data.json, instead of sfm_data.bin