### PR TITLE
fix error that cannot find lemon/config.h when use openMVG as a third party 

### DIFF
--- a/src/third_party/lemon/lemon/CMakeLists.txt
+++ b/src/third_party/lemon/lemon/CMakeLists.txt
@@ -78,7 +78,7 @@ INSTALL(
 
 INSTALL(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h
-  DESTINATION include/openMVG/third_party/lemon
+  DESTINATION include/openMVG/third_party/lemon/lemon
   COMPONENT headers
 )
 


### PR DESCRIPTION
this error is mentioned in https://github.com/openMVG/openMVG/issues/1021