### PR TITLE
[cameras] simplify AngleBetweenRay

### DIFF
--- a/src/openMVG/cameras/Camera_Intrinsics.hpp
+++ b/src/openMVG/cameras/Camera_Intrinsics.hpp
@@ -274,9 +274,8 @@ inline double AngleBetweenRay
   // ray = X - C = R.t() * K.inv() * x
   const Vec3 ray1 = ( pose1.rotation().transpose() * intrinsic1->operator()( x1 ) ).normalized();
   const Vec3 ray2 = ( pose2.rotation().transpose() * intrinsic2->operator()( x2 ) ).normalized();
-  const double mag = ray1.norm() * ray2.norm();
   const double dotAngle = ray1.dot( ray2 );
-  return R2D( acos( clamp( dotAngle / mag, -1.0 + 1.e-8, 1.0 - 1.e-8 ) ) );
+  return R2D( acos( clamp( dotAngle, -1.0 + 1.e-8, 1.0 - 1.e-8 ) ) );
 }
 
 /**

--- a/src/openMVG/cameras/PinholeCamera.hpp
+++ b/src/openMVG/cameras/PinholeCamera.hpp
@@ -98,9 +98,8 @@ struct PinholeCamera
       (cam1._K.inverse() * Vec3(x1(0), x1(1), 1.))).normalized();
     Vec3 ray2 = (cam2._R.transpose() *
       (cam2._K.inverse() * Vec3(x2(0), x2(1), 1.))).normalized();
-    double mag = ray1.norm() * ray2.norm();
     double dotAngle = ray1.dot(ray2);
-    return R2D(acos(clamp(dotAngle/mag, -1.0 + 1.e-8, 1.0 - 1.e-8)));
+    return R2D(acos(clamp(dotAngle, -1.0 + 1.e-8, 1.0 - 1.e-8)));
   }
 
 };


### PR DESCRIPTION
Since `ray1` and `ray2` are already normalized` ray1.norm() `== `ray2.norm()` = 1