### PR TITLE
Add required libraries to each targets to build shared libraries

### DIFF
--- a/src/openMVG_Samples/multiview_robust_essential_ba/CMakeLists.txt
+++ b/src/openMVG_Samples/multiview_robust_essential_ba/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(openMVG_sample_multiview_robustEssential_ba
   openMVG_matching
   openMVG_system
   openMVG_sfm
+  openMVG_multiview
   stlplus)
 target_compile_definitions(openMVG_sample_multiview_robustEssential_ba
   PRIVATE -DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/src/software/Geodesy/CMakeLists.txt
+++ b/src/software/Geodesy/CMakeLists.txt
@@ -4,6 +4,8 @@ target_link_libraries(openMVG_main_geodesy_registration_to_gps_position
   openMVG_system
   openMVG_features
   openMVG_sfm
+  openMVG_matching
+  openMVG_geometry
   easyexif
   stlplus)
 

--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -8,6 +8,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_SfMInit_ImageListing
   openMVG_image
   openMVG_features
   openMVG_sfm
+  openMVG_multiview
   easyexif
   )
 
@@ -17,6 +18,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_ConvertList
   openMVG_system
   openMVG_features
   openMVG_sfm
+  openMVG_multiview
   )
 
 # Installation rules
@@ -86,6 +88,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_IncrementalSfM
   openMVG_image
   openMVG_features
   openMVG_sfm
+  openMVG_matching
   stlplus
   )
 
@@ -95,6 +98,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_GlobalSfM
   openMVG_image
   openMVG_features
   openMVG_sfm
+  openMVG_matching
   stlplus
   )
 
@@ -119,6 +123,8 @@ TARGET_LINK_LIBRARIES(openMVG_main_ComputeStructureFromKnownPoses
   openMVG_system
   openMVG_features
   openMVG_sfm
+  openMVG_geometry
+  openMVG_matching
   stlplus
   )
 
@@ -144,6 +150,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_ChangeLocalOrigin
   openMVG_image
   openMVG_features
   openMVG_sfm
+  openMVG_geometry
   stlplus
   )
 
@@ -172,6 +179,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_SplitMatchFileIntoMatchFiles
   openMVG_image
   openMVG_features
   openMVG_sfm
+  openMVG_matching
   stlplus
   )
 
@@ -201,6 +209,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_exportMatches
   openMVG_system
   openMVG_features
   openMVG_sfm
+  openMVG_matching
   stlplus
   )
 
@@ -211,6 +220,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_exportTracks
   openMVG_system
   openMVG_features
   openMVG_sfm
+  openMVG_matching
   stlplus
   )
 
@@ -297,6 +307,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_openMVG2MESHLAB
   openMVG_image
   openMVG_features
   openMVG_sfm
+  openMVG_multiview
   stlplus
   )
 
@@ -385,6 +396,9 @@ TARGET_LINK_LIBRARIES(openMVG_main_evalQuality
   openMVG_system
   openMVG_features
   openMVG_sfm
+  openMVG_geometry
+  openMVG_multiview
+  openMVG_numeric
   stlplus
   )
 

--- a/src/software/SfMWebGLViewer/CMakeLists.txt
+++ b/src/software/SfMWebGLViewer/CMakeLists.txt
@@ -8,6 +8,8 @@ target_link_libraries(openMVG_main_openMVG2WebGL
   openMVG_features
   openMVG_image
   openMVG_sfm
+  openMVG_matching
+  openMVG_geometry
   stlplus
   )
 

--- a/src/software/colorHarmonize/CMakeLists.txt
+++ b/src/software/colorHarmonize/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(openMVG_main_ColHarmonize
   openMVG_lInftyComputerVision
   openMVG_sfm
   openMVG_system
+  openMVG_matching
   stlplus
   )
 


### PR DESCRIPTION
```
cmake -DCMAKE_BUILD_TYPE=RELEASE -DOpenMVG_BUILD_SHARED=ON ../src
make -j$(nproc)
```
Shows so many `error adding symbols: DSO missing from command line`

I added required libraries to each CMake targets. I hope it is the right way.
  