### PR TITLE
[SfMv2] reset track ratio each time we augment the pose set

### DIFF
--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM2.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM2.cpp
@@ -148,8 +148,8 @@ bool SequentialSfMReconstructionEngine2::Process() {
 
   // Incrementally estimate the pose of the cameras based on a confidence score.
   // The confidence score is based on the track_inlier_ratio.
-  // First the camera with the most of 2D-3D overlap are added the we added
-  // the one with lower confidence.
+  // First the camera with the most of 2D-3D overlap are added then we add
+  // ones with lower confidence.
   const std::array<float, 2> track_inlier_ratios = {0.2, 0.0};
   for (auto track_inlier_ratio = track_inlier_ratios.cbegin(); 
     track_inlier_ratio < track_inlier_ratios.cend(); ++track_inlier_ratio)
@@ -177,7 +177,7 @@ bool SequentialSfMReconstructionEngine2::Process() {
       if (pose_before >= pose_after)
         break;
       pose_before = sfm_data_.GetPoses().size();
-      // Since we have augmented our set of pose we can reset our track inlier ratio iterator 
+      // Since we have augmented our set of poses we can reset our track inlier ratio iterator 
       track_inlier_ratio = track_inlier_ratios.cbegin();
     }
   }


### PR DESCRIPTION
the track_inlier_ratio is  a good safe guard to avoid to estimate poses of yet weakly supported views.

Nevertheless, actually, once we reach a part of the view graph with a weakly supported views the track_inlier_ratio is downgraded (from 0.2 to 0.0) and it is never upgraded again until the end of the reconstruction. Weakly supported part of the viewgraph could be transition between two "communities" and thus I think we should reset the ratio each time we augment the pose set (I do think it was the intended behavior) to avoid to register some view too early that could create a "very unfortunate ordering". On my experiments, reseting the track_inlier_ratio leads to **really** far more stable reconstructions (less bad registrations), at the expense of course of a bigger number of iterations (but maybe we could fine tune the ratios. something like this works well on my sets { 0.15, 0.05, 0.02, 0.0 }).