### PR TITLE
Fix typo in ply export code

### DIFF
--- a/src/openMVG/sfm/sfm_data_io_ply.hpp
+++ b/src/openMVG/sfm/sfm_data_io_ply.hpp
@@ -168,7 +168,7 @@ inline bool Save_PLY
           else
           {
             stream.write( reinterpret_cast<const char*> ( iterGCP.second.X.data() ), sizeof( Vec3 ) );
-            stream.write( reinterpret_cast<const char*> ( Vec3uc(255, 255, 255).data() ), sizeof( Vec3uc ) );
+            stream.write( reinterpret_cast<const char*> ( Vec3uc(255, 0, 0).data() ), sizeof( Vec3uc ) );
           }
         }
       }


### PR DESCRIPTION
Export control points in red.
Currently, it exports control points in white if save with binary format.