### PR TITLE
Agisoft Photoscan Camera Exporter

### DIFF
--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -255,6 +255,7 @@ install(TARGETS openMVG_main_ExportUndistortedImages DESTINATION bin/)
 # - OpenMVS
 # - CMPMVS
 # - Meshlab
+# - Agisoft Photoscan
 # - MVE (File format v2)
 ###
 
@@ -314,6 +315,17 @@ target_link_libraries(openMVG_main_openMVG2MESHLAB
   stlplus
 )
 
+# - Export a SfM openMVG scene to Agisoft Photoscan
+# -
+ADD_EXECUTABLE(openMVG_main_openMVG2Agisoft main_openMVG2Agisoft.cpp)
+TARGET_LINK_LIBRARIES(openMVG_main_openMVG2Agisoft
+  openMVG_system
+  openMVG_image
+  openMVG_features
+  openMVG_sfm
+  stlplus
+  )
+  
 # - Export a SfM openMVG scene to mvs-texturing scene folder
 # -
 add_executable(openMVG_main_openMVG2MVSTEXTURING main_openMVG2MVSTEXTURING.cpp)
@@ -353,6 +365,8 @@ set_property(TARGET openMVG_main_openMVG2CMPMVS PROPERTY FOLDER OpenMVG/software
 install(TARGETS openMVG_main_openMVG2CMPMVS DESTINATION bin/)
 set_property(TARGET openMVG_main_openMVG2MESHLAB PROPERTY FOLDER OpenMVG/software)
 install(TARGETS openMVG_main_openMVG2MESHLAB DESTINATION bin/)
+set_property(TARGET openMVG_main_openMVG2Agisoft PROPERTY FOLDER OpenMVG/software)
+install(TARGETS openMVG_main_openMVG2Agisoft DESTINATION bin/)
 set_property(TARGET openMVG_main_openMVG2MVSTEXTURING PROPERTY FOLDER OpenMVG/software)
 install(TARGETS openMVG_main_openMVG2MVSTEXTURING DESTINATION bin/)
 set_property(TARGET openMVG_main_openMVG2MVE2 PROPERTY FOLDER OpenMVG/software)

--- a/src/software/SfM/main_openMVG2Agisoft.cpp
+++ b/src/software/SfM/main_openMVG2Agisoft.cpp
@@ -115,6 +115,9 @@ int main(int argc, char **argv)
             "<p2>" << params[7] << "</p2>\n"
             "<k3>" << params[5] << "</k3>\n";
           break;
+        default:
+          std::cerr << "Unsupported camera model for export." << std::endl;
+          return EXIT_FAILURE;
         }
       }
 

--- a/src/software/SfM/main_openMVG2Agisoft.cpp
+++ b/src/software/SfM/main_openMVG2Agisoft.cpp
@@ -67,9 +67,11 @@ int main(int argc, char **argv)
 
   std::ofstream outfile(stlplus::create_filespec(sOutDir, "cameras", "xml").c_str());
 
-  outfile << "<document version = \"1.2.0\">\n";
-  outfile << "  <chunk>\n";
+  outfile << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+  outfile << "<document version = \"1.3.0\">\n";
+  outfile << "<chunk>\n";
 
+  outfile << "<sensors>\n";
   for (const auto& intrinsic : sfm_data.GetIntrinsics())
   {
 	  if (isPinhole(intrinsic.second->getType()))
@@ -120,6 +122,7 @@ int main(int argc, char **argv)
 		  outfile << "</sensor>\n";
 	  }
   }
+  outfile << "</sensors>\n";
 
   outfile << "<cameras>\n";
   for (const auto& view : sfm_data.GetViews())
@@ -127,7 +130,7 @@ int main(int argc, char **argv)
 	  const openMVG::geometry::Pose3 poseMVG(sfm_data.GetPoseOrDie(view.second.get()));
 	  auto mat34 = poseMVG.asMatrix();
 
-	  outfile << "<camera id=\"" << view.first << "\" label=\"" << view.second->s_Img_path << "\" sensor_id=\"" << view.second->id_intrinsic << "\" enabled=\"true\">\n";
+	  outfile << "<camera id=\"" << view.first << "\" label=\"" << view.second->s_Img_path << "\" sensor_id=\"" << view.second->id_intrinsic << "\" enabled=\"1\">\n";
 	  outfile << "<transform>" << mat34 << " 0.0 0.0 0.0 1.0</transform>\n";
 	  outfile << "</camera>\n";
   }
@@ -138,10 +141,6 @@ int main(int argc, char **argv)
 	  "<size>100 100 100 </size>\n"
 	  "<R>1 0 0 0 1 0 0 0 1 </R>\n"
 	  "</region>\n"
-	  "<transform>\n"
-	  "<rotation>1.0000000000000000e+00 0.0000000000000000e+00 0.0000000000000000e+00 0.0000000000000000e+00 1.0000000000000000e+00 0.0000000000000000e+00 0.0000000000000000e+00 0.0000000000000000e+00 1.0000000000000000e+00</rotation>\n"
-	  "<translation>0.0 0.0 0.0</translation>\n"
-	  "</transform>\n"
 	  "<settings>\n"
 	  "<property name=\"accuracy_tiepoints\" value=\"1\"/>\n"
 	  "<property name=\"accuracy_cameras\" value=\"10\" />\n"

--- a/src/software/SfM/main_openMVG2Agisoft.cpp
+++ b/src/software/SfM/main_openMVG2Agisoft.cpp
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
   for (const auto& view : sfm_data.GetViews())
   {
     const openMVG::geometry::Pose3 poseMVG(sfm_data.GetPoseOrDie(view.second.get()));
-    auto mat34 = poseMVG.asMatrix();
+    auto mat34 = poseMVG.inverse().asMatrix();
 
     outfile << "<camera id=\"" << view.first << "\" label=\"" << view.second->s_Img_path << "\" sensor_id=\"" << view.second->id_intrinsic << "\" enabled=\"1\">\n";
     outfile << "<transform>" << mat34 << " 0.0 0.0 0.0 1.0</transform>\n";

--- a/src/software/SfM/main_openMVG2Agisoft.cpp
+++ b/src/software/SfM/main_openMVG2Agisoft.cpp
@@ -82,7 +82,8 @@ int main(int argc, char **argv)
         "<sensor id=\"" << intrinsic.first << "\" label=\"sensor_" << intrinsic.first << "\" type=\"frame\">\n" <<
         "<resolution width=\"" << cam->w() << "\" height=\"" << cam->h() << "\"/>\n" <<
         "<property name=\"fixed\" value=\"false\"/>\n" <<
-        "<calibration type=\"frame\" class=\"adjusted\">\n";
+        "<calibration type=\"frame\" class=\"adjusted\">\n" <<
+        "<resolution width=\"" << cam->w() << "\" height=\"" << cam->h() << "\"/>\n";
 
       outfile <<
         "<fx>" << cam->focal() << "</fx>\n" <<

--- a/src/software/SfM/main_openMVG2Agisoft.cpp
+++ b/src/software/SfM/main_openMVG2Agisoft.cpp
@@ -74,85 +74,85 @@ int main(int argc, char **argv)
   outfile << "<sensors>\n";
   for (const auto& intrinsic : sfm_data.GetIntrinsics())
   {
-	  if (isPinhole(intrinsic.second->getType()))
-	  {
-		  const Pinhole_Intrinsic * cam = dynamic_cast<const Pinhole_Intrinsic*>(intrinsic.second.get());
+    if (isPinhole(intrinsic.second->getType()))
+    {
+      const Pinhole_Intrinsic * cam = dynamic_cast<const Pinhole_Intrinsic*>(intrinsic.second.get());
 
-		  outfile << std::setprecision(16) << 
-			  "<sensor id=\"" << intrinsic.first << "\" label=\"sensor_" << intrinsic.first << "\" type=\"frame\">\n" <<
-			  "<resolution width=\"" << cam->w() << "\" height=\"" << cam->h() << "\"/>\n" <<
-			  "<property name=\"fixed\" value=\"false\"/>\n" <<
-			  "<calibration type=\"frame\" class=\"adjusted\">\n";
+      outfile << std::setprecision(16) << 
+        "<sensor id=\"" << intrinsic.first << "\" label=\"sensor_" << intrinsic.first << "\" type=\"frame\">\n" <<
+        "<resolution width=\"" << cam->w() << "\" height=\"" << cam->h() << "\"/>\n" <<
+        "<property name=\"fixed\" value=\"false\"/>\n" <<
+        "<calibration type=\"frame\" class=\"adjusted\">\n";
 
-		  outfile <<
-			  "<fx>" << cam->focal() << "</fx>\n" <<
-			  "<fy>" << cam->focal() << "</fy>\n";
+      outfile <<
+        "<fx>" << cam->focal() << "</fx>\n" <<
+        "<fy>" << cam->focal() << "</fy>\n";
 
-		  outfile <<
-			  "<cx>" << cam->principal_point()[0] << "</cx>\n" <<
-			  "<cy>" << cam->principal_point()[1] << "</cy>\n";
+      outfile <<
+        "<cx>" << cam->principal_point()[0] << "</cx>\n" <<
+        "<cy>" << cam->principal_point()[1] << "</cy>\n";
 
-		  if (cam->have_disto())
-		  {
-			  auto params = cam->getParams();
-			  switch (cam->getType())
-			  {
-			  case PINHOLE_CAMERA_RADIAL1:
-				  outfile <<
-					  "<k1>" << params[3] << "</k1>\n";
-				  break;
-			  case PINHOLE_CAMERA_RADIAL3:
-				  outfile <<
-					  "<k1>" << params[3] << "</k1>\n"
-					  "<k2>" << params[4] << "</k2>\n"
-					  "<k3>" << params[5] << "</k3>\n";
-				  break;
-			  case PINHOLE_CAMERA_BROWN:
-				  outfile <<
-					  "<k1>" << params[3] << "</k1>\n"
-					  "<k2>" << params[4] << "</k2>\n"
-					  "<p1>" << params[6] << "</p1>\n"
-					  "<p2>" << params[7] << "</p2>\n"
-					  "<k3>" << params[5] << "</k3>\n";
-				  break;
-			  }
-		  }
+      if (cam->have_disto())
+      {
+        auto params = cam->getParams();
+        switch (cam->getType())
+        {
+        case PINHOLE_CAMERA_RADIAL1:
+          outfile <<
+            "<k1>" << params[3] << "</k1>\n";
+          break;
+        case PINHOLE_CAMERA_RADIAL3:
+          outfile <<
+            "<k1>" << params[3] << "</k1>\n"
+            "<k2>" << params[4] << "</k2>\n"
+            "<k3>" << params[5] << "</k3>\n";
+          break;
+        case PINHOLE_CAMERA_BROWN:
+          outfile <<
+            "<k1>" << params[3] << "</k1>\n"
+            "<k2>" << params[4] << "</k2>\n"
+            "<p1>" << params[6] << "</p1>\n"
+            "<p2>" << params[7] << "</p2>\n"
+            "<k3>" << params[5] << "</k3>\n";
+          break;
+        }
+      }
 
-		  outfile << "</calibration>\n";
-		  outfile << "</sensor>\n";
-	  }
+      outfile << "</calibration>\n";
+      outfile << "</sensor>\n";
+    }
   }
   outfile << "</sensors>\n";
 
   outfile << "<cameras>\n";
   for (const auto& view : sfm_data.GetViews())
   {
-	  const openMVG::geometry::Pose3 poseMVG(sfm_data.GetPoseOrDie(view.second.get()));
-	  auto mat34 = poseMVG.asMatrix();
+    const openMVG::geometry::Pose3 poseMVG(sfm_data.GetPoseOrDie(view.second.get()));
+    auto mat34 = poseMVG.asMatrix();
 
-	  outfile << "<camera id=\"" << view.first << "\" label=\"" << view.second->s_Img_path << "\" sensor_id=\"" << view.second->id_intrinsic << "\" enabled=\"1\">\n";
-	  outfile << "<transform>" << mat34 << " 0.0 0.0 0.0 1.0</transform>\n";
-	  outfile << "</camera>\n";
+    outfile << "<camera id=\"" << view.first << "\" label=\"" << view.second->s_Img_path << "\" sensor_id=\"" << view.second->id_intrinsic << "\" enabled=\"1\">\n";
+    outfile << "<transform>" << mat34 << " 0.0 0.0 0.0 1.0</transform>\n";
+    outfile << "</camera>\n";
   }
   outfile << "</cameras>\n";
 
   outfile << "<region>\n"
-	  "<center>0 0 0 </center>\n"
-	  "<size>100 100 100 </size>\n"
-	  "<R>1 0 0 0 1 0 0 0 1 </R>\n"
-	  "</region>\n"
-	  "<settings>\n"
-	  "<property name=\"accuracy_tiepoints\" value=\"1\"/>\n"
-	  "<property name=\"accuracy_cameras\" value=\"10\" />\n"
-	  "<property name=\"accuracy_cameras_ypr\" value=\"2\" />\n"
-	  "<property name=\"accuracy_markers\" value=\"0.005\" />\n"
-	  "<property name=\"accuracy_scalebars\" value=\"0.001\" />\n"
-	  "<property name=\"accuracy_projections\" value=\"0.1\" />\n"
-	  "</settings>\n";
+    "<center>0 0 0 </center>\n"
+    "<size>100 100 100 </size>\n"
+    "<R>1 0 0 0 1 0 0 0 1 </R>\n"
+    "</region>\n"
+    "<settings>\n"
+    "<property name=\"accuracy_tiepoints\" value=\"1\"/>\n"
+    "<property name=\"accuracy_cameras\" value=\"10\" />\n"
+    "<property name=\"accuracy_cameras_ypr\" value=\"2\" />\n"
+    "<property name=\"accuracy_markers\" value=\"0.005\" />\n"
+    "<property name=\"accuracy_scalebars\" value=\"0.001\" />\n"
+    "<property name=\"accuracy_projections\" value=\"0.1\" />\n"
+    "</settings>\n";
 
   outfile << 
-	  "</chunk>\n"
-	  "</document>\n";
+    "</chunk>\n"
+    "</document>\n";
 
   outfile.close();
 

--- a/src/software/SfM/main_openMVG2Agisoft.cpp
+++ b/src/software/SfM/main_openMVG2Agisoft.cpp
@@ -1,0 +1,161 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2018 Etienne Danvoye
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/cameras/Camera_Pinhole.hpp"
+#include "openMVG/cameras/Camera_Pinhole_Radial.hpp"
+#include "openMVG/image/image_io.hpp"
+#include "openMVG/multiview/projection.hpp"
+#include "openMVG/sfm/sfm_data.hpp"
+#include "openMVG/sfm/sfm_data_io.hpp"
+
+#include "third_party/cmdLine/cmdLine.h"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+#include <fstream>
+#include <iomanip>
+
+using namespace openMVG;
+using namespace openMVG::cameras;
+using namespace openMVG::geometry;
+using namespace openMVG::image;
+using namespace openMVG::sfm;
+
+int main(int argc, char **argv)
+{
+  CmdLine cmd;
+
+  std::string sSfM_Data_Filename;
+  std::string sOutDir = "";
+
+  cmd.add( make_option('i', sSfM_Data_Filename, "sfmdata") );
+  cmd.add( make_option('o', sOutDir, "outdir") );
+
+  try {
+      if (argc == 1) throw std::string("Invalid command line parameter.");
+      cmd.process(argc, argv);
+  } catch (const std::string& s) {
+      std::cerr << "Usage: " << argv[0] << '\n'
+      << "[-i|--sfmdata] filename, the SfM_Data file to convert\n"
+      << "[-o|--outdir] path\n"
+      << std::endl;
+
+      std::cerr << s << std::endl;
+      return EXIT_FAILURE;
+  }
+
+  std::cout << " You called : " <<std::endl
+            << argv[0] << std::endl
+            << "--sfmdata " << sSfM_Data_Filename << std::endl
+            << "--outdir " << sOutDir << std::endl;
+
+  // Create output dir
+  if (!stlplus::folder_exists(sOutDir))
+    stlplus::folder_create( sOutDir );
+
+  // Read the SfM scene
+  SfM_Data sfm_data;
+  if (!Load(sfm_data, sSfM_Data_Filename, ESfM_Data(VIEWS|INTRINSICS|EXTRINSICS))) {
+    std::cerr << std::endl
+      << "The input SfM_Data file \""<< sSfM_Data_Filename << "\" cannot be read." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::ofstream outfile(stlplus::create_filespec(sOutDir, "cameras", "xml").c_str());
+
+  outfile << "<document version = \"1.2.0\">\n";
+  outfile << "  <chunk>\n";
+
+  for (const auto& intrinsic : sfm_data.GetIntrinsics())
+  {
+	  if (isPinhole(intrinsic.second->getType()))
+	  {
+		  const Pinhole_Intrinsic * cam = dynamic_cast<const Pinhole_Intrinsic*>(intrinsic.second.get());
+
+		  outfile << std::setprecision(16) << 
+			  "<sensor id=\"" << intrinsic.first << "\" label=\"sensor_" << intrinsic.first << "\" type=\"frame\">\n" <<
+			  "<resolution width=\"" << cam->w() << "\" height=\"" << cam->h() << "\"/>\n" <<
+			  "<property name=\"fixed\" value=\"false\"/>\n" <<
+			  "<calibration type=\"frame\" class=\"adjusted\">\n";
+
+		  outfile <<
+			  "<fx>" << cam->focal() << "</fx>\n" <<
+			  "<fy>" << cam->focal() << "</fy>\n";
+
+		  outfile <<
+			  "<cx>" << cam->principal_point()[0] << "</cx>\n" <<
+			  "<cy>" << cam->principal_point()[1] << "</cy>\n";
+
+		  if (cam->have_disto())
+		  {
+			  auto params = cam->getParams();
+			  switch (cam->getType())
+			  {
+			  case PINHOLE_CAMERA_RADIAL1:
+				  outfile <<
+					  "<k1>" << params[3] << "</k1>\n";
+				  break;
+			  case PINHOLE_CAMERA_RADIAL3:
+				  outfile <<
+					  "<k1>" << params[3] << "</k1>\n"
+					  "<k2>" << params[4] << "</k2>\n"
+					  "<k3>" << params[5] << "</k3>\n";
+				  break;
+			  case PINHOLE_CAMERA_BROWN:
+				  outfile <<
+					  "<k1>" << params[3] << "</k1>\n"
+					  "<k2>" << params[4] << "</k2>\n"
+					  "<p1>" << params[6] << "</p1>\n"
+					  "<p2>" << params[7] << "</p2>\n"
+					  "<k3>" << params[5] << "</k3>\n";
+				  break;
+			  }
+		  }
+
+		  outfile << "</calibration>\n";
+		  outfile << "</sensor>\n";
+	  }
+  }
+
+  outfile << "<cameras>\n";
+  for (const auto& view : sfm_data.GetViews())
+  {
+	  const openMVG::geometry::Pose3 poseMVG(sfm_data.GetPoseOrDie(view.second.get()));
+	  auto mat34 = poseMVG.asMatrix();
+
+	  outfile << "<camera id=\"" << view.first << "\" label=\"" << view.second->s_Img_path << "\" sensor_id=\"" << view.second->id_intrinsic << "\" enabled=\"true\">\n";
+	  outfile << "<transform>" << mat34 << " 0.0 0.0 0.0 1.0</transform>\n";
+	  outfile << "</camera>\n";
+  }
+  outfile << "</cameras>\n";
+
+  outfile << "<region>\n"
+	  "<center>0 0 0 </center>\n"
+	  "<size>100 100 100 </size>\n"
+	  "<R>1 0 0 0 1 0 0 0 1 </R>\n"
+	  "</region>\n"
+	  "<transform>\n"
+	  "<rotation>1.0000000000000000e+00 0.0000000000000000e+00 0.0000000000000000e+00 0.0000000000000000e+00 1.0000000000000000e+00 0.0000000000000000e+00 0.0000000000000000e+00 0.0000000000000000e+00 1.0000000000000000e+00</rotation>\n"
+	  "<translation>0.0 0.0 0.0</translation>\n"
+	  "</transform>\n"
+	  "<settings>\n"
+	  "<property name=\"accuracy_tiepoints\" value=\"1\"/>\n"
+	  "<property name=\"accuracy_cameras\" value=\"10\" />\n"
+	  "<property name=\"accuracy_cameras_ypr\" value=\"2\" />\n"
+	  "<property name=\"accuracy_markers\" value=\"0.005\" />\n"
+	  "<property name=\"accuracy_scalebars\" value=\"0.001\" />\n"
+	  "<property name=\"accuracy_projections\" value=\"0.1\" />\n"
+	  "</settings>\n";
+
+  outfile << 
+	  "</chunk>\n"
+	  "</document>\n";
+
+  outfile.close();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This PR adds a new executable main_openMVG2Agisoft used to convert the SfM file into Agisoft Photoscan's XML camera format.

Note that this does not recreate a full Agisoft project, but simply the XML containing the camera information (intrinsics and extrinsics). This file can be imported in Agisoft with the menu Tools->Import->Import Cameras.

This tool is especially useful in workflows where we need to exchange data between OpenMVG and Agisoft and we want both outputs to be in the same coordinate space.

The usage of this new exe is straightforward, simply use -i and -o to specify the input file and the output path.

This has been tested with Agisoft Photoscan 1.3.3.
