### PR TITLE
Sfm Data Colorization

### DIFF
--- a/src/openMVG/sfm/sfm_data_colorization.cpp
+++ b/src/openMVG/sfm/sfm_data_colorization.cpp
@@ -1,0 +1,146 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+#include "openMVG/sfm/sfm_data_colorization.hpp"
+#include "openMVG/image/image_io.hpp"
+#include "openMVG/stl/stl.hpp"
+#include "third_party/progress/progress_display.hpp"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+#include "openMVG/image/image_container.hpp"
+#include "openMVG/image/pixel_types.hpp"
+
+namespace openMVG {
+namespace sfm {
+
+/// Find the color of the SfM_Data Landmarks/structure
+bool ColorizeTracks(
+  const SfM_Data & sfm_data,
+  std::vector<Vec3> & vec_3dPoints,
+  std::vector<Vec3> & vec_tracksColor)
+{
+  // Colorize each track
+  // Start with the most representative image
+  //   and iterate to provide a color to each 3D point
+
+  {
+    C_Progress_display my_progress_bar(sfm_data.GetLandmarks().size(),
+                                       std::cout,
+                                       "\nCompute scene structure color\n");
+
+    vec_tracksColor.resize(sfm_data.GetLandmarks().size());
+    vec_3dPoints.resize(sfm_data.GetLandmarks().size());
+
+    //Build a list of contiguous index for the trackIds
+    std::map<IndexT, IndexT> trackIds_to_contiguousIndexes;
+    IndexT cpt = 0;
+    for (Landmarks::const_iterator it = sfm_data.GetLandmarks().begin();
+      it != sfm_data.GetLandmarks().end(); ++it, ++cpt)
+    {
+      trackIds_to_contiguousIndexes[it->first] = cpt;
+      vec_3dPoints[cpt] = it->second.X;
+    }
+
+    // The track list that will be colored (point removed during the process)
+    std::set<IndexT> remainingTrackToColor;
+    std::transform(sfm_data.GetLandmarks().begin(), sfm_data.GetLandmarks().end(),
+      std::inserter(remainingTrackToColor, remainingTrackToColor.begin()),
+      stl::RetrieveKey());
+
+    while ( !remainingTrackToColor.empty() )
+    {
+      // Find the most representative image (for the remaining 3D points)
+      //  a. Count the number of observation per view for each 3Dpoint Index
+      //  b. Sort to find the most representative view index
+
+      std::map<IndexT, IndexT> map_IndexCardinal; // ViewId, Cardinal
+      for (std::set<IndexT>::const_iterator
+        iterT = remainingTrackToColor.begin();
+        iterT != remainingTrackToColor.end();
+        ++iterT)
+      {
+        const size_t trackId = *iterT;
+        const Observations & obs = sfm_data.GetLandmarks().at(trackId).obs;
+        for (Observations::const_iterator iterObs = obs.begin();
+          iterObs != obs.end(); ++iterObs)
+        {
+          const size_t viewId = iterObs->first;
+          if (map_IndexCardinal.find(viewId) == map_IndexCardinal.end())
+            map_IndexCardinal[viewId] = 1;
+          else
+            ++map_IndexCardinal[viewId];
+        }
+      }
+
+      // Find the View index that is the most represented
+      std::vector<IndexT> vec_cardinal;
+      std::transform(map_IndexCardinal.begin(),
+        map_IndexCardinal.end(),
+        std::back_inserter(vec_cardinal),
+        stl::RetrieveValue());
+      using namespace stl::indexed_sort;
+      std::vector<sort_index_packet_descend<IndexT, IndexT>> packet_vec(vec_cardinal.size());
+      sort_index_helper(packet_vec, &vec_cardinal[0], 1);
+
+      // First image index with the most of occurence
+      std::map<IndexT, IndexT>::const_iterator iterTT = map_IndexCardinal.begin();
+      std::advance(iterTT, packet_vec[0].index);
+      const size_t view_index = iterTT->first;
+      const View * view = sfm_data.GetViews().at(view_index).get();
+      const std::string sView_filename = stlplus::create_filespec(sfm_data.s_root_path,
+        view->s_Img_path);
+      image::Image<image::RGBColor> image_rgb;
+      image::Image<unsigned char> image_gray;
+      const bool b_rgb_image = true; // ReadImage(sView_filename.c_str(), &image_rgb);  // TODO FIX
+      if (!b_rgb_image) //try Gray level
+      {
+        const bool b_gray_image = ReadImage(sView_filename.c_str(), &image_gray);
+        if (!b_gray_image)
+        {
+          std::cerr << "Cannot open provided the image." << std::endl;
+          return false;
+        }
+      }
+
+      // Iterate through the remaining track to color
+      // - look if the current view is present to color the track
+      std::set<IndexT> set_toRemove;
+      for (std::set<IndexT>::const_iterator
+        iterT = remainingTrackToColor.begin();
+        iterT != remainingTrackToColor.end();
+        ++iterT)
+      {
+        const size_t trackId = *iterT;
+        const Observations & obs = sfm_data.GetLandmarks().at(trackId).obs;
+        Observations::const_iterator it = obs.find(view_index);
+
+        if (it != obs.end())
+        {
+          // Color the track
+          const Vec2 & pt = it->second.x;
+          const image::RGBColor color = b_rgb_image ? image_rgb(pt.y(), pt.x()) : image::RGBColor(image_gray(pt.y(), pt.x()));
+
+          vec_tracksColor[ trackIds_to_contiguousIndexes[trackId] ] = Vec3(color.r(), color.g(), color.b());
+          set_toRemove.insert(trackId);
+          ++my_progress_bar;
+        }
+      }
+      // Remove colored track
+      for (std::set<IndexT>::const_iterator iter = set_toRemove.begin();
+        iter != set_toRemove.end(); ++iter)
+      {
+        remainingTrackToColor.erase(*iter);
+      }
+    }
+  }
+  return true;
+}
+
+} // namespace sfm
+} // namespace openMVG

--- a/src/openMVG/sfm/sfm_data_colorization.hpp
+++ b/src/openMVG/sfm/sfm_data_colorization.hpp
@@ -1,0 +1,29 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2015 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+#ifndef OPENMVG_SFM_SFM_DATA_COLORIZATION_HPP
+#define OPENMVG_SFM_SFM_DATA_COLORIZATION_HPP
+
+
+#include "openMVG/sfm/sfm_data.hpp"
+
+namespace openMVG {
+namespace sfm {
+
+struct SfM_Data;
+
+bool ColorizeTracks(
+  const SfM_Data & sfm_data,
+  std::vector<Vec3> & vec_3dPoints,
+  std::vector<Vec3> & vec_tracksColor);
+
+} // namespace sfm
+} // namespace openMVG
+
+#endif // OPENMVG_SFM_SFM_DATA_COLORIZATION_HPP

--- a/src/software/SfM/main_ComputeSfM_DataColor.cpp
+++ b/src/software/SfM/main_ComputeSfM_DataColor.cpp
@@ -6,143 +6,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "openMVG/image/image_io.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/sfm/sfm_data_io.hpp"
-#include "openMVG/stl/stl.hpp"
 #include "openMVG/types.hpp"
 #include "software/SfM/SfMPlyHelper.hpp"
-
 #include "third_party/cmdLine/cmdLine.h"
-#include "third_party/progress/progress_display.hpp"
-#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+#include "openMVG/sfm/sfm_data_colorization.hpp"
 
 using namespace openMVG;
-using namespace openMVG::image;
 using namespace openMVG::sfm;
-
-/// Find the color of the SfM_Data Landmarks/structure
-bool ColorizeTracks(
-  const SfM_Data & sfm_data,
-  std::vector<Vec3> & vec_3dPoints,
-  std::vector<Vec3> & vec_tracksColor)
-{
-  // Colorize each track
-  //  Start with the most representative image
-  //    and iterate to provide a color to each 3D point
-
-  {
-    C_Progress_display my_progress_bar(sfm_data.GetLandmarks().size(),
-                                       std::cout,
-                                       "\nCompute scene structure color\n");
-
-    vec_tracksColor.resize(sfm_data.GetLandmarks().size());
-    vec_3dPoints.resize(sfm_data.GetLandmarks().size());
-
-    //Build a list of contiguous index for the trackIds
-    std::map<IndexT, IndexT> trackIds_to_contiguousIndexes;
-    IndexT cpt = 0;
-    for (Landmarks::const_iterator it = sfm_data.GetLandmarks().begin();
-      it != sfm_data.GetLandmarks().end(); ++it, ++cpt)
-    {
-      trackIds_to_contiguousIndexes[it->first] = cpt;
-      vec_3dPoints[cpt] = it->second.X;
-    }
-
-    // The track list that will be colored (point removed during the process)
-    std::set<IndexT> remainingTrackToColor;
-    std::transform(sfm_data.GetLandmarks().begin(), sfm_data.GetLandmarks().end(),
-      std::inserter(remainingTrackToColor, remainingTrackToColor.begin()),
-      stl::RetrieveKey());
-
-    while ( !remainingTrackToColor.empty() )
-    {
-      // Find the most representative image (for the remaining 3D points)
-      //  a. Count the number of observation per view for each 3Dpoint Index
-      //  b. Sort to find the most representative view index
-
-      std::map<IndexT, IndexT> map_IndexCardinal; // ViewId, Cardinal
-      for (std::set<IndexT>::const_iterator
-        iterT = remainingTrackToColor.begin();
-        iterT != remainingTrackToColor.end();
-        ++iterT)
-      {
-        const size_t trackId = *iterT;
-        const Observations & obs = sfm_data.GetLandmarks().at(trackId).obs;
-        for (Observations::const_iterator iterObs = obs.begin();
-          iterObs != obs.end(); ++iterObs)
-        {
-          const size_t viewId = iterObs->first;
-          if (map_IndexCardinal.find(viewId) == map_IndexCardinal.end())
-            map_IndexCardinal[viewId] = 1;
-          else
-            ++map_IndexCardinal[viewId];
-        }
-      }
-
-      // Find the View index that is the most represented
-      std::vector<IndexT> vec_cardinal;
-      std::transform(map_IndexCardinal.begin(),
-        map_IndexCardinal.end(),
-        std::back_inserter(vec_cardinal),
-        stl::RetrieveValue());
-      using namespace stl::indexed_sort;
-      std::vector<sort_index_packet_descend<IndexT, IndexT>> packet_vec(vec_cardinal.size());
-      sort_index_helper(packet_vec, &vec_cardinal[0], 1);
-
-      // First image index with the most of occurence
-      std::map<IndexT, IndexT>::const_iterator iterTT = map_IndexCardinal.begin();
-      std::advance(iterTT, packet_vec[0].index);
-      const size_t view_index = iterTT->first;
-      const View * view = sfm_data.GetViews().at(view_index).get();
-      const std::string sView_filename = stlplus::create_filespec(sfm_data.s_root_path,
-        view->s_Img_path);
-      Image<RGBColor> image_rgb;
-      Image<unsigned char> image_gray;
-      const bool b_rgb_image = ReadImage(sView_filename.c_str(), &image_rgb);
-      if (!b_rgb_image) //try Gray level
-      {
-        const bool b_gray_image = ReadImage(sView_filename.c_str(), &image_gray);
-        if (!b_gray_image)
-        {
-          std::cerr << "Cannot open provided the image." << std::endl;
-          return false;
-        }
-      }
-
-      // Iterate through the remaining track to color
-      // - look if the current view is present to color the track
-      std::set<IndexT> set_toRemove;
-      for (std::set<IndexT>::const_iterator
-        iterT = remainingTrackToColor.begin();
-        iterT != remainingTrackToColor.end();
-        ++iterT)
-      {
-        const size_t trackId = *iterT;
-        const Observations & obs = sfm_data.GetLandmarks().at(trackId).obs;
-        Observations::const_iterator it = obs.find(view_index);
-
-        if (it != obs.end())
-        {
-          // Color the track
-          const Vec2 & pt = it->second.x;
-          const RGBColor color = b_rgb_image ? image_rgb(pt.y(), pt.x()) : RGBColor(image_gray(pt.y(), pt.x()));
-
-          vec_tracksColor[ trackIds_to_contiguousIndexes[trackId] ] = Vec3(color.r(), color.g(), color.b());
-          set_toRemove.insert(trackId);
-          ++my_progress_bar;
-        }
-      }
-      // Remove colored track
-      for (std::set<IndexT>::const_iterator iter = set_toRemove.begin();
-        iter != set_toRemove.end(); ++iter)
-      {
-        remainingTrackToColor.erase(*iter);
-      }
-    }
-  }
-  return true;
-}
 
 /// Export camera poses positions as a Vec3 vector
 void GetCameraPositions(const SfM_Data & sfm_data, std::vector<Vec3> & vec_camPosition)
@@ -210,5 +83,6 @@ int main(int argc, char **argv)
       return EXIT_SUCCESS;
     }
   }
+
   return EXIT_FAILURE;
 }


### PR DESCRIPTION
This is a PR to provide the sfm colorize functionally for different executables (main_openMVG2Colmap, main_openMVG2NVM)

At the moment the line (line 100 in sfm_data_colorization.cpp)
`const bool b_rgb_image = ReadImage(sView_filename.c_str(), &image_rgb);`

causes the following error message 

`../../Linux-x86_64-Release/libopenMVG_sfm.a(sfm_data_colorization.cpp.o): In function `openMVG::sfm::ColorizeTracks(openMVG::sfm::SfM_Data const&, std::vector<Eigen::Matrix<double, 3, 1, 0, 3, 1>, std::allocator<Eigen::Matrix<double, 3, 1, 0, 3, 1> > >&, std::vector<Eigen::Matrix<double, 3, 1, 0, 3, 1>, std::allocator<Eigen::Matrix<double, 3, 1, 0, 3, 1> > >&)':
sfm_data_colorization.cpp:(.text+0x979): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgb<unsigned char> >'
sfm_data_colorization.cpp:(.text+0xda0): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgb<unsigned char> >'
sfm_data_colorization.cpp:(.text+0x1057): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgb<unsigned char> >'
sfm_data_colorization.cpp:(.text+0x1548): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgb<unsigned char> >'
../../Linux-x86_64-Release/libopenMVG_sfm.a(sfm_data_colorization.cpp.o): In function `int openMVG::image::ReadImage<unsigned char>(char const*, openMVG::image::Image<unsigned char>*)':
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE]+0x57): undefined reference to `openMVG::image::ReadImage(char const*, std::vector<unsigned char, std::allocator<unsigned char> >*, int*, int*, int*)'
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE]+0xc9): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgba<unsigned char> >'
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE]+0x162): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgba<unsigned char> >'
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE]+0x21c): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgb<unsigned char> >'
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE]+0x2b5): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgb<unsigned char> >'
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE]+0x67f): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgb<unsigned char> >'
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageIhEEiPKcPNS0_5ImageIT_EE]+0x86e): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgba<unsigned char> >'
../../Linux-x86_64-Release/libopenMVG_sfm.a(sfm_data_colorization.cpp.o): In function `int openMVG::image::ReadImage<openMVG::image::Rgb<unsigned char> >(char const*, openMVG::image::Image<openMVG::image::Rgb<unsigned char> >*)':
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageINS0_3RgbIhEEEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageINS0_3RgbIhEEEEiPKcPNS0_5ImageIT_EE]+0x57): undefined reference to `openMVG::image::ReadImage(char const*, std::vector<unsigned char, std::allocator<unsigned char> >*, int*, int*, int*)'
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageINS0_3RgbIhEEEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageINS0_3RgbIhEEEEiPKcPNS0_5ImageIT_EE]+0xb6): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgba<unsigned char> >'
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageINS0_3RgbIhEEEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageINS0_3RgbIhEEEEiPKcPNS0_5ImageIT_EE]+0x14f): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgba<unsigned char> >'
sfm_data_colorization.cpp:(.text._ZN7openMVG5image9ReadImageINS0_3RgbIhEEEEiPKcPNS0_5ImageIT_EE[_ZN7openMVG5image9ReadImageINS0_3RgbIhEEEEiPKcPNS0_5ImageIT_EE]+0x51e): undefined reference to `vtable for openMVG::image::Image<openMVG::image::Rgba<unsigned char> >'
collect2: error: ld returned 1 exit status
make[2]: *** [Linux-x86_64-Release/openMVG_main_ComputeSfM_DataColor] Error 1
make[1]: *** [software/SfM/CMakeFiles/openMVG_main_ComputeSfM_DataColor.dir/all] Error 2
make: *** [all] Error 2`

With 
`const bool b_rgb_image = true; // ReadImage(sView_filename.c_str(), &image_rgb); `
the PR compiles and links correctly

I'm pretty sure this is caused by the template used by openMVG::image::Image. 
Unfortunately my c++ template experience is quite limited ...
Any ideas / suggestions?