### PR TITLE
New Executable for Control Point Registration on the Command Line

### DIFF
--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -239,6 +239,13 @@ target_link_libraries(openMVG_main_ExportUndistortedImages
   stlplus
 )
 
+add_executable(openMVG_main_ControlPointsRegistration main_ControlPointsRegistration.cpp)
+target_link_libraries(openMVG_main_ControlPointsRegistration
+  openMVG_system
+  openMVG_features
+  openMVG_sfm
+  stlplus)
+  
 # installation rules
 set_property(TARGET openMVG_main_exportKeypoints PROPERTY FOLDER OpenMVG/software)
 install(TARGETS openMVG_main_exportKeypoints DESTINATION bin/)
@@ -248,6 +255,8 @@ set_property(TARGET openMVG_main_exportTracks PROPERTY FOLDER OpenMVG/software)
 install(TARGETS openMVG_main_exportTracks DESTINATION bin/)
 set_property(TARGET openMVG_main_ExportUndistortedImages PROPERTY FOLDER OpenMVG/software)
 install(TARGETS openMVG_main_ExportUndistortedImages DESTINATION bin/)
+set_property(TARGET openMVG_main_ControlPointsRegistration PROPERTY FOLDER OpenMVG/software)
+install(TARGETS openMVG_main_ControlPointsRegistration DESTINATION bin/)
 
 ###
 # SfM export to X

--- a/src/software/SfM/main_ControlPointsRegistration.cpp
+++ b/src/software/SfM/main_ControlPointsRegistration.cpp
@@ -1,0 +1,263 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2016 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/geometry/rigid_transformation3D_srt.hpp"
+#include "openMVG/geometry/Similarity3.hpp"
+#include "openMVG/geometry/Similarity3_Kernel.hpp"
+#include "openMVG/sfm/sfm_data.hpp"
+#include "openMVG/sfm/sfm_data_io.hpp"
+#include "openMVG/sfm/sfm_data_transform.hpp"
+#include "openMVG/cameras/Camera_Intrinsics.hpp"
+#include "openMVG/multiview/triangulation_nview.hpp"
+#include "openMVG/sfm/sfm_data_triangulation.hpp"
+#include "openMVG/geometry/rigid_transformation3D_srt.hpp"
+#include "openMVG/geometry/Similarity3.hpp"
+#include "openMVG/sfm/sfm_data_BA_ceres.hpp"
+
+#include "software/SfM/SfMPlyHelper.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+#include "third_party/cmdLine/cmdLine.h"
+
+#include <iostream>
+#include <iomanip>
+#include <string>
+
+using namespace openMVG;
+using namespace openMVG::cameras;
+using namespace openMVG::sfm;
+
+using namespace std;
+
+int main(int argc, char **argv)
+{
+  std::string
+    sSfM_Data_Filename_In,
+    sSfM_Data_Filename_Out;
+
+  CmdLine cmd;
+  cmd.add(make_option('i', sSfM_Data_Filename_In, "input_file"));
+  cmd.add(make_option('o', sSfM_Data_Filename_Out, "output_file"));
+
+  try
+  {
+    if (argc == 1) throw std::string("Invalid command line parameter.");
+    cmd.process(argc, argv);
+  }
+  catch (const std::string& s)
+  {
+    std::cerr
+      << "Usage: " << argv[0] << '\n'
+      << " Control Points registration of a SfM Data scene,\n"
+      << "[-i|--input_file] path to the input SfM_Data scene\n"
+      << "[-o|--output_file] path to the output SfM_Data scene\n"
+      << std::endl;
+
+    std::cerr << s << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (sSfM_Data_Filename_In.empty() || sSfM_Data_Filename_Out.empty())
+  {
+    std::cerr << "Invalid input or output filename." << std::endl;
+    return EXIT_FAILURE;
+  }
+  
+  //
+  // Load a SfM scene
+  // For each valid view (pose & intrinsic defined)
+  //  - iff a GPS position can be parsed
+  //    - store corresponding camera pose & GPS position
+  // - Compute the registration between the selected camera poses & GPS positions
+
+  // Load input SfM_Data scene
+  SfM_Data sfm_data;
+  if (!Load(sfm_data, sSfM_Data_Filename_In, ESfM_Data(ALL)))
+  {
+    std::cerr
+      << "\nThe input SfM_Data file \"" << sSfM_Data_Filename_In
+      << "\" cannot be read." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  //---
+  // registration (coarse):
+  // - compute the 3D points corresponding to the control point observation for the SfM scene
+  // - compute a coarse registration between the controls points & the triangulated point
+  // - transform the scene according the found transformation
+  //---
+  std::map<IndexT, Vec3> vec_control_points, vec_triangulated;
+  std::map<IndexT, double> vec_triangulation_errors;
+  for (const auto & control_point_it : sfm_data.control_points)
+  {
+	  const Landmark & landmark = control_point_it.second;
+	  //Triangulate the observations:
+	  const Observations & obs = landmark.obs;
+	  std::vector<Vec3> bearing;
+	  std::vector<Mat34> poses;
+	  bearing.reserve(obs.size());
+	  poses.reserve(obs.size());
+	  for (const auto & obs_it : obs)
+	  {
+		  const View * view = sfm_data.views.at(obs_it.first).get();
+		  if (!sfm_data.IsPoseAndIntrinsicDefined(view))
+			  continue;
+		  const openMVG::cameras::IntrinsicBase * cam = sfm_data.GetIntrinsics().at(view->id_intrinsic).get();
+		  const openMVG::geometry::Pose3 pose = sfm_data.GetPoseOrDie(view);
+		  const Vec2 pt = obs_it.second.x;
+		  bearing.emplace_back((*cam)(cam->get_ud_pixel(pt)));
+		  poses.emplace_back(pose.asMatrix());
+	  }
+	  const Eigen::Map<const Mat3X> bearing_matrix(bearing[0].data(), 3, bearing.size());
+	  Vec4 Xhomogeneous;
+	  if (!TriangulateNViewAlgebraic(bearing_matrix, poses, &Xhomogeneous))
+	  {
+		  std::cout << "Invalid triangulation" << std::endl;
+		  return EXIT_FAILURE;
+	  }
+	  const Vec3 X = Xhomogeneous.hnormalized();
+	  // Test validity of the hypothesis (front of the cameras):
+	  bool bChierality = true;
+	  int i(0);
+	  double reprojection_error_sum(0.0);
+	  for (const auto & obs_it : obs)
+	  {
+		  const View * view = sfm_data.views.at(obs_it.first).get();
+		  if (!sfm_data.IsPoseAndIntrinsicDefined(view))
+			  continue;
+
+		  const Pose3 pose = sfm_data.GetPoseOrDie(view);
+		  bChierality &= CheiralityTest(bearing[i], pose, X);
+		  const openMVG::cameras::IntrinsicBase * cam = sfm_data.GetIntrinsics().at(view->id_intrinsic).get();
+		  const Vec2 pt = obs_it.second.x;
+		  const Vec2 residual = cam->residual(pose(X), pt);
+		  reprojection_error_sum += residual.norm();
+		  ++i;
+	  }
+	  if (bChierality) // Keep the point only if it has a positive depth
+	  {
+		  vec_triangulated[control_point_it.first] = X;
+		  vec_control_points[control_point_it.first] = landmark.X;
+		  vec_triangulation_errors[control_point_it.first] = reprojection_error_sum / (double)bearing.size();
+	  }
+	  else
+	  {
+		  std::cout << "Control Point cannot be triangulated (not in front of the cameras)" << std::endl;
+		  return EXIT_FAILURE;
+	  }
+  }
+
+  if (vec_control_points.size() < 3)
+  {
+	  std::cerr << "Insufficient number of triangulated control points." << std::endl;
+	  return EXIT_FAILURE;
+  }
+
+  // compute the similarity
+  {
+	  // data conversion to appropriate container
+	  Mat x1(3, vec_control_points.size()),
+		  x2(3, vec_control_points.size());
+	  for (size_t i = 0; i < vec_control_points.size(); ++i)
+	  {
+		  x1.col(i) = vec_triangulated[i];
+		  x2.col(i) = vec_control_points[i];
+	  }
+
+	  std::cout
+		  << "Control points observation triangulations:\n"
+		  << x1 << std::endl << std::endl
+		  << "Control points coords:\n"
+		  << x2 << std::endl << std::endl;
+
+	  Vec3 t;
+	  Mat3 R;
+	  double S;
+	  if (openMVG::geometry::FindRTS(x1, x2, &S, &t, &R))
+	  {
+		  openMVG::geometry::Refine_RTS(x1, x2, &S, &t, &R);
+		  std::cout << "Found transform:\n"
+			  << " scale: " << S << "\n"
+			  << " rotation:\n" << R << "\n"
+			  << " translation: " << t.transpose() << std::endl;
+
+
+		  //--
+		  // Apply the found transformation as a 3D Similarity transformation matrix // S * R * X + t
+		  //--
+
+		  const openMVG::geometry::Similarity3 sim(geometry::Pose3(R, -R.transpose() * t / S), S);
+		  openMVG::sfm::ApplySimilarity(sim, sfm_data);
+
+		  // Display some statistics:
+		  std::stringstream os;
+		  for (Landmarks::const_iterator iterL = sfm_data.control_points.begin();
+			  iterL != sfm_data.control_points.end(); ++iterL)
+		  {
+			  const IndexT CPIndex = iterL->first;
+			  // If the control point has not been used, continue...
+			  if (vec_triangulation_errors.find(CPIndex) == vec_triangulation_errors.end())
+				  continue;
+
+			  os
+				  << "CP index: " << CPIndex << "\n"
+				  << "CP triangulation error: " << vec_triangulation_errors[CPIndex] << " pixel(s)\n"
+				  << "CP registration error: "
+				  << (sim(vec_triangulated[CPIndex]) - vec_control_points[CPIndex]).norm() << " user unit(s)" << "\n\n";
+		  }
+		  std::cout << os.str();
+	  }
+	  else
+	  {
+		  std::cerr << "Registration failed. Please check your Control Points coordinates." << std::endl;
+		  return EXIT_FAILURE;
+	  }
+  }
+
+  //---
+  // Bundle adjustment with GCP
+  //---
+  {
+	  using namespace openMVG::sfm;
+	  Bundle_Adjustment_Ceres::BA_Ceres_options options;
+	  Bundle_Adjustment_Ceres bundle_adjustment_obj(options);
+	  Control_Point_Parameter control_point_opt(20.0, true);
+	  if (!bundle_adjustment_obj.Adjust(sfm_data,
+		  Optimize_Options
+		  (
+			  cameras::Intrinsic_Parameter_Type::NONE, // Keep intrinsic constant
+			  Extrinsic_Parameter_Type::ADJUST_ALL, // Adjust camera motion
+			  Structure_Parameter_Type::ADJUST_ALL, // Adjust structure
+			  control_point_opt // Use GCP and weight more their observation residuals
+		  )
+	  )
+		  )
+	  {
+		  std::cerr << "BA with GCP failed." << std::endl;
+		  return EXIT_FAILURE;
+	  }
+  }
+
+
+  // Export the SfM_Data scene in the expected format
+  if (Save(
+        sfm_data,
+        sSfM_Data_Filename_Out.c_str(),
+        ESfM_Data(ALL)))
+  {
+    return EXIT_SUCCESS;
+  }
+  else
+  {
+    std::cerr
+      << std::endl
+      << "An error occured while trying to save \""
+      << sSfM_Data_Filename_Out << "\"." << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_FAILURE;
+}

--- a/src/software/SfM/main_ControlPointsRegistration.cpp
+++ b/src/software/SfM/main_ControlPointsRegistration.cpp
@@ -69,10 +69,7 @@ int main(int argc, char **argv)
   
   //
   // Load a SfM scene
-  // For each valid view (pose & intrinsic defined)
-  //  - iff a GPS position can be parsed
-  //    - store corresponding camera pose & GPS position
-  // - Compute the registration between the selected camera poses & GPS positions
+  // - Compute the registration between the control point observations and reference position
 
   // Load input SfM_Data scene
   SfM_Data sfm_data;
@@ -94,152 +91,152 @@ int main(int argc, char **argv)
   std::map<IndexT, double> vec_triangulation_errors;
   for (const auto & control_point_it : sfm_data.control_points)
   {
-	  const Landmark & landmark = control_point_it.second;
-	  //Triangulate the observations:
-	  const Observations & obs = landmark.obs;
-	  std::vector<Vec3> bearing;
-	  std::vector<Mat34> poses;
-	  bearing.reserve(obs.size());
-	  poses.reserve(obs.size());
-	  for (const auto & obs_it : obs)
-	  {
-		  const View * view = sfm_data.views.at(obs_it.first).get();
-		  if (!sfm_data.IsPoseAndIntrinsicDefined(view))
-			  continue;
-		  const openMVG::cameras::IntrinsicBase * cam = sfm_data.GetIntrinsics().at(view->id_intrinsic).get();
-		  const openMVG::geometry::Pose3 pose = sfm_data.GetPoseOrDie(view);
-		  const Vec2 pt = obs_it.second.x;
-		  bearing.emplace_back((*cam)(cam->get_ud_pixel(pt)));
-		  poses.emplace_back(pose.asMatrix());
-	  }
-	  const Eigen::Map<const Mat3X> bearing_matrix(bearing[0].data(), 3, bearing.size());
-	  Vec4 Xhomogeneous;
-	  if (!TriangulateNViewAlgebraic(bearing_matrix, poses, &Xhomogeneous))
-	  {
-		  std::cout << "Invalid triangulation" << std::endl;
-		  return EXIT_FAILURE;
-	  }
-	  const Vec3 X = Xhomogeneous.hnormalized();
-	  // Test validity of the hypothesis (front of the cameras):
-	  bool bChierality = true;
-	  int i(0);
-	  double reprojection_error_sum(0.0);
-	  for (const auto & obs_it : obs)
-	  {
-		  const View * view = sfm_data.views.at(obs_it.first).get();
-		  if (!sfm_data.IsPoseAndIntrinsicDefined(view))
-			  continue;
+    const Landmark & landmark = control_point_it.second;
+    //Triangulate the observations:
+    const Observations & obs = landmark.obs;
+    std::vector<Vec3> bearing;
+    std::vector<Mat34> poses;
+    bearing.reserve(obs.size());
+    poses.reserve(obs.size());
+    for (const auto & obs_it : obs)
+    {
+      const View * view = sfm_data.views.at(obs_it.first).get();
+      if (!sfm_data.IsPoseAndIntrinsicDefined(view))
+        continue;
+      const openMVG::cameras::IntrinsicBase * cam = sfm_data.GetIntrinsics().at(view->id_intrinsic).get();
+      const openMVG::geometry::Pose3 pose = sfm_data.GetPoseOrDie(view);
+      const Vec2 pt = obs_it.second.x;
+      bearing.emplace_back((*cam)(cam->get_ud_pixel(pt)));
+      poses.emplace_back(pose.asMatrix());
+    }
+    const Eigen::Map<const Mat3X> bearing_matrix(bearing[0].data(), 3, bearing.size());
+    Vec4 Xhomogeneous;
+    if (!TriangulateNViewAlgebraic(bearing_matrix, poses, &Xhomogeneous))
+    {
+      std::cout << "Invalid triangulation" << std::endl;
+      return EXIT_FAILURE;
+    }
+    const Vec3 X = Xhomogeneous.hnormalized();
+    // Test validity of the hypothesis (front of the cameras):
+    bool bChierality = true;
+    int i(0);
+    double reprojection_error_sum(0.0);
+    for (const auto & obs_it : obs)
+    {
+      const View * view = sfm_data.views.at(obs_it.first).get();
+      if (!sfm_data.IsPoseAndIntrinsicDefined(view))
+        continue;
 
-		  const Pose3 pose = sfm_data.GetPoseOrDie(view);
-		  bChierality &= CheiralityTest(bearing[i], pose, X);
-		  const openMVG::cameras::IntrinsicBase * cam = sfm_data.GetIntrinsics().at(view->id_intrinsic).get();
-		  const Vec2 pt = obs_it.second.x;
-		  const Vec2 residual = cam->residual(pose(X), pt);
-		  reprojection_error_sum += residual.norm();
-		  ++i;
-	  }
-	  if (bChierality) // Keep the point only if it has a positive depth
-	  {
-		  vec_triangulated[control_point_it.first] = X;
-		  vec_control_points[control_point_it.first] = landmark.X;
-		  vec_triangulation_errors[control_point_it.first] = reprojection_error_sum / (double)bearing.size();
-	  }
-	  else
-	  {
-		  std::cout << "Control Point cannot be triangulated (not in front of the cameras)" << std::endl;
-		  return EXIT_FAILURE;
-	  }
+      const Pose3 pose = sfm_data.GetPoseOrDie(view);
+      bChierality &= CheiralityTest(bearing[i], pose, X);
+      const openMVG::cameras::IntrinsicBase * cam = sfm_data.GetIntrinsics().at(view->id_intrinsic).get();
+      const Vec2 pt = obs_it.second.x;
+      const Vec2 residual = cam->residual(pose(X), pt);
+      reprojection_error_sum += residual.norm();
+      ++i;
+    }
+    if (bChierality) // Keep the point only if it has a positive depth
+    {
+      vec_triangulated[control_point_it.first] = X;
+      vec_control_points[control_point_it.first] = landmark.X;
+      vec_triangulation_errors[control_point_it.first] = reprojection_error_sum / (double)bearing.size();
+    }
+    else
+    {
+      std::cout << "Control Point cannot be triangulated (not in front of the cameras)" << std::endl;
+      return EXIT_FAILURE;
+    }
   }
 
   if (vec_control_points.size() < 3)
   {
-	  std::cerr << "Insufficient number of triangulated control points." << std::endl;
-	  return EXIT_FAILURE;
+    std::cerr << "Insufficient number of triangulated control points." << std::endl;
+    return EXIT_FAILURE;
   }
 
   // compute the similarity
   {
-	  // data conversion to appropriate container
-	  Mat x1(3, vec_control_points.size()),
-		  x2(3, vec_control_points.size());
-	  for (size_t i = 0; i < vec_control_points.size(); ++i)
-	  {
-		  x1.col(i) = vec_triangulated[i];
-		  x2.col(i) = vec_control_points[i];
-	  }
+    // data conversion to appropriate container
+    Mat x1(3, vec_control_points.size()),
+      x2(3, vec_control_points.size());
+    for (size_t i = 0; i < vec_control_points.size(); ++i)
+    {
+      x1.col(i) = vec_triangulated[i];
+      x2.col(i) = vec_control_points[i];
+    }
 
-	  std::cout
-		  << "Control points observation triangulations:\n"
-		  << x1 << std::endl << std::endl
-		  << "Control points coords:\n"
-		  << x2 << std::endl << std::endl;
+    std::cout
+      << "Control points observation triangulations:\n"
+      << x1 << std::endl << std::endl
+      << "Control points coords:\n"
+      << x2 << std::endl << std::endl;
 
-	  Vec3 t;
-	  Mat3 R;
-	  double S;
-	  if (openMVG::geometry::FindRTS(x1, x2, &S, &t, &R))
-	  {
-		  openMVG::geometry::Refine_RTS(x1, x2, &S, &t, &R);
-		  std::cout << "Found transform:\n"
-			  << " scale: " << S << "\n"
-			  << " rotation:\n" << R << "\n"
-			  << " translation: " << t.transpose() << std::endl;
+    Vec3 t;
+    Mat3 R;
+    double S;
+    if (openMVG::geometry::FindRTS(x1, x2, &S, &t, &R))
+    {
+      openMVG::geometry::Refine_RTS(x1, x2, &S, &t, &R);
+      std::cout << "Found transform:\n"
+        << " scale: " << S << "\n"
+        << " rotation:\n" << R << "\n"
+        << " translation: " << t.transpose() << std::endl;
 
 
-		  //--
-		  // Apply the found transformation as a 3D Similarity transformation matrix // S * R * X + t
-		  //--
+      //--
+      // Apply the found transformation as a 3D Similarity transformation matrix // S * R * X + t
+      //--
 
-		  const openMVG::geometry::Similarity3 sim(geometry::Pose3(R, -R.transpose() * t / S), S);
-		  openMVG::sfm::ApplySimilarity(sim, sfm_data);
+      const openMVG::geometry::Similarity3 sim(geometry::Pose3(R, -R.transpose() * t / S), S);
+      openMVG::sfm::ApplySimilarity(sim, sfm_data);
 
-		  // Display some statistics:
-		  std::stringstream os;
-		  for (Landmarks::const_iterator iterL = sfm_data.control_points.begin();
-			  iterL != sfm_data.control_points.end(); ++iterL)
-		  {
-			  const IndexT CPIndex = iterL->first;
-			  // If the control point has not been used, continue...
-			  if (vec_triangulation_errors.find(CPIndex) == vec_triangulation_errors.end())
-				  continue;
+      // Display some statistics:
+      std::stringstream os;
+      for (Landmarks::const_iterator iterL = sfm_data.control_points.begin();
+        iterL != sfm_data.control_points.end(); ++iterL)
+      {
+        const IndexT CPIndex = iterL->first;
+        // If the control point has not been used, continue...
+        if (vec_triangulation_errors.find(CPIndex) == vec_triangulation_errors.end())
+          continue;
 
-			  os
-				  << "CP index: " << CPIndex << "\n"
-				  << "CP triangulation error: " << vec_triangulation_errors[CPIndex] << " pixel(s)\n"
-				  << "CP registration error: "
-				  << (sim(vec_triangulated[CPIndex]) - vec_control_points[CPIndex]).norm() << " user unit(s)" << "\n\n";
-		  }
-		  std::cout << os.str();
-	  }
-	  else
-	  {
-		  std::cerr << "Registration failed. Please check your Control Points coordinates." << std::endl;
-		  return EXIT_FAILURE;
-	  }
+        os
+          << "CP index: " << CPIndex << "\n"
+          << "CP triangulation error: " << vec_triangulation_errors[CPIndex] << " pixel(s)\n"
+          << "CP registration error: "
+          << (sim(vec_triangulated[CPIndex]) - vec_control_points[CPIndex]).norm() << " user unit(s)" << "\n\n";
+      }
+      std::cout << os.str();
+    }
+    else
+    {
+      std::cerr << "Registration failed. Please check your Control Points coordinates." << std::endl;
+      return EXIT_FAILURE;
+    }
   }
 
   //---
   // Bundle adjustment with GCP
   //---
   {
-	  using namespace openMVG::sfm;
-	  Bundle_Adjustment_Ceres::BA_Ceres_options options;
-	  Bundle_Adjustment_Ceres bundle_adjustment_obj(options);
-	  Control_Point_Parameter control_point_opt(20.0, true);
-	  if (!bundle_adjustment_obj.Adjust(sfm_data,
-		  Optimize_Options
-		  (
-			  cameras::Intrinsic_Parameter_Type::NONE, // Keep intrinsic constant
-			  Extrinsic_Parameter_Type::ADJUST_ALL, // Adjust camera motion
-			  Structure_Parameter_Type::ADJUST_ALL, // Adjust structure
-			  control_point_opt // Use GCP and weight more their observation residuals
-		  )
-	  )
-		  )
-	  {
-		  std::cerr << "BA with GCP failed." << std::endl;
-		  return EXIT_FAILURE;
-	  }
+    using namespace openMVG::sfm;
+    Bundle_Adjustment_Ceres::BA_Ceres_options options;
+    Bundle_Adjustment_Ceres bundle_adjustment_obj(options);
+    Control_Point_Parameter control_point_opt(20.0, true);
+    if (!bundle_adjustment_obj.Adjust(sfm_data,
+          Optimize_Options
+          (
+            cameras::Intrinsic_Parameter_Type::NONE, // Keep intrinsic constant
+            Extrinsic_Parameter_Type::ADJUST_ALL, // Adjust camera motion
+            Structure_Parameter_Type::ADJUST_ALL, // Adjust structure
+            control_point_opt // Use GCP and weight more their observation residuals
+          )
+        )
+      )
+    {
+      std::cerr << "BA with GCP failed." << std::endl;
+      return EXIT_FAILURE;
+    }
   }
 
 


### PR DESCRIPTION
This PR adds a new executable to run Control Point Registration on the command line.

I have simply moved the existing code from ui_openMVG_control_points_registration, which performs the same operation, but from user input.

Having a command line utility for the control point operation is very useful if an exterior tool is providing the control point position in the images, and their corresponding world position.

Here is an example Python code to load an existing SfM file (in json format), read all the images, detect Aruco markers with opencv, then align the scene with this new exe, using desired world position for the markers.

```
# Sample code: Detect Aruco Markers and add them to the json SfM scene file
# Author: Etienne Danvoye

def align_from_aruco(sfm_filename):

    # Generate Aruco Board
    aruco_dict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)

    # These are our desired positions for the markers
    marker_info = {       
    
        # Markers from new Aruco calibration panel
        # These are the desired world position of the markers
        'aruco_0':  (0.0, 4.0, 0.0),
        'aruco_1':  (1.5, 4.0, 0.0),
        'aruco_2':  (3.0, 4.0, 0.0),
        'aruco_3':  (4.5, 4.0, 0.0),
        'aruco_4':  (6.0, 4.0, 0.0),

        'aruco_5':  (0.0, 2.5, 0.0),
        'aruco_6':  (1.5, 2.5, 0.0),
        'aruco_7':  (3.0, 2.5, 0.0),
        'aruco_8':  (4.5, 2.5, 0.0),
        'aruco_9':  (6.0, 2.5, 0.0),

        'aruco_10': (0.0, 1.0, 0.0),
        'aruco_11': (1.5, 1.0, 0.0),
        'aruco_12': (3.0, 1.0, 0.0),
        'aruco_13': (4.5 ,1.0, 0.0),
        'aruco_14': (6.0, 1.0, 0.0),
    }

    # sfm_filename needs to be a SfM file ni json format
    if not '.json' in sfm_filename:
        raise Exception("First convert SfM file to json")

    # Load json SFM Data
    with open(sfm_filename, 'r') as f:
        sfm_data = json.load(f)

    # Clear existing control points
    sfm_data['control_points'] = []

    marker_index = 0
    marker_dict = {}

    # Detect markers
    root_path = sfm_data['root_path']
    for view in sfm_data['views']:
        filename = view['value']['ptr_wrapper']['data']['filename']
        full_path = os.path.join(root_path, filename)

        print 'Detecting markers in %s' % filename

        # Read image file
        img = cv2.imread(full_path, cv2.IMREAD_UNCHANGED)
        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)

        # detect aruco markers in image
        corners,ids,rejected = cv2.aruco.detectMarkers(gray, aruco_dict)

        for corner,marker_id in zip(corners, ids):

            marker_name = 'aruco_%d' % marker_id
            marker_upper_left = corner[0][0]

            if marker_name not in marker_info:
                continue

            # Create new marker
            if marker_name not in marker_dict:
                item = {}
                item['key'] = marker_index
                marker_index = marker_index + 1
                item['value'] = {}
                item['value']['X'] = list(marker_info[marker_name])
                item['value']['observations'] = []

                marker_dict[marker_name] = item
                sfm_data['control_points'].append(item)
            else:
                item = marker_dict[marker_name]

            #  Add observation to marker
            obs = {}
            obs['key'] = view['value']['ptr_wrapper']['data']['id_view']
            obs['value'] = {}
            obs['value']['id_feat'] = 0 # not used for control_points                        
            obs['value']['x'] = [float(marker_upper_left[0]),float(marker_upper_left[1])]
            item['value']['observations'].append( obs )

    # Write new json
    json_file_with_markers = os.path.splitext(sfm_filename)[0] + '_markers.json'
    with open(json_file_with_markers, 'w') as f:
        print 'Writing json file %s' % json_file_with_markers
        json_str = json.dumps(sfm_data)
        f.write(json_str)

    # Run new exe to align scene from control points
    output_file = os.path.splitext(json_file_with_markers)[0] + '_aligned.bin'
    cmd = [os.path.join(OPENMVG_BIN,'openMVG_main_ControlPointsRegistration.exe'), 
        '-i', json_file_with_markers, 
        '-o', output_file
    ]
    subprocess.check_output(cmd, stderr=subprocess.STDOUT, cwd=cwd)
```
