### PR TITLE
[sfm] Improve robust triangulation

### DIFF
--- a/src/openMVG/multiview/triangulation_nview.cpp
+++ b/src/openMVG/multiview/triangulation_nview.cpp
@@ -17,18 +17,18 @@ namespace openMVG {
 void TriangulateNView
 (
   const Mat3X &x,
-  const std::vector<Mat34> &Ps,
+  const std::vector<Mat34> &poses,
   Vec4 *X
 )
 {
   assert(X != nullptr);
   const Mat2X::Index nviews = x.cols();
-  assert(static_cast<size_t>(nviews) == Ps.size());
+  assert(static_cast<size_t>(nviews) == poses.size());
 
   Mat A = Mat::Zero(3 * nviews, 4 + nviews);
   for (Mat::Index i = 0; i < nviews; ++i)
   {
-    A.block<3, 4>(3 * i, 0)     = -Ps[i];
+    A.block<3, 4>(3 * i, 0)     = -poses[i];
     A.block<3,1> (3 * i, 4 + i) = x.col(i);
   }
   Vec X_and_alphas(4 + nviews);
@@ -39,8 +39,8 @@ void TriangulateNView
 bool TriangulateNViewAlgebraic
 (
   const Mat3X & points,
-  const std::vector<Mat34>& poses,
-  Vec4* X
+  const std::vector<Mat34> &poses,
+  Vec4 *X
 )
 {
   assert(poses.size() == points.cols());

--- a/src/openMVG/sfm/sfm_data_triangulation.cpp
+++ b/src/openMVG/sfm/sfm_data_triangulation.cpp
@@ -40,6 +40,47 @@ SfM_Data_Structure_Computation_Blind::SfM_Data_Structure_Computation_Blind
 {
 }
 
+/// Triangulate a given track
+bool track_full_triangulation
+(
+  const SfM_Data & sfm_data,
+  const Observations & obs,
+  Vec3 & X
+)
+{
+  if (obs.size() >= 2)
+  {
+    std::vector<Vec3> bearing;
+    std::vector<Mat34> poses;
+    bearing.reserve(obs.size());
+    poses.reserve(obs.size());
+    for (const auto& curr_obs : obs)
+    {
+      const View * view = sfm_data.views.at(curr_obs.first).get();
+      if (!sfm_data.IsPoseAndIntrinsicDefined(view))
+        continue;
+      const IntrinsicBase * cam = sfm_data.GetIntrinsics().at(view->id_intrinsic).get();
+      const Pose3 pose = sfm_data.GetPoseOrDie(view);
+      bearing.emplace_back((*cam)(cam->get_ud_pixel(curr_obs.second.x)));
+      poses.emplace_back(pose.asMatrix());
+    }
+    if (bearing.size() >= 2)
+    {
+      const Eigen::Map<const Mat3X> bearing_matrix(bearing[0].data(), 3, bearing.size());
+      Vec4 Xhomogeneous;
+      TriangulateNViewAlgebraic
+      (
+        bearing_matrix,
+        poses, // Ps are projective cameras.
+        &Xhomogeneous);
+      X = Xhomogeneous.hnormalized();
+      return true;
+    }
+  }
+  return false;
+}
+
+
 /// Triangulate a given track from a selection of observations
 bool track_sample_triangulation
 (
@@ -116,10 +157,8 @@ const
       bool bKeep = false;
       {
         // Generate the track 3D hypothesis
-        std::set<IndexT> samples;
-        for (size_t i = 0; i < obs.size(); ++i)  { samples.insert(i); }
         Vec3 X;
-        if (track_sample_triangulation(sfm_data, obs, samples, X))
+        if (track_full_triangulation(sfm_data, obs, X))
         {
           bool bChierality = true;
           for (Observations::const_iterator obs_it = obs.begin();
@@ -253,23 +292,18 @@ const
   if (min_required_inliers_ == min_sample_index_ &&
       obs.size() == min_required_inliers_)
   {
-    std::set<IndexT> samples;
-    for (int i = 0; i < min_required_inliers_; ++i)  { samples.insert(i); }
     // Generate the 3D point hypothesis by triangulating the observations
     Vec3 X;
-    if (track_sample_triangulation(sfm_data, obs, samples, X))
+    if (track_full_triangulation(sfm_data, obs, X))
     {
       // Test validity of the hypothesis:
       // - residual error
       // - chierality
       bool bChierality = true;
       bool bReprojection_error = true;
-      IndexT validity_test_count = 0;
-      for (std::set<IndexT>::const_iterator it = samples.begin();
-        it != samples.end() && bChierality && bReprojection_error; ++it)
+      for (Observations::const_iterator itObs = obs.begin();
+        itObs != obs.end() && bChierality && bReprojection_error; ++itObs)
       {
-        Observations::const_iterator itObs = obs.begin();
-        std::advance(itObs, *it);
         const View * view = sfm_data.views.at(itObs->first).get();
         if (!sfm_data.IsPoseAndIntrinsicDefined(view))
           continue;
@@ -278,11 +312,9 @@ const
         bChierality &= CheiralityTest((*cam)(itObs->second.x), pose, X);
         const Vec2 residual = cam->residual(pose(X), itObs->second.x);
         bReprojection_error &= residual.squaredNorm() < dSquared_pixel_threshold;
-        validity_test_count += (bChierality && bReprojection_error) ? 1 : 0;
       }
 
-      if (bChierality && bReprojection_error &&
-          validity_test_count >= min_required_inliers_)
+      if (bChierality && bReprojection_error)
       {
         landmark.X = X;
         landmark.obs = obs;
@@ -335,7 +367,7 @@ const
         continue;
       const IntrinsicBase * cam = sfm_data.GetIntrinsics().at(view->id_intrinsic).get();
       const Pose3 pose = sfm_data.GetPoseOrDie(view);
-      bChierality &= CheiralityTest((*cam)(itObs->second.x), pose, X);;
+      bChierality &= CheiralityTest((*cam)(itObs->second.x), pose, X);
       const Vec2 residual = cam->residual(pose(X), itObs->second.x);
       bReprojection_error &= residual.squaredNorm() < dSquared_pixel_threshold;
       validity_test_count += (bChierality && bReprojection_error) ? 1 : 0;
@@ -346,6 +378,7 @@ const
       continue;
 
     std::deque<IndexT> inlier_set;
+    bool bChierality_obs = true;
     double current_error = 0.0;
     // inlier/outlier classification according pixel residual errors.
     for (const auto & obs_it : obs)
@@ -357,6 +390,8 @@ const
       const Pose3 pose = sfm_data.GetPoseOrDie(view);
       const Vec2 residual = intrinsic->residual(pose(X), obs_it.second.x);
       const double residual_d = residual.squaredNorm();
+      bChierality_obs &= CheiralityTest((*intrinsic)(obs_it.second.x), pose, X);
+      if (!bChierality_obs) break;
       if (residual_d < dSquared_pixel_threshold)
       {
         inlier_set.push_front(obs_it.first);
@@ -368,7 +403,9 @@ const
       }
     }
     // Does the hypothesis is the best one we have seen and have sufficient inliers.
-    if (current_error < best_error && inlier_set.size() >= min_required_inliers_)
+    if (bChierality_obs && 
+      current_error < best_error && 
+      inlier_set.size() >= min_required_inliers_)
     {
       best_model = X;
       best_inlier_set = inlier_set;


### PR DESCRIPTION
Improve triangulation by:
- Using cheirality as an hard requierement for inlier classification
- Removing an useless test on exhaustive triangulation
 => in this case if one obs fail its obvious the number of valid observation will be < of the min_required_inliers_
- Adding a function to triangulate the full track in order to (hopefully) improve the computation time and simplify the code at some place (at the price of not being very DRY).