### PR TITLE
remove useless argument passing

### DIFF
--- a/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions.cpp
+++ b/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions.cpp
@@ -36,7 +36,6 @@ namespace impl
 template <typename ScalarT>
 void Match
 (
-  const sfm::SfM_Data & sfm_data,
   const sfm::Regions_Provider & regions_provider,
   const Pair_Set & pairs,
   float fDistRatio,
@@ -228,7 +227,6 @@ void Match
 
 void Cascade_Hashing_Matcher_Regions::Match
 (
-  const sfm::SfM_Data & sfm_data,
   const std::shared_ptr<sfm::Regions_Provider> & regions_provider,
   const Pair_Set & pairs,
   PairWiseMatchesContainer & map_PutativesMatches, // the pairwise photometric corresponding points
@@ -247,7 +245,6 @@ void Cascade_Hashing_Matcher_Regions::Match
   if (regions_provider->Type_id() == typeid(unsigned char).name())
   {
     impl::Match<unsigned char>(
-      sfm_data,
       *regions_provider.get(),
       pairs,
       f_dist_ratio_,
@@ -258,7 +255,6 @@ void Cascade_Hashing_Matcher_Regions::Match
   if (regions_provider->Type_id() == typeid(float).name())
   {
     impl::Match<float>(
-      sfm_data,
       *regions_provider.get(),
       pairs,
       f_dist_ratio_,

--- a/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions.hpp
+++ b/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions.hpp
@@ -15,7 +15,6 @@
 
 namespace openMVG { namespace matching { class PairWiseMatchesContainer; } }
 namespace openMVG { namespace sfm { struct Regions_Provider; } }
-namespace openMVG { namespace sfm { struct SfM_Data; } }
 
 namespace openMVG {
 namespace matching_image_collection {
@@ -37,9 +36,7 @@ class Cascade_Hashing_Matcher_Regions : public Matcher
 
   /// Find corresponding points between some pair of view Ids
   void Match
-  (
-    const sfm::SfM_Data & sfm_data,
-    const std::shared_ptr<sfm::Regions_Provider> & regions_provider,
+  (const std::shared_ptr<sfm::Regions_Provider> & regions_provider,
     const Pair_Set & pairs,
     matching::PairWiseMatchesContainer & map_PutativesMatches, // the pairwise photometric corresponding points
     C_Progress * progress = nullptr

--- a/src/openMVG/matching_image_collection/GeometricFilter.hpp
+++ b/src/openMVG/matching_image_collection/GeometricFilter.hpp
@@ -19,6 +19,7 @@
 #include "third_party/progress/progress_display.hpp"
 
 namespace openMVG { namespace sfm { struct Regions_Provider; } }
+namespace openMVG { namespace sfm { class SfM_Data; } }
 
 namespace openMVG {
 

--- a/src/openMVG/matching_image_collection/Matcher.hpp
+++ b/src/openMVG/matching_image_collection/Matcher.hpp
@@ -21,7 +21,6 @@ namespace openMVG {
 
 namespace sfm {
   struct Regions_Provider;
-  struct SfM_Data;
 } // namespace sfm
 
 namespace matching_image_collection {
@@ -37,7 +36,6 @@ class Matcher
 
   /// Find corresponding points between some pair of view Ids
   virtual void Match(
-    const sfm::SfM_Data & sfm_data,
     const std::shared_ptr<sfm::Regions_Provider> & regions_provider,
     const Pair_Set & pairs, // list of pair to consider for matching
     matching::PairWiseMatchesContainer & map_putatives_matches, // the output pairwise photometric corresponding points

--- a/src/openMVG/matching_image_collection/Matcher_Regions.cpp
+++ b/src/openMVG/matching_image_collection/Matcher_Regions.cpp
@@ -26,7 +26,6 @@ Matcher_Regions::Matcher_Regions(
 }
 
 void Matcher_Regions::Match(
-  const sfm::SfM_Data & sfm_data,
   const std::shared_ptr<sfm::Regions_Provider> & regions_provider,
   const Pair_Set & pairs,
   PairWiseMatchesContainer & map_PutativesMatches,

--- a/src/openMVG/matching_image_collection/Matcher_Regions.hpp
+++ b/src/openMVG/matching_image_collection/Matcher_Regions.hpp
@@ -16,7 +16,6 @@
 
 namespace openMVG { namespace matching { class PairWiseMatchesContainer; } }
 namespace openMVG { namespace sfm { struct Regions_Provider; } }
-namespace openMVG { namespace sfm { struct SfM_Data; } }
 
 namespace openMVG {
 namespace matching_image_collection {
@@ -38,7 +37,6 @@ class Matcher_Regions : public Matcher
   /// Find corresponding points between some pair of view Ids
   void Match
   (
-    const sfm::SfM_Data & sfm_data,
     const std::shared_ptr<sfm::Regions_Provider> & regions_provider,
     const Pair_Set & pairs,
     matching::PairWiseMatchesContainer & map_PutativesMatches, // the pairwise photometric corresponding points

--- a/src/software/SfM/main_ComputeMatches.cpp
+++ b/src/software/SfM/main_ComputeMatches.cpp
@@ -366,7 +366,7 @@ int main(int argc, char **argv)
           break;
       }
       // Photometric matching of putative pairs
-      collectionMatcher->Match(sfm_data, regions_provider, pairs, map_PutativesMatches, &progress);
+      collectionMatcher->Match(regions_provider, pairs, map_PutativesMatches, &progress);
       //---------------------------------------
       //-- Export putative matches
       //---------------------------------------


### PR DESCRIPTION
Hello,
This is a tiny PR to remove the `SfM_Data` argument in the `Matcher::Match(...)` method (and derived classes equivalents). It is never actually used in the matcher.

Cheers