### PR TITLE
export cereal as target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -227,12 +227,16 @@ ENDMACRO(UNIT_TEST)
 # - internal if cereal not found
 # ==============================================================================
 find_package(cereal QUIET CONFIG)
-if (NOT cereal_FOUND)
-  set(CEREAL_INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/cereal/include)
+if (NOT TARGET cereal)
+  add_library(cereal INTERFACE)
+  target_include_directories(cereal
+    INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/dependencies/cereal/include>
+      $<INSTALL_INTERFACE:include/openMVG_dependencies/cereal/include>
+  )
+  install(TARGETS cereal EXPORT openMVG-targets)
+
   set(OpenMVG_USE_INTERNAL_CEREAL ON)
-else()
-  get_target_property(CEREAL_INCLUDE_DIRS cereal INTERFACE_INCLUDE_DIRECTORIES)
 endif()
 
 # ==============================================================================
@@ -242,8 +246,8 @@ endif()
 # - external if EIGEN_INCLUDE_DIR_HINTS is defined
 # - internal if Eigen not found
 # ==============================================================================
-find_package(eigen3 QUIET)
-if (NOT eigen3_FOUND)
+find_package(Eigen3 QUIET)
+if (NOT Eigen3_FOUND)
   set(EIGEN_INCLUDE_DIR_HINTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/eigen)
   set(OpenMVG_USE_INTERNAL_EIGEN ON)
   find_package(Eigen QUIET)

--- a/src/openMVG/cameras/CMakeLists.txt
+++ b/src/openMVG/cameras/CMakeLists.txt
@@ -20,6 +20,6 @@ UNIT_TEST(openMVG Camera_Spherical openMVG_camera)
 UNIT_TEST(openMVG Camera_Subset_Parametrization openMVG_camera)
 
 add_library(openMVG_camera_test INTERFACE)
-target_link_libraries(openMVG_camera_test INTERFACE openMVG_camera cereal)
+target_link_libraries(openMVG_camera_test INTERFACE openMVG_camera)
 
 UNIT_TEST(openMVG Camera_IO "openMVG_camera_test;${STLPLUS_LIBRARY}")

--- a/src/openMVG/cameras/CMakeLists.txt
+++ b/src/openMVG/cameras/CMakeLists.txt
@@ -4,7 +4,7 @@ set_property(TARGET openMVG_camera APPEND PROPERTY
   INTERFACE_INCLUDE_DIRECTORIES "$<INSTALL_INTERFACE:include>")
 
 target_compile_features(openMVG_camera INTERFACE ${CXX11_FEATURES})
-target_link_libraries(openMVG_camera INTERFACE openMVG_numeric ${OPENMVG_LIBRARY_DEPENDENCIES})
+target_link_libraries(openMVG_camera INTERFACE openMVG_numeric cereal ${OPENMVG_LIBRARY_DEPENDENCIES})
 install(TARGETS openMVG_camera DESTINATION lib EXPORT openMVG-targets)
 
 UNIT_TEST(openMVG Camera_Pinhole openMVG_camera)
@@ -20,8 +20,6 @@ UNIT_TEST(openMVG Camera_Spherical openMVG_camera)
 UNIT_TEST(openMVG Camera_Subset_Parametrization openMVG_camera)
 
 add_library(openMVG_camera_test INTERFACE)
-target_link_libraries(openMVG_camera_test INTERFACE openMVG_camera)
-target_include_directories(openMVG_camera_test
-  INTERFACE $<BUILD_INTERFACE:${CEREAL_INCLUDE_DIRS}>)
+target_link_libraries(openMVG_camera_test INTERFACE openMVG_camera cereal)
 
 UNIT_TEST(openMVG Camera_IO "openMVG_camera_test;${STLPLUS_LIBRARY}")

--- a/src/openMVG/features/CMakeLists.txt
+++ b/src/openMVG/features/CMakeLists.txt
@@ -26,13 +26,12 @@ target_include_directories(openMVG_features
   PUBLIC
     $<BUILD_INTERFACE:${EIGEN_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${CEREAL_INCLUDE_DIRS}>
     $<INSTALL_INTERFACE:include>
     $<INSTALL_INTERFACE:include/openMVG>
 )
 target_link_libraries(openMVG_features
   PRIVATE openMVG_fast ${STLPLUS_LIBRARY}
-  PUBLIC ${OPENMVG_LIBRARY_DEPENDENCIES})
+  PUBLIC ${OPENMVG_LIBRARY_DEPENDENCIES} cereal)
 if (MSVC)
   set_target_properties(openMVG_features PROPERTIES COMPILE_FLAGS "/bigobj")
   target_compile_options(openMVG_features PUBLIC "-D_USE_MATH_DEFINES")

--- a/src/openMVG/geometry/CMakeLists.txt
+++ b/src/openMVG/geometry/CMakeLists.txt
@@ -21,6 +21,7 @@ set_property(TARGET openMVG_geometry PROPERTY FOLDER OpenMVG/OpenMVG)
 target_link_libraries(openMVG_geometry
   PUBLIC
     openMVG_numeric
+    cereal
   PRIVATE
     openMVG_linearProgramming
 )

--- a/src/openMVG/matching/CMakeLists.txt
+++ b/src/openMVG/matching/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(openMVG_matching
   PUBLIC
     openMVG_features
     Threads::Threads
+    cereal
 )
 if (NOT DEFINED OpenMVG_USE_INTERNAL_FLANN)
 target_link_libraries(openMVG_matching

--- a/src/openMVG/sfm/CMakeLists.txt
+++ b/src/openMVG/sfm/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(openMVG_sfm
     openMVG_graph
     openMVG_matching
     openMVG_multiview
+    cereal
     ${OPENMVG_LIBRARY_DEPENDENCIES}
 )
 


### PR DESCRIPTION
I was having issues with `cereal` when using `openMVG` as library.  `openMVG` does not export `cereal` when using internal version.

I created new interface target which is installed with `openMVG-targets`. I also added `cereal` as public dependency to all targets where it is used in header files. Usually in *_io.hpp. All test are passing and I can use `openMVG` as external library while still using headers which include `<cereal/...>`