### PR TITLE
SfM regions provider include in ACRobust header files fix

### DIFF
--- a/src/openMVG/matching_image_collection/E_ACRobust.hpp
+++ b/src/openMVG/matching_image_collection/E_ACRobust.hpp
@@ -22,6 +22,7 @@
 #include "openMVG/robust_estimation/robust_estimator_ACRansacKernelAdaptator.hpp"
 #include "openMVG/robust_estimation/guided_matching.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
+#include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
 #include "openMVG/types.hpp"
 
 namespace openMVG {

--- a/src/openMVG/matching_image_collection/F_ACRobust.hpp
+++ b/src/openMVG/matching_image_collection/F_ACRobust.hpp
@@ -21,6 +21,7 @@
 #include "openMVG/robust_estimation/robust_estimator_ACRansac.hpp"
 #include "openMVG/robust_estimation/robust_estimator_ACRansacKernelAdaptator.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
+#include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
 
 namespace openMVG { namespace sfm { struct Regions_Provider; }
 

--- a/src/openMVG/matching_image_collection/H_ACRobust.hpp
+++ b/src/openMVG/matching_image_collection/H_ACRobust.hpp
@@ -21,6 +21,7 @@
 #include "openMVG/robust_estimation/robust_estimator_ACRansac.hpp"
 #include "openMVG/robust_estimation/robust_estimator_ACRansacKernelAdaptator.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
+#include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
 
 namespace openMVG {
 


### PR DESCRIPTION
All three `*_ACRobust.hpp` files are missing SfM regions provider includes needed by `Regions_Provider::get()` calls in these files. This PR fixes the problem.