### PR TITLE
Fix MatchesViewer  (QSvgWidget loading error)

### DIFF
--- a/src/software/ui/SfM/adjacency_matrix_viewer/matchingpairgraphicsview.cpp
+++ b/src/software/ui/SfM/adjacency_matrix_viewer/matchingpairgraphicsview.cpp
@@ -10,6 +10,7 @@
 #include "pairgraphicsitem.h"
 #include "mainframe.h"
 
+#include <QByteArray>
 #include <QSvgWidget>
 #ifndef QT_NO_WHEELEVENT
 #include <QWheelEvent>
@@ -86,7 +87,7 @@ void MatchingPairGraphicsView::mousePressEvent(QMouseEvent * event)
             bVertical
           );
         QSvgWidget *svg = new QSvgWidget;
-        svg->load(QString::fromStdString(svg_string));
+        svg->load(QByteArray(svg_string.c_str()));
 
         std::ostringstream ofs;
         ofs << view_I->s_Img_path << " " << view_J->s_Img_path


### PR DESCRIPTION
Hi,

While trying to use the ui_openMVG_MatchesViewer I was getting an error while mouse-clicking on an entry in the adjacency matrix.

When clicked, an window (where the image pair should appear) opened but instead of loading the images and feature pairs it put an error on the console:


Cannot open file \<?xml version="1.0" standalone="yes"?\>
\<!-- SVG graphic --\>
\<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'
width="6144px" height="2048px" preserveAspectRatio="xMinYMin meet" viewBox="0 0 6144 2048" version="1.1"\>
\<image x="0" y="0" width="3072px" height="2048px" opacity="1" xlink:href="fo-0.jpg"/\>
\<image x="3072" y="0" width="3072px" height="2048px" opacity="1" xlink:href="fo-2.jpg"/\>
\<polyline points="2170.62,51.3092,5574.03,12.4763" stroke="rgb(0,212,255)" stroke-width="2" fill="none"/\>
\<polyline points="2164.28,60.5547,5565.18,21.0059" stroke="rgb(0,199,255)" stroke-width="2" fill="none"/\>
\<polyline points="2015.92,76.9175,5382.22,24.4487" stroke="rgb(63,255,0)" stroke-width="2" fill="none"/\>
...
...
\</svg\>', because: File name too long

(data in the error is not that important -> I just paste it to have an idea what was printed on the console)

I noticed that the QSvgWidget either requires a path to a file name (type QString) or data (type QByteArray). In the code the svg data was casted to QString instead of QByteArray. This small PR corrects that.

Cheers,
Klemen

  