### PR TITLE
Corrected a problem with updating intrinsics after BA in localization…

### DIFF
--- a/src/openMVG/sfm/pipelines/localization/SfM_Localizer.cpp
+++ b/src/openMVG/sfm/pipelines/localization/SfM_Localizer.cpp
@@ -311,7 +311,7 @@ namespace sfm {
     {
       pose = sfm_data.poses[0];
       if (b_refine_intrinsic)
-        *intrinsics = *shared_intrinsics;
+        intrinsics->updateFromParams(shared_intrinsics->getParams());
     }
 
     return b_BA_Status;


### PR DESCRIPTION
Hi @pmoulon,

while looking at the localization module I noticed that the intrinsics in the RefinePose function do not get updated correctly (they are not updated with the new optimized values). 

I solved the problem with a simple _updateFromParams_ call as the _shared_intrinsics_ is just a clone of _intrinsics_. I'm not sure if that is the best solution but please have a look.

Cheers,
Klemen