### PR TITLE
[sfm] Add ply output at the end each resection round in IncrementalSfMv2

### DIFF
--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM2.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM2.cpp
@@ -163,6 +163,9 @@ bool SequentialSfMReconstructionEngine2::Process() {
       RemoveOutliers_AngleError(sfm_data_, 2.0);
       RemoveOutliers_PixelResidualError(sfm_data_, 4.0);
       eraseUnstablePosesAndObservations(sfm_data_);
+      std::ostringstream os;
+      os << std::setw(8) << std::setfill('0') << resection_round << "_Resection";
+      Save(sfm_data_, stlplus::create_filespec(sOut_directory_, os.str(), ".ply"), ESfM_Data(ALL));
       ++resection_round;
     }
   }


### PR DESCRIPTION
I have backported this feature from IncrementalSfMv1. I found it very useful in order to control the consistency of the reconstruction. 