### PR TITLE
Fixes the typo on the build scripts for vcpkg compilation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -156,7 +156,7 @@ Checking out OpenMVG and build it
 $ git clone --recursive https://github.com/openMVG/openMVG.git
 $ mkdir openMVG_Build
 $ cd openMVG_Build
-$ cmake ../openMVG/src/ -DCMAKE_TOOLCHAIN_FILE=<VCPK_ROOT>/scripts/buildsystems/vcpkg.cmake
+$ cmake -DCMAKE_TOOLCHAIN_FILE=<VCPK_ROOT>/scripts/buildsystems/vcpkg.cmake ../openMVG/src/
 $ cmake --build .
 ```
 


### PR DESCRIPTION
I have came across below error when following the installation steps described in build.md:

```
cmake ../openMVG/src/ -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake
CMake Error: The source directory "../vcpkg/scripts/buildsystems/vcpkg.cmake" is a file, not a
directory.
Specify --help for usage, or press the help button on the CMake GUI.
```

This has also happened to some other packages: `https://github.com/willyd/caffe-builder/issues/39#issuecomment-290877409` and is apparently just a typo on the readme. I have updated the instructions so that it works in my current system.