### PR TITLE
fix an error in colorHarmonize about eigen

### DIFF
--- a/src/software/colorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/colorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -398,7 +398,7 @@ bool ColorHarmonizationEngineGlobal::Process()
   {
     const size_t imaNum = *iterSet;
     using Vec256 = Eigen::Matrix<double, 256, 1>;
-    std::vector< Vec256 > vec_map_lut(3);
+    std::vector< Vec256,Eigen::aligned_allocator<Vec256> > vec_map_lut(3);
 
     const size_t nodeIndex = std::distance(set_indeximage.begin(), iterSet);
 


### PR DESCRIPTION
Error
--
openMVG_main_ColHarmonize: /home/yan/Desktop/openMVG_Color/openMVG/src/third_party/eigen/Eigen/src/Core/DenseStorage.h:128: Eigen::internal::plain_array<T, Size, MatrixOrArrayOptions, 32>::plain_array() [with T = double; int Size = 256; int MatrixOrArrayOptions = 0]: Assertion `(internal::UIntPtr(eigen_unaligned_array_assert_workaround_gcc47(array)) & (31)) == 0 && "this assertion is explained here: " "http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html" " **** READ THIS WEB PAGE !!! ****"' failed.
Aborted (core dumped)

Reference
---
http://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html