### PR TITLE
Target architecture

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,7 +100,6 @@ endif()
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmakeFindModules)
 include(OptimizeForArchitecture)
-AutodetectHostArchitecture()
 OptimizeForArchitecture()
 
 if (UNIX AND NOT OpenMVG_BUILD_COVERAGE)


### PR DESCRIPTION
This commit prevents OpenMVG to override cache variable `TARGET_ARCHITECTURE`. Default value is `auto` and will internally call `AutodetectHostArchitecture`