### PR TITLE
FIx the CVPR 2017 resection solver

### DIFF
--- a/src/openMVG/multiview/solver_resection_p3p_ke.hpp
+++ b/src/openMVG/multiview/solver_resection_p3p_ke.hpp
@@ -15,8 +15,8 @@ namespace openMVG {
 namespace euclidean_resection {
 
 struct P3PSolver_Ke {
-  enum { MINIMUM_SAMPLES = 6 };
-  enum { MAX_MODELS = 1 };
+  enum { MINIMUM_SAMPLES = 3 };
+  enum { MAX_MODELS = 4 };
 
   // Solve the absolute camera pose problem.
   // Use "An Efficient Algebraic Solution to the Perspective-Three-Point Problem".


### PR DESCRIPTION
Num samples where copy pasted from the 6 point DLT solver file. This could lead to some bad behavior into the ACRansac framework.