### PR TITLE
Split SFM Compute matches into functional parts

### DIFF
--- a/src/openMVG/matching/indMatch.hpp
+++ b/src/openMVG/matching/indMatch.hpp
@@ -102,6 +102,26 @@ inline Pair_Set getPairs(const PairWiseMatches & matches)
   return pairs;
 }
 
+/**
+ * @brief Get the subset of the matches that corresponds to the given pairs 
+ * 
+ * @param matches     Initial matches 
+ * @param pairs       The only pairs to keep 
+ * @return PairWiseMatches The matches that are inside the pairset
+ */
+inline PairWiseMatches getPairs( const PairWiseMatches & matches, const Pair_Set & pairs )
+{
+  PairWiseMatches res;
+  for( auto it_pair : pairs )
+  {
+    if( matches.count( it_pair ) )
+    {
+      res.insert( std::make_pair( it_pair , matches.at( it_pair ) ) );
+    }
+  }
+  return res; 
+}
+
 }  // namespace matching
 }  // namespace openMVG
 

--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -60,8 +60,8 @@ target_link_libraries(openMVG_main_ListMatchingPairs
     ${STLPLUS_LIBRARY}
 )
 
-add_executable( openMVG_main_PairsGenerator main_PairsGenerator.cpp )
-target_link_libraries( openMVG_main_PairsGenerator 
+add_executable( openMVG_main_PairGenerator main_PairGenerator.cpp )
+target_link_libraries( openMVG_main_PairGenerator 
   PRIVATE
     openMVG_features
     openMVG_multiview
@@ -107,14 +107,14 @@ target_link_libraries(openMVG_main_MatchesToTracks
 # Installation rules
 set_property( TARGET openMVG_main_ListMatchingPairs PROPERTY FOLDER OpenMVG/software )
 set_property( TARGET openMVG_main_ComputeFeatures   PROPERTY FOLDER OpenMVG/software )
-set_property( TARGET openMVG_main_PairsGenerator    PROPERTY FOLDER OpenMVG/software )
+set_property( TARGET openMVG_main_PairGenerator    PROPERTY FOLDER OpenMVG/software )
 set_property( TARGET openMVG_main_ComputeMatches    PROPERTY FOLDER OpenMVG/software )
 set_property( TARGET openMVG_main_GeometricFilter   PROPERTY FOLDER OpenMVG/software )
 set_property( TARGET openMVG_main_MatchesToTracks   PROPERTY FOLDER OpenMVG/software )
 
 install( TARGETS openMVG_main_ListMatchingPairs DESTINATION bin/ )
 install( TARGETS openMVG_main_ComputeFeatures   DESTINATION bin/ )
-install( TARGETS openMVG_main_PairsGenerator    DESTINATION bin/ )
+install( TARGETS openMVG_main_PairGenerator    DESTINATION bin/ )
 install( TARGETS openMVG_main_ComputeMatches    DESTINATION bin/ )
 install( TARGETS openMVG_main_GeometricFilter   DESTINATION bin/ )
 install( TARGETS openMVG_main_MatchesToTracks   DESTINATION bin/ )

--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -60,6 +60,16 @@ target_link_libraries(openMVG_main_ListMatchingPairs
     ${STLPLUS_LIBRARY}
 )
 
+add_executable( openMVG_main_PairsGenerator main_PairsGenerator.cpp )
+target_link_libraries( openMVG_main_PairsGenerator 
+  PRIVATE
+    openMVG_features
+    openMVG_multiview
+    openMVG_sfm
+    openMVG_system
+    ${STLPLUS_LIBRARY}
+)
+
 add_executable(openMVG_main_ComputeMatches main_ComputeMatches.cpp)
 target_link_libraries(openMVG_main_ComputeMatches
   PRIVATE
@@ -95,14 +105,19 @@ target_link_libraries(openMVG_main_MatchesToTracks
 )
 
 # Installation rules
-set_property(TARGET openMVG_main_ComputeFeatures PROPERTY FOLDER OpenMVG/software)
-install(TARGETS openMVG_main_ComputeFeatures DESTINATION bin/)
-set_property(TARGET openMVG_main_ListMatchingPairs PROPERTY FOLDER OpenMVG/software)
-install(TARGETS openMVG_main_ListMatchingPairs DESTINATION bin/)
-set_property(TARGET openMVG_main_ComputeMatches PROPERTY FOLDER OpenMVG/software)
-install(TARGETS openMVG_main_ComputeMatches DESTINATION bin/)
-set_property(TARGET openMVG_main_MatchesToTracks PROPERTY FOLDER OpenMVG/software)
-install(TARGETS openMVG_main_MatchesToTracks DESTINATION bin/)
+set_property( TARGET openMVG_main_ListMatchingPairs PROPERTY FOLDER OpenMVG/software )
+set_property( TARGET openMVG_main_ComputeFeatures   PROPERTY FOLDER OpenMVG/software )
+set_property( TARGET openMVG_main_PairsGenerator    PROPERTY FOLDER OpenMVG/software )
+set_property( TARGET openMVG_main_ComputeMatches    PROPERTY FOLDER OpenMVG/software )
+set_property( TARGET openMVG_main_GeometricFilter   PROPERTY FOLDER OpenMVG/software )
+set_property( TARGET openMVG_main_MatchesToTracks   PROPERTY FOLDER OpenMVG/software )
+
+install( TARGETS openMVG_main_ListMatchingPairs DESTINATION bin/ )
+install( TARGETS openMVG_main_ComputeFeatures   DESTINATION bin/ )
+install( TARGETS openMVG_main_PairsGenerator    DESTINATION bin/ )
+install( TARGETS openMVG_main_ComputeMatches    DESTINATION bin/ )
+install( TARGETS openMVG_main_GeometricFilter   DESTINATION bin/ )
+install( TARGETS openMVG_main_MatchesToTracks   DESTINATION bin/ )
 
 ###
 # SfM Pipelines

--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -72,6 +72,18 @@ target_link_libraries(openMVG_main_ComputeMatches
     ${STLPLUS_LIBRARY}
 )
 
+add_executable(openMVG_main_GeometricFilter main_GeometricFilter.cpp)
+target_link_libraries(openMVG_main_GeometricFilter
+  PRIVATE
+    openMVG_graph
+    openMVG_features
+    openMVG_matching_image_collection
+    openMVG_multiview
+    openMVG_sfm
+    openMVG_system
+    ${STLPLUS_LIBRARY}
+)
+
 add_executable(openMVG_main_MatchesToTracks main_MatchesToTracks.cpp)
 target_link_libraries(openMVG_main_MatchesToTracks
   PRIVATE

--- a/src/software/SfM/SfM_GlobalPipeline.py.in
+++ b/src/software/SfM/SfM_GlobalPipeline.py.in
@@ -55,7 +55,7 @@ pFeatures = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_Compu
 pFeatures.wait()
 
 print ("3. Compute matching pairs")
-pPairs = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_PairsGenerator"), "-i", matches_dir+"/sfm_data.json", "-o" , matches_dir + "/pairs.bin" ] )
+pPairs = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_PairGenerator"), "-i", matches_dir+"/sfm_data.json", "-o" , matches_dir + "/pairs.bin" ] )
 pPairs.wait()
 
 print ("4. Compute matches")

--- a/src/software/SfM/SfM_GlobalPipeline.py.in
+++ b/src/software/SfM/SfM_GlobalPipeline.py.in
@@ -54,24 +54,32 @@ print ("2. Compute features")
 pFeatures = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeFeatures"),  "-i", matches_dir+"/sfm_data.json", "-o", matches_dir, "-m", "SIFT"] )
 pFeatures.wait()
 
-print ("3. Compute matches")
-pMatches = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeMatches"),  "-i", matches_dir+"/sfm_data.json", "-o", matches_dir, "-g", "e"] )
+print ("3. Compute matching pairs")
+pPairs = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_PairsGenerator"), "-i", matches_dir+"/sfm_data.json", "-o" , matches_dir + "/pairs.bin" ] )
+pPairs.wait()
+
+print ("4. Compute matches")
+pMatches = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeMatches"),  "-i", matches_dir+"/sfm_data.json", "-p", matches_dir+ "/pairs.bin", "-o", matches_dir + "/matches.putative.bin" ] )
 pMatches.wait()
+
+print ("5. Filter matches" )
+pFiltering = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_GeometricFilter"), "-i", matches_dir+"/sfm_data.json", "-m", matches_dir+"/matches.putative.bin" , "-g" , "e" , "-o" , matches_dir+"/matches.e.bin" ] )
+pFiltering.wait()
 
 # Create the reconstruction if not present
 if not os.path.exists(reconstruction_dir):
     os.mkdir(reconstruction_dir)
 
-print ("4. Do Global reconstruction")
+print ("6. Do Global reconstruction")
 pRecons = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_GlobalSfM"),  "-i", matches_dir+"/sfm_data.json", "-m", matches_dir, "-o", reconstruction_dir] )
 pRecons.wait()
 
-print ("5. Colorize Structure")
+print ("7. Colorize Structure")
 pRecons = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeSfM_DataColor"),  "-i", reconstruction_dir+"/sfm_data.bin", "-o", os.path.join(reconstruction_dir,"colorized.ply")] )
 pRecons.wait()
 
 # optional, compute final valid structure from the known camera poses
-print ("6. Structure from Known Poses (robust triangulation)")
+print ("8. Structure from Known Poses (robust triangulation)")
 pRecons = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeStructureFromKnownPoses"),  "-i", reconstruction_dir+"/sfm_data.bin", "-m", matches_dir, "-f", os.path.join(matches_dir, "matches.e.bin"), "-o", os.path.join(reconstruction_dir,"robust.bin")] )
 pRecons.wait()
 

--- a/src/software/SfM/SfM_SequentialPipeline.py.in
+++ b/src/software/SfM/SfM_SequentialPipeline.py.in
@@ -54,24 +54,32 @@ print ("2. Compute features")
 pFeatures = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeFeatures"),  "-i", matches_dir+"/sfm_data.json", "-o", matches_dir, "-m", "SIFT"] )
 pFeatures.wait()
 
-print ("3. Compute matches")
-pMatches = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeMatches"),  "-i", matches_dir+"/sfm_data.json", "-o", matches_dir] )
+print ("3. Compute matching pairs")
+pPairs = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_PairsGenerator"), "-i", matches_dir+"/sfm_data.json", "-o" , matches_dir + "/pairs.bin" ] )
+pPairs.wait()
+
+print ("4. Compute matches")
+pMatches = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeMatches"),  "-i", matches_dir+"/sfm_data.json", "-p", matches_dir+ "/pairs.bin", "-o", matches_dir + "/matches.putative.bin" ] )
 pMatches.wait()
+
+print ("5. Filter matches" )
+pFiltering = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_GeometricFilter"), "-i", matches_dir+"/sfm_data.json", "-m", matches_dir+"/matches.putative.bin" , "-g" , "f" , "-o" , matches_dir+"/matches.f.bin" ] )
+pFiltering.wait()
 
 # Create the reconstruction if not present
 if not os.path.exists(reconstruction_dir):
     os.mkdir(reconstruction_dir)
 
-print ("4. Do Sequential/Incremental reconstruction")
+print ("6. Do Sequential/Incremental reconstruction")
 pRecons = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_IncrementalSfM"),  "-i", matches_dir+"/sfm_data.json", "-m", matches_dir, "-o", reconstruction_dir] )
 pRecons.wait()
 
-print ("5. Colorize Structure")
+print ("7. Colorize Structure")
 pRecons = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeSfM_DataColor"),  "-i", reconstruction_dir+"/sfm_data.bin", "-o", os.path.join(reconstruction_dir,"colorized.ply")] )
 pRecons.wait()
 
 # optional, compute final valid structure from the known camera poses
-print ("6. Structure from Known Poses (robust triangulation)")
+print ("8. Structure from Known Poses (robust triangulation)")
 pRecons = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeStructureFromKnownPoses"),  "-i", reconstruction_dir+"/sfm_data.bin", "-m", matches_dir, "-f", os.path.join(matches_dir, "matches.f.bin"), "-o", os.path.join(reconstruction_dir,"robust.bin")] )
 pRecons.wait()
 

--- a/src/software/SfM/SfM_SequentialPipeline.py.in
+++ b/src/software/SfM/SfM_SequentialPipeline.py.in
@@ -55,7 +55,7 @@ pFeatures = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_Compu
 pFeatures.wait()
 
 print ("3. Compute matching pairs")
-pPairs = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_PairsGenerator"), "-i", matches_dir+"/sfm_data.json", "-o" , matches_dir + "/pairs.bin" ] )
+pPairs = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_PairGenerator"), "-i", matches_dir+"/sfm_data.json", "-o" , matches_dir + "/pairs.bin" ] )
 pPairs.wait()
 
 print ("4. Compute matches")

--- a/src/software/SfM/main_ComputeMatches.cpp
+++ b/src/software/SfM/main_ComputeMatches.cpp
@@ -1,30 +1,30 @@
 // This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
 
-// Copyright (c) 2012, 2016 Pierre MOULON.
+// Copyright (c) 2012, 2019 Pierre MOULON, Romuald Perrot.
 
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "openMVG/graph/graph.hpp"
 #include "openMVG/features/akaze/image_describer_akaze.hpp"
 #include "openMVG/features/descriptor.hpp"
 #include "openMVG/features/feature.hpp"
+#include "openMVG/graph/graph.hpp"
 #include "openMVG/matching/indMatch.hpp"
 #include "openMVG/matching/indMatch_utils.hpp"
-#include "openMVG/matching_image_collection/Matcher_Regions.hpp"
+#include "openMVG/matching/pairwiseAdjacencyDisplay.hpp"
 #include "openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions.hpp"
-#include "openMVG/matching_image_collection/GeometricFilter.hpp"
-#include "openMVG/sfm/pipelines/sfm_features_provider.hpp"
-#include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
-#include "openMVG/sfm/pipelines/sfm_regions_provider_cache.hpp"
-#include "openMVG/matching_image_collection/F_ACRobust.hpp"
 #include "openMVG/matching_image_collection/E_ACRobust.hpp"
 #include "openMVG/matching_image_collection/E_ACRobust_Angular.hpp"
 #include "openMVG/matching_image_collection/Eo_Robust.hpp"
+#include "openMVG/matching_image_collection/F_ACRobust.hpp"
+#include "openMVG/matching_image_collection/GeometricFilter.hpp"
 #include "openMVG/matching_image_collection/H_ACRobust.hpp"
+#include "openMVG/matching_image_collection/Matcher_Regions.hpp"
 #include "openMVG/matching_image_collection/Pair_Builder.hpp"
-#include "openMVG/matching/pairwiseAdjacencyDisplay.hpp"
+#include "openMVG/sfm/pipelines/sfm_features_provider.hpp"
+#include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
+#include "openMVG/sfm/pipelines/sfm_regions_provider_cache.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/sfm/sfm_data_io.hpp"
 #include "openMVG/stl/stl.hpp"
@@ -47,164 +47,101 @@ using namespace std;
 
 enum EGeometricModel
 {
-  FUNDAMENTAL_MATRIX = 0,
-  ESSENTIAL_MATRIX   = 1,
-  HOMOGRAPHY_MATRIX  = 2,
+  FUNDAMENTAL_MATRIX       = 0,
+  ESSENTIAL_MATRIX         = 1,
+  HOMOGRAPHY_MATRIX        = 2,
   ESSENTIAL_MATRIX_ANGULAR = 3,
-  ESSENTIAL_MATRIX_ORTHO = 4
-};
-
-enum EPairMode
-{
-  PAIR_EXHAUSTIVE = 0,
-  PAIR_CONTIGUOUS = 1,
-  PAIR_FROM_FILE  = 2
+  ESSENTIAL_MATRIX_ORTHO   = 4
 };
 
 /// Compute corresponding features between a series of views:
 /// - Load view images description (regions: features & descriptors)
 /// - Compute putative local feature matches (descriptors matching)
-/// - Compute geometric coherent feature matches (robust model estimation from putative matches)
-/// - Export computed data
-int main(int argc, char **argv)
+int main( int argc, char** argv )
 {
   CmdLine cmd;
 
-  std::string sSfM_Data_Filename;
-  std::string sMatchesDirectory = "";
-  std::string sGeometricModel = "f";
-  float fDistRatio = 0.8f;
-  int iMatchingVideoMode = -1;
-  std::string sPredefinedPairList = "";
-  std::string sNearestMatchingMethod = "AUTO";
-  bool bForce = false;
-  bool bGuided_matching = false;
-  int imax_iteration = 2048;
-  unsigned int ui_max_cache_size = 0;
+  std::string  sSfM_Data_Filename;
+  std::string  sOutputFilename        = "";
+  float        fDistRatio             = 0.8f;
+  std::string  sPredefinedPairList    = "";
+  std::string  sNearestMatchingMethod = "AUTO";
+  bool         bForce                 = false;
+  unsigned int ui_max_cache_size      = 0;
 
   //required
-  cmd.add( make_option('i', sSfM_Data_Filename, "input_file") );
-  cmd.add( make_option('o', sMatchesDirectory, "out_dir") );
+  cmd.add( make_option( 'i', sSfM_Data_Filename, "input_file" ) );
+  cmd.add( make_option( 'o', sOutputFilename, "out_dir" ) );
+  cmd.add( make_option( 'p', sPredefinedPairList, "pair_list" ) );
   // Options
-  cmd.add( make_option('r', fDistRatio, "ratio") );
-  cmd.add( make_option('g', sGeometricModel, "geometric_model") );
-  cmd.add( make_option('v', iMatchingVideoMode, "video_mode_matching") );
-  cmd.add( make_option('l', sPredefinedPairList, "pair_list") );
-  cmd.add( make_option('n', sNearestMatchingMethod, "nearest_matching_method") );
-  cmd.add( make_option('f', bForce, "force") );
-  cmd.add( make_option('m', bGuided_matching, "guided_matching") );
-  cmd.add( make_option('I', imax_iteration, "max_iteration") );
-  cmd.add( make_option('c', ui_max_cache_size, "cache_size") );
+  cmd.add( make_option( 'r', fDistRatio, "ratio" ) );
+  cmd.add( make_option( 'n', sNearestMatchingMethod, "nearest_matching_method" ) );
+  cmd.add( make_option( 'f', bForce, "force" ) );
+  cmd.add( make_option( 'c', ui_max_cache_size, "cache_size" ) );
 
-
-  try {
-      if (argc == 1) throw std::string("Invalid command line parameter.");
-      cmd.process(argc, argv);
-  } catch (const std::string& s) {
-      std::cerr << "Usage: " << argv[0] << '\n'
-      << "[-i|--input_file] a SfM_Data file\n"
-      << "[-o|--out_dir path] output path where computed are stored\n"
-      << "\n[Optional]\n"
-      << "[-f|--force] Force to recompute data]\n"
-      << "[-r|--ratio] Distance ratio to discard non meaningful matches\n"
-      << "   0.8: (default).\n"
-      << "[-g|--geometric_model]\n"
-      << "  (pairwise correspondences filtering thanks to robust model estimation):\n"
-      << "   f: (default) fundamental matrix,\n"
-      << "   e: essential matrix,\n"
-      << "   h: homography matrix.\n"
-      << "   a: essential matrix with an angular parametrization,\n"
-      << "   o: orthographic essential matrix.\n"
-      << "[-v|--video_mode_matching]\n"
-      << "  (sequence matching with an overlap of X images)\n"
-      << "   X: with match 0 with (1->X), ...]\n"
-      << "   2: will match 0 with (1,2), 1 with (2,3), ...\n"
-      << "   3: will match 0 with (1,2,3), 1 with (2,3,4), ...\n"
-      << "[-l]--pair_list] file\n"
-      << "[-n|--nearest_matching_method]\n"
-      << "  AUTO: auto choice from regions type,\n"
-      << "  For Scalar based regions descriptor:\n"
-      << "    BRUTEFORCEL2: L2 BruteForce matching,\n"
-      << "    ANNL2: L2 Approximate Nearest Neighbor matching,\n"
-      << "    CASCADEHASHINGL2: L2 Cascade Hashing matching.\n"
-      << "    FASTCASCADEHASHINGL2: (default)\n"
-      << "      L2 Cascade Hashing with precomputed hashed regions\n"
-      << "     (faster than CASCADEHASHINGL2 but use more memory).\n"
-      << "  For Binary based descriptor:\n"
-      << "    BRUTEFORCEHAMMING: BruteForce Hamming matching.\n"
-      << "[-m|--guided_matching]\n"
-      << "  use the found model to improve the pairwise correspondences.\n"
-      << "[-c|--cache_size]\n"
-      << "  Use a regions cache (only cache_size regions will be stored in memory)\n"
-      << "  If not used, all regions will be load in memory."
-      << std::endl;
-
-      std::cerr << s << std::endl;
-      return EXIT_FAILURE;
+  try
+  {
+    if ( argc == 1 )
+      throw std::string( "Invalid command line parameter." );
+    cmd.process( argc, argv );
   }
+  catch ( const std::string& s )
+  {
+    std::cerr << "Usage: " << argv[ 0 ] << '\n'
+              << "[-i|--input_file]   A SfM_Data file\n"
+              << "[-o|--output_file]  Output path where computed are stored\n"
+              << "[-p]--pair_list]    Pairs list file\n"
+              << "\n[Optional]\n"
+              << "[-f|--force] Force to recompute data]\n"
+              << "[-r|--ratio] Distance ratio to discard non meaningful matches\n"
+              << "   0.8: (default).\n"
+              << "[-n|--nearest_matching_method]\n"
+              << "  AUTO: auto choice from regions type,\n"
+              << "  For Scalar based regions descriptor:\n"
+              << "    BRUTEFORCEL2: L2 BruteForce matching,\n"
+              << "    ANNL2: L2 Approximate Nearest Neighbor matching,\n"
+              << "    CASCADEHASHINGL2: L2 Cascade Hashing matching.\n"
+              << "    FASTCASCADEHASHINGL2: (default)\n"
+              << "      L2 Cascade Hashing with precomputed hashed regions\n"
+              << "     (faster than CASCADEHASHINGL2 but use more memory).\n"
+              << "  For Binary based descriptor:\n"
+              << "    BRUTEFORCEHAMMING: BruteForce Hamming matching.\n"
+              << "[-c|--cache_size]\n"
+              << "  Use a regions cache (only cache_size regions will be stored in memory)\n"
+              << "  If not used, all regions will be load in memory."
+              << std::endl;
 
-  std::cout << " You called : " << "\n"
-            << argv[0] << "\n"
-            << "--input_file " << sSfM_Data_Filename << "\n"
-            << "--out_dir " << sMatchesDirectory << "\n"
-            << "Optional parameters:" << "\n"
-            << "--force " << bForce << "\n"
-            << "--ratio " << fDistRatio << "\n"
-            << "--geometric_model " << sGeometricModel << "\n"
-            << "--video_mode_matching " << iMatchingVideoMode << "\n"
-            << "--pair_list " << sPredefinedPairList << "\n"
-            << "--nearest_matching_method " << sNearestMatchingMethod << "\n"
-            << "--guided_matching " << bGuided_matching << "\n"
-            << "--cache_size " << ((ui_max_cache_size == 0) ? "unlimited" : std::to_string(ui_max_cache_size)) << std::endl;
-
-  EPairMode ePairmode = (iMatchingVideoMode == -1 ) ? PAIR_EXHAUSTIVE : PAIR_CONTIGUOUS;
-
-  if (sPredefinedPairList.length()) {
-    ePairmode = PAIR_FROM_FILE;
-    if (iMatchingVideoMode>0) {
-      std::cerr << "\nIncompatible options: --videoModeMatching and --pairList" << std::endl;
-      return EXIT_FAILURE;
-    }
-  }
-
-  if (sMatchesDirectory.empty() || !stlplus::is_folder(sMatchesDirectory))  {
-    std::cerr << "\nIt is an invalid output directory" << std::endl;
+    std::cerr << s << std::endl;
     return EXIT_FAILURE;
   }
 
-  EGeometricModel eGeometricModelToCompute = FUNDAMENTAL_MATRIX;
-  std::string sGeometricMatchesFilename = "";
-  switch (sGeometricModel[0])
+  std::cout << " You called : "
+            << "\n"
+            << argv[ 0 ] << "\n"
+            << "--input_file " << sSfM_Data_Filename << "\n"
+            << "--output_file " << sOutputFilename << "\n"
+            << "--pair_list " << sPredefinedPairList << "\n"
+            << "Optional parameters:"
+            << "\n"
+            << "--force " << bForce << "\n"
+            << "--ratio " << fDistRatio << "\n"
+            << "--nearest_matching_method " << sNearestMatchingMethod << "\n"
+            << "--cache_size " << ( ( ui_max_cache_size == 0 ) ? "unlimited" : std::to_string( ui_max_cache_size ) ) << std::endl;
+
+  if ( sPredefinedPairList.empty() )
   {
-    case 'f': case 'F':
-      eGeometricModelToCompute = FUNDAMENTAL_MATRIX;
-      sGeometricMatchesFilename = "matches.f.bin";
-    break;
-    case 'e': case 'E':
-      eGeometricModelToCompute = ESSENTIAL_MATRIX;
-      sGeometricMatchesFilename = "matches.e.bin";
-    break;
-    case 'h': case 'H':
-      eGeometricModelToCompute = HOMOGRAPHY_MATRIX;
-      sGeometricMatchesFilename = "matches.h.bin";
-    break;
-    case 'a': case 'A':
-      eGeometricModelToCompute = ESSENTIAL_MATRIX_ANGULAR;
-      sGeometricMatchesFilename = "matches.f.bin";
-    break;
-    case 'o': case 'O':
-      eGeometricModelToCompute = ESSENTIAL_MATRIX_ORTHO;
-      sGeometricMatchesFilename = "matches.o.bin";
-    break;
-    default:
-      std::cerr << "Unknown geometric model" << std::endl;
-      return EXIT_FAILURE;
+    std::cerr << "\nNo input pairs file set." << std::endl;
+    return EXIT_FAILURE;
+  }
+  if ( sOutputFilename.empty() )
+  {
+    std::cerr << "\nNo output file set." << std::endl;
+    return EXIT_FAILURE;
   }
 
   // -----------------------------
-  // - Load SfM_Data Views & intrinsics data
-  // a. Compute putative descriptor matches
-  // b. Geometric filtering of putative matches
+  // . Load SfM_Data Views & intrinsics data
+  // . Compute putative descriptor matches
   // + Export some statistics
   // -----------------------------
 
@@ -212,23 +149,25 @@ int main(int argc, char **argv)
   // Read SfM Scene (image view & intrinsics data)
   //---------------------------------------
   SfM_Data sfm_data;
-  if (!Load(sfm_data, sSfM_Data_Filename, ESfM_Data(VIEWS|INTRINSICS))) {
+  if ( !Load( sfm_data, sSfM_Data_Filename, ESfM_Data( VIEWS | INTRINSICS ) ) )
+  {
     std::cerr << std::endl
-      << "The input SfM_Data file \""<< sSfM_Data_Filename << "\" cannot be read." << std::endl;
+              << "The input SfM_Data file \"" << sSfM_Data_Filename << "\" cannot be read." << std::endl;
     return EXIT_FAILURE;
   }
+  const std::string sMatchesDirectory = stlplus::folder_part( sSfM_Data_Filename ) + "/../matches/";
 
   //---------------------------------------
   // Load SfM Scene regions
   //---------------------------------------
   // Init the regions_type from the image describer file (used for image regions extraction)
   using namespace openMVG::features;
-  const std::string sImage_describer = stlplus::create_filespec(sMatchesDirectory, "image_describer", "json");
-  std::unique_ptr<Regions> regions_type = Init_region_type_from_file(sImage_describer);
-  if (!regions_type)
+  const std::string        sImage_describer = stlplus::create_filespec( sMatchesDirectory, "image_describer", "json" );
+  std::unique_ptr<Regions> regions_type     = Init_region_type_from_file( sImage_describer );
+  if ( !regions_type )
   {
     std::cerr << "Invalid: "
-      << sImage_describer << " regions type file." << std::endl;
+              << sImage_describer << " regions type file." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -240,7 +179,7 @@ int main(int argc, char **argv)
 
   // Load the corresponding view regions
   std::shared_ptr<Regions_Provider> regions_provider;
-  if (ui_max_cache_size == 0)
+  if ( ui_max_cache_size == 0 )
   {
     // Default regions provider (load & store all regions in memory)
     regions_provider = std::make_shared<Regions_Provider>();
@@ -248,14 +187,16 @@ int main(int argc, char **argv)
   else
   {
     // Cached regions provider (load & store regions on demand)
-    regions_provider = std::make_shared<Regions_Provider_Cache>(ui_max_cache_size);
+    regions_provider = std::make_shared<Regions_Provider_Cache>( ui_max_cache_size );
   }
 
   // Show the progress on the command line:
   C_Progress_display progress;
 
-  if (!regions_provider->load(sfm_data, sMatchesDirectory, regions_type, &progress)) {
-    std::cerr << std::endl << "Invalid regions." << std::endl;
+  if ( !regions_provider->load( sfm_data, sMatchesDirectory, regions_type, &progress ) )
+  {
+    std::cerr << std::endl
+              << "Invalid regions." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -263,95 +204,78 @@ int main(int argc, char **argv)
 
   // Build some alias from SfM_Data Views data:
   // - List views as a vector of filenames & image sizes
-  std::vector<std::string> vec_fileNames;
+  std::vector<std::string>               vec_fileNames;
   std::vector<std::pair<size_t, size_t>> vec_imagesSize;
   {
-    vec_fileNames.reserve(sfm_data.GetViews().size());
-    vec_imagesSize.reserve(sfm_data.GetViews().size());
-    for (Views::const_iterator iter = sfm_data.GetViews().begin();
-      iter != sfm_data.GetViews().end();
-      ++iter)
+    vec_fileNames.reserve( sfm_data.GetViews().size() );
+    vec_imagesSize.reserve( sfm_data.GetViews().size() );
+    for ( Views::const_iterator iter = sfm_data.GetViews().begin();
+          iter != sfm_data.GetViews().end();
+          ++iter )
     {
-      const View * v = iter->second.get();
-      vec_fileNames.push_back(stlplus::create_filespec(sfm_data.s_root_path,
-          v->s_Img_path));
-      vec_imagesSize.push_back( std::make_pair( v->ui_width, v->ui_height) );
+      const View* v = iter->second.get();
+      vec_fileNames.push_back( stlplus::create_filespec( sfm_data.s_root_path,
+                                                         v->s_Img_path ) );
+      vec_imagesSize.push_back( std::make_pair( v->ui_width, v->ui_height ) );
     }
   }
 
-  std::cout << std::endl << " - PUTATIVE MATCHES - " << std::endl;
+  std::cout << std::endl
+            << " - PUTATIVE MATCHES - " << std::endl;
   // If the matches already exists, reload them
-  if (!bForce
-        && (stlplus::file_exists(sMatchesDirectory + "/matches.putative.txt")
-        || stlplus::file_exists(sMatchesDirectory + "/matches.putative.bin"))
-  )
+  if ( !bForce && ( stlplus::file_exists( sOutputFilename ) ) )
   {
-    if (!(Load(map_PutativesMatches, sMatchesDirectory + "/matches.putative.bin") ||
-          Load(map_PutativesMatches, sMatchesDirectory + "/matches.putative.txt")) )
+    if ( !( Load( map_PutativesMatches, sOutputFilename ) ) )
     {
       std::cerr << "Cannot load input matches file";
       return EXIT_FAILURE;
     }
     std::cout << "\t PREVIOUS RESULTS LOADED;"
-      << " #pair: " << map_PutativesMatches.size() << std::endl;
+              << " #pair: " << map_PutativesMatches.size() << std::endl;
   }
   else // Compute the putative matches
   {
-    std::cout << "Use: ";
-    switch (ePairmode)
-    {
-      case PAIR_EXHAUSTIVE: std::cout << "exhaustive pairwise matching" << std::endl; break;
-      case PAIR_CONTIGUOUS: std::cout << "sequence pairwise matching" << std::endl; break;
-      case PAIR_FROM_FILE:  std::cout << "user defined pairwise matching" << std::endl; break;
-    }
-
     // Allocate the right Matcher according the Matching requested method
     std::unique_ptr<Matcher> collectionMatcher;
-    if (sNearestMatchingMethod == "AUTO")
+    if ( sNearestMatchingMethod == "AUTO" )
     {
-      if (regions_type->IsScalar())
+      if ( regions_type->IsScalar() )
       {
         std::cout << "Using FAST_CASCADE_HASHING_L2 matcher" << std::endl;
-        collectionMatcher.reset(new Cascade_Hashing_Matcher_Regions(fDistRatio));
+        collectionMatcher.reset( new Cascade_Hashing_Matcher_Regions( fDistRatio ) );
       }
-      else
-      if (regions_type->IsBinary())
+      else if ( regions_type->IsBinary() )
       {
         std::cout << "Using BRUTE_FORCE_HAMMING matcher" << std::endl;
-        collectionMatcher.reset(new Matcher_Regions(fDistRatio, BRUTE_FORCE_HAMMING));
+        collectionMatcher.reset( new Matcher_Regions( fDistRatio, BRUTE_FORCE_HAMMING ) );
       }
     }
-    else
-    if (sNearestMatchingMethod == "BRUTEFORCEL2")
+    else if ( sNearestMatchingMethod == "BRUTEFORCEL2" )
     {
       std::cout << "Using BRUTE_FORCE_L2 matcher" << std::endl;
-      collectionMatcher.reset(new Matcher_Regions(fDistRatio, BRUTE_FORCE_L2));
+      collectionMatcher.reset( new Matcher_Regions( fDistRatio, BRUTE_FORCE_L2 ) );
     }
-    else
-    if (sNearestMatchingMethod == "BRUTEFORCEHAMMING")
+    else if ( sNearestMatchingMethod == "BRUTEFORCEHAMMING" )
     {
       std::cout << "Using BRUTE_FORCE_HAMMING matcher" << std::endl;
-      collectionMatcher.reset(new Matcher_Regions(fDistRatio, BRUTE_FORCE_HAMMING));
+      collectionMatcher.reset( new Matcher_Regions( fDistRatio, BRUTE_FORCE_HAMMING ) );
     }
-    else
-    if (sNearestMatchingMethod == "ANNL2")
+    else if ( sNearestMatchingMethod == "ANNL2" )
     {
       std::cout << "Using ANN_L2 matcher" << std::endl;
-      collectionMatcher.reset(new Matcher_Regions(fDistRatio, ANN_L2));
+      collectionMatcher.reset( new Matcher_Regions( fDistRatio, ANN_L2 ) );
     }
-    else
-    if (sNearestMatchingMethod == "CASCADEHASHINGL2")
+    else if ( sNearestMatchingMethod == "CASCADEHASHINGL2" )
     {
       std::cout << "Using CASCADE_HASHING_L2 matcher" << std::endl;
-      collectionMatcher.reset(new Matcher_Regions(fDistRatio, CASCADE_HASHING_L2));
+      collectionMatcher.reset( new Matcher_Regions( fDistRatio, CASCADE_HASHING_L2 ) );
     }
-    else
-    if (sNearestMatchingMethod == "FASTCASCADEHASHINGL2")
+    else if ( sNearestMatchingMethod == "FASTCASCADEHASHINGL2" )
     {
       std::cout << "Using FAST_CASCADE_HASHING_L2 matcher" << std::endl;
-      collectionMatcher.reset(new Cascade_Hashing_Matcher_Regions(fDistRatio));
+      collectionMatcher.reset( new Cascade_Hashing_Matcher_Regions( fDistRatio ) );
     }
-    if (!collectionMatcher)
+    if ( !collectionMatcher )
     {
       std::cerr << "Invalid Nearest Neighbor method: " << sNearestMatchingMethod << std::endl;
       return EXIT_FAILURE;
@@ -361,157 +285,38 @@ int main(int argc, char **argv)
     {
       // From matching mode compute the pair list that have to be matched:
       Pair_Set pairs;
-      switch (ePairmode)
+      if ( !loadPairs( sfm_data.GetViews().size(), sPredefinedPairList, pairs ) )
       {
-        case PAIR_EXHAUSTIVE: pairs = exhaustivePairs(sfm_data.GetViews().size()); break;
-        case PAIR_CONTIGUOUS: pairs = contiguousWithOverlap(sfm_data.GetViews().size(), iMatchingVideoMode); break;
-        case PAIR_FROM_FILE:
-          if (!loadPairs(sfm_data.GetViews().size(), sPredefinedPairList, pairs))
-          {
-              return EXIT_FAILURE;
-          }
-          break;
+        std::cerr << "Failed to load pairs from file: \"" << sPredefinedPairList << "\"" << std::endl;
+        return EXIT_FAILURE;
       }
       // Photometric matching of putative pairs
-      collectionMatcher->Match(regions_provider, pairs, map_PutativesMatches, &progress);
+      collectionMatcher->Match( regions_provider, pairs, map_PutativesMatches, &progress );
       //---------------------------------------
       //-- Export putative matches
       //---------------------------------------
-      if (!Save(map_PutativesMatches, std::string(sMatchesDirectory + "/matches.putative.bin")))
+      if ( !Save( map_PutativesMatches, std::string( sOutputFilename ) ) )
       {
-        std::cerr
-          << "Cannot save computed matches in: "
-          << std::string(sMatchesDirectory + "/matches.putative.bin");
+        std::cerr << "Cannot save computed matches in: "
+                  << sOutputFilename << std::endl;
         return EXIT_FAILURE;
       }
     }
     std::cout << "Task (Regions Matching) done in (s): " << timer.elapsed() << std::endl;
   }
   //-- export putative matches Adjacency matrix
-  PairWiseMatchingToAdjacencyMatrixSVG(vec_fileNames.size(),
-    map_PutativesMatches,
-    stlplus::create_filespec(sMatchesDirectory, "PutativeAdjacencyMatrix", "svg"));
+  PairWiseMatchingToAdjacencyMatrixSVG( vec_fileNames.size(),
+                                        map_PutativesMatches,
+                                        stlplus::create_filespec( sMatchesDirectory, "PutativeAdjacencyMatrix", "svg" ) );
   //-- export view pair graph once putative graph matches have been computed
   {
     std::set<IndexT> set_ViewIds;
-    std::transform(sfm_data.GetViews().begin(), sfm_data.GetViews().end(),
-      std::inserter(set_ViewIds, set_ViewIds.begin()), stl::RetrieveKey());
-    graph::indexedGraph putativeGraph(set_ViewIds, getPairs(map_PutativesMatches));
+    std::transform( sfm_data.GetViews().begin(), sfm_data.GetViews().end(), std::inserter( set_ViewIds, set_ViewIds.begin() ), stl::RetrieveKey() );
+    graph::indexedGraph putativeGraph( set_ViewIds, getPairs( map_PutativesMatches ) );
     graph::exportToGraphvizData(
-      stlplus::create_filespec(sMatchesDirectory, "putative_matches"),
-      putativeGraph);
+        stlplus::create_filespec( sMatchesDirectory, "putative_matches" ),
+        putativeGraph );
   }
 
-  //---------------------------------------
-  // b. Geometric filtering of putative matches
-  //    - AContrario Estimation of the desired geometric model
-  //    - Use an upper bound for the a contrario estimated threshold
-  //---------------------------------------
-
-  std::unique_ptr<ImageCollectionGeometricFilter> filter_ptr(
-    new ImageCollectionGeometricFilter(&sfm_data, regions_provider));
-
-  if (filter_ptr)
-  {
-    system::Timer timer;
-    const double d_distance_ratio = 0.6;
-
-    PairWiseMatches map_GeometricMatches;
-    switch (eGeometricModelToCompute)
-    {
-      case HOMOGRAPHY_MATRIX:
-      {
-        const bool bGeometric_only_guided_matching = true;
-        filter_ptr->Robust_model_estimation(
-          GeometricFilter_HMatrix_AC(4.0, imax_iteration),
-          map_PutativesMatches, bGuided_matching,
-          bGeometric_only_guided_matching ? -1.0 : d_distance_ratio, &progress);
-        map_GeometricMatches = filter_ptr->Get_geometric_matches();
-      }
-      break;
-      case FUNDAMENTAL_MATRIX:
-      {
-        filter_ptr->Robust_model_estimation(
-          GeometricFilter_FMatrix_AC(4.0, imax_iteration),
-          map_PutativesMatches, bGuided_matching, d_distance_ratio, &progress);
-        map_GeometricMatches = filter_ptr->Get_geometric_matches();
-      }
-      break;
-      case ESSENTIAL_MATRIX:
-      {
-        filter_ptr->Robust_model_estimation(
-          GeometricFilter_EMatrix_AC(4.0, imax_iteration),
-          map_PutativesMatches, bGuided_matching, d_distance_ratio, &progress);
-        map_GeometricMatches = filter_ptr->Get_geometric_matches();
-
-        //-- Perform an additional check to remove pairs with poor overlap
-        std::vector<PairWiseMatches::key_type> vec_toRemove;
-        for (const auto & pairwisematches_it : map_GeometricMatches)
-        {
-          const size_t putativePhotometricCount = map_PutativesMatches.find(pairwisematches_it.first)->second.size();
-          const size_t putativeGeometricCount = pairwisematches_it.second.size();
-          const float ratio = putativeGeometricCount / static_cast<float>(putativePhotometricCount);
-          if (putativeGeometricCount < 50 || ratio < .3f)  {
-            // the pair will be removed
-            vec_toRemove.push_back(pairwisematches_it.first);
-          }
-        }
-        //-- remove discarded pairs
-        for (const auto & pair_to_remove_it : vec_toRemove)
-        {
-          map_GeometricMatches.erase(pair_to_remove_it);
-        }
-      }
-      break;
-      case ESSENTIAL_MATRIX_ANGULAR:
-      {
-        filter_ptr->Robust_model_estimation(
-          GeometricFilter_ESphericalMatrix_AC_Angular(4.0, imax_iteration),
-          map_PutativesMatches, bGuided_matching);
-        map_GeometricMatches = filter_ptr->Get_geometric_matches();
-      }
-      break;
-      case ESSENTIAL_MATRIX_ORTHO:
-      {
-        filter_ptr->Robust_model_estimation(
-          GeometricFilter_EOMatrix_RA(2.0, imax_iteration),
-          map_PutativesMatches, bGuided_matching, d_distance_ratio, &progress);
-        map_GeometricMatches = filter_ptr->Get_geometric_matches();
-      }
-      break;
-    }
-
-    //---------------------------------------
-    //-- Export geometric filtered matches
-    //---------------------------------------
-    if (!Save(map_GeometricMatches,
-      std::string(sMatchesDirectory + "/" + sGeometricMatchesFilename)))
-    {
-      std::cerr
-          << "Cannot save computed matches in: "
-          << std::string(sMatchesDirectory + "/" + sGeometricMatchesFilename);
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Task done in (s): " << timer.elapsed() << std::endl;
-
-    //-- export Adjacency matrix
-    std::cout << "\n Export Adjacency Matrix of the pairwise's geometric matches"
-      << std::endl;
-    PairWiseMatchingToAdjacencyMatrixSVG(vec_fileNames.size(),
-      map_GeometricMatches,
-      stlplus::create_filespec(sMatchesDirectory, "GeometricAdjacencyMatrix", "svg"));
-
-    //-- export view pair graph once geometric filter have been done
-    {
-      std::set<IndexT> set_ViewIds;
-      std::transform(sfm_data.GetViews().begin(), sfm_data.GetViews().end(),
-        std::inserter(set_ViewIds, set_ViewIds.begin()), stl::RetrieveKey());
-      graph::indexedGraph putativeGraph(set_ViewIds, getPairs(map_GeometricMatches));
-      graph::exportToGraphvizData(
-        stlplus::create_filespec(sMatchesDirectory, "geometric_matches"),
-        putativeGraph);
-    }
-  }
   return EXIT_SUCCESS;
 }

--- a/src/software/SfM/main_GeometricFilter.cpp
+++ b/src/software/SfM/main_GeometricFilter.cpp
@@ -6,25 +6,25 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "openMVG/graph/graph.hpp"
 #include "openMVG/features/akaze/image_describer_akaze.hpp"
 #include "openMVG/features/descriptor.hpp"
 #include "openMVG/features/feature.hpp"
+#include "openMVG/graph/graph.hpp"
 #include "openMVG/matching/indMatch.hpp"
 #include "openMVG/matching/indMatch_utils.hpp"
-#include "openMVG/matching_image_collection/Matcher_Regions.hpp"
+#include "openMVG/matching/pairwiseAdjacencyDisplay.hpp"
 #include "openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions.hpp"
-#include "openMVG/matching_image_collection/GeometricFilter.hpp"
-#include "openMVG/sfm/pipelines/sfm_features_provider.hpp"
-#include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
-#include "openMVG/sfm/pipelines/sfm_regions_provider_cache.hpp"
-#include "openMVG/matching_image_collection/F_ACRobust.hpp"
 #include "openMVG/matching_image_collection/E_ACRobust.hpp"
 #include "openMVG/matching_image_collection/E_ACRobust_Angular.hpp"
 #include "openMVG/matching_image_collection/Eo_Robust.hpp"
+#include "openMVG/matching_image_collection/F_ACRobust.hpp"
+#include "openMVG/matching_image_collection/GeometricFilter.hpp"
 #include "openMVG/matching_image_collection/H_ACRobust.hpp"
+#include "openMVG/matching_image_collection/Matcher_Regions.hpp"
 #include "openMVG/matching_image_collection/Pair_Builder.hpp"
-#include "openMVG/matching/pairwiseAdjacencyDisplay.hpp"
+#include "openMVG/sfm/pipelines/sfm_features_provider.hpp"
+#include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
+#include "openMVG/sfm/pipelines/sfm_regions_provider_cache.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/sfm/sfm_data_io.hpp"
 #include "openMVG/stl/stl.hpp"
@@ -47,11 +47,11 @@ using namespace std;
 
 enum EGeometricModel
 {
-  FUNDAMENTAL_MATRIX = 0,
-  ESSENTIAL_MATRIX   = 1,
-  HOMOGRAPHY_MATRIX  = 2,
+  FUNDAMENTAL_MATRIX       = 0,
+  ESSENTIAL_MATRIX         = 1,
+  HOMOGRAPHY_MATRIX        = 2,
   ESSENTIAL_MATRIX_ANGULAR = 3,
-  ESSENTIAL_MATRIX_ORTHO = 4
+  ESSENTIAL_MATRIX_ORTHO   = 4
 };
 
 /// Compute corresponding features between a series of views:
@@ -59,122 +59,129 @@ enum EGeometricModel
 /// - Compute putative local feature matches (descriptors matching)
 /// - Compute geometric coherent feature matches (robust model estimation from putative matches)
 /// - Export computed data
-int main(int argc, char **argv)
+int main( int argc, char** argv )
 {
   CmdLine cmd;
 
-  // The scene 
+  // The scene
   std::string sSfM_Data_Filename;
-  // The input matches 
+  // The input matches
   std::string sPutativeMatchesFilename;
-  // The output matches 
+  // The output matches
   std::string sFilteredMatchesFilename;
-  // The input pairs 
+  // The input pairs
   std::string sInputPairsFilename;
   // The output pairs
   std::string sOutputPairsFilename;
 
-  std::string sGeometricModel = "f";
-  bool bForce = false;
-  bool bGuided_matching = false;
-  int imax_iteration = 2048;
+  std::string  sGeometricModel   = "f";
+  bool         bForce            = false;
+  bool         bGuided_matching  = false;
+  int          imax_iteration    = 2048;
   unsigned int ui_max_cache_size = 0;
 
   //required
-  cmd.add( make_option('i', sSfM_Data_Filename, "input_file") );
-  cmd.add( make_option('o', sFilteredMatchesFilename, "output_file") );
-  cmd.add( make_option('m', sPutativeMatchesFilename, "matches") );
+  cmd.add( make_option( 'i', sSfM_Data_Filename, "input_file" ) );
+  cmd.add( make_option( 'o', sFilteredMatchesFilename, "output_file" ) );
+  cmd.add( make_option( 'm', sPutativeMatchesFilename, "matches" ) );
   // Options
-  cmd.add( make_option('p', sInputPairsFilename, "input_pairs") );
-  cmd.add( make_option('s', sOutputPairsFilename, "output_pairs" ) );
-  cmd.add( make_option('g', sGeometricModel, "geometric_model") );
-  cmd.add( make_option('f', bForce, "force") );
-  cmd.add( make_option('r', bGuided_matching, "guided_matching") );
-  cmd.add( make_option('I', imax_iteration, "max_iteration") );
-  cmd.add( make_option('c', ui_max_cache_size, "cache_size") );
+  cmd.add( make_option( 'p', sInputPairsFilename, "input_pairs" ) );
+  cmd.add( make_option( 's', sOutputPairsFilename, "output_pairs" ) );
+  cmd.add( make_option( 'g', sGeometricModel, "geometric_model" ) );
+  cmd.add( make_option( 'f', bForce, "force" ) );
+  cmd.add( make_option( 'r', bGuided_matching, "guided_matching" ) );
+  cmd.add( make_option( 'I', imax_iteration, "max_iteration" ) );
+  cmd.add( make_option( 'c', ui_max_cache_size, "cache_size" ) );
 
+  try
+  {
+    if ( argc == 1 )
+      throw std::string( "Invalid command line parameter." );
+    cmd.process( argc, argv );
+  }
+  catch ( const std::string& s )
+  {
+    std::cerr << "Usage: " << argv[ 0 ] << '\n'
+              << "[-i|--input_file]       A SfM_Data file\n"
+              << "[-m|--matches]          (Input) matches filename\n"
+              << "[-o|--output_file]      (Output) filtered matches filename\n"
+              << "\n[Optional]\n"
+              << "[-p|--input_pairs]      (Input) pairs filename\n"
+              << "[-s|--output_pairs]     (Output) filtered pairs filename\n"
+              << "[-f|--force]            Force to recompute data\n"
+              << "[-g|--geometric_model]\n"
+              << "  (pairwise correspondences filtering thanks to robust model estimation):\n"
+              << "   f: (default) fundamental matrix,\n"
+              << "   e: essential matrix,\n"
+              << "   h: homography matrix.\n"
+              << "   a: essential matrix with an angular parametrization,\n"
+              << "   o: orthographic essential matrix.\n"
+              << "[-r|--guided_matching]  Use the found model to improve the pairwise correspondences.\n"
+              << "[-c|--cache_size]\n"
+              << "  Use a regions cache (only cache_size regions will be stored in memory)\n"
+              << "  If not used, all regions will be load in memory."
+              << std::endl;
 
-  try {
-      if (argc == 1) throw std::string("Invalid command line parameter.");
-      cmd.process(argc, argv);
-  } catch (const std::string& s) {
-      std::cerr << "Usage: " << argv[0] << '\n'
-      << "[-i|--input_file]       A SfM_Data file\n"
-      << "[-m|--matches]          (Input) matches filename\n"
-      << "[-o|--output_file]      (Output) filtered matches filename\n"
-      << "\n[Optional]\n"
-      << "[-p|--input_pairs]      (Input) pairs filename\n"
-      << "[-s|--output_pairs]     (Output) filtered pairs filename\n"
-      << "[-f|--force]            Force to recompute data\n"
-      << "[-g|--geometric_model]\n"
-      << "  (pairwise correspondences filtering thanks to robust model estimation):\n"
-      << "   f: (default) fundamental matrix,\n"
-      << "   e: essential matrix,\n"
-      << "   h: homography matrix.\n"
-      << "   a: essential matrix with an angular parametrization,\n"
-      << "   o: orthographic essential matrix.\n"
-      << "[-r|--guided_matching]  Use the found model to improve the pairwise correspondences.\n"
-      << "[-c|--cache_size]\n"
-      << "  Use a regions cache (only cache_size regions will be stored in memory)\n"
-      << "  If not used, all regions will be load in memory."
-      << std::endl;
-
-      std::cerr << s << std::endl;
-      return EXIT_FAILURE;
+    std::cerr << s << std::endl;
+    return EXIT_FAILURE;
   }
 
-  std::cout << " You called : " << "\n"
-            << argv[0] << "\n"
+  std::cout << " You called : "
+            << "\n"
+            << argv[ 0 ] << "\n"
             << "--input_file:        " << sSfM_Data_Filename << "\n"
             << "--matches:           " << sPutativeMatchesFilename << "\n"
             << "--output_file:       " << sFilteredMatchesFilename << "\n"
-            << "Optional parameters: " << "\n"
-            << "--input_pairs        " << sInputPairsFilename << "\n" 
+            << "Optional parameters: "
+            << "\n"
+            << "--input_pairs        " << sInputPairsFilename << "\n"
             << "--output_pairs       " << sOutputPairsFilename << "\n"
-            << "--force              " << (bForce ? "true" : "false") << "\n"
+            << "--force              " << ( bForce ? "true" : "false" ) << "\n"
             << "--geometric_model    " << sGeometricModel << "\n"
             << "--guided_matching    " << bGuided_matching << "\n"
-            << "--cache_size         " << ((ui_max_cache_size == 0) ? "unlimited" : std::to_string(ui_max_cache_size)) << std::endl;
+            << "--cache_size         " << ( ( ui_max_cache_size == 0 ) ? "unlimited" : std::to_string( ui_max_cache_size ) ) << std::endl;
 
-
-
-  if (sFilteredMatchesFilename.empty() )  
+  if ( sFilteredMatchesFilename.empty() )
   {
     std::cerr << "\nIt is an invalid output file" << std::endl;
     return EXIT_FAILURE;
   }
-  if( sSfM_Data_Filename.empty() )
+  if ( sSfM_Data_Filename.empty() )
   {
-    std::cerr << "\nIt is an invalid SfM file" << std::endl; 
+    std::cerr << "\nIt is an invalid SfM file" << std::endl;
     return EXIT_FAILURE;
   }
-  if( sPutativeMatchesFilename.empty() )
+  if ( sPutativeMatchesFilename.empty() )
   {
-    std::cerr << "\nIt is an invalid putative matche file" << std::endl; 
+    std::cerr << "\nIt is an invalid putative matche file" << std::endl;
     return EXIT_FAILURE;
   }
 
-  const std::string sMatchesDirectory = stlplus::folder_part( sSfM_Data_Filename ) + "/../matches/" ;
-
+  const std::string sMatchesDirectory = stlplus::folder_part( sSfM_Data_Filename ) + "/../matches/";
 
   EGeometricModel eGeometricModelToCompute = FUNDAMENTAL_MATRIX;
-  switch (sGeometricModel[0])
+  switch ( sGeometricModel[ 0 ] )
   {
-    case 'f': case 'F':
+    case 'f':
+    case 'F':
       eGeometricModelToCompute = FUNDAMENTAL_MATRIX;
-    break;
-    case 'e': case 'E':
+      break;
+    case 'e':
+    case 'E':
       eGeometricModelToCompute = ESSENTIAL_MATRIX;
-    break;
-    case 'h': case 'H':
+      break;
+    case 'h':
+    case 'H':
       eGeometricModelToCompute = HOMOGRAPHY_MATRIX;
-    break;
-    case 'a': case 'A':
+      break;
+    case 'a':
+    case 'A':
       eGeometricModelToCompute = ESSENTIAL_MATRIX_ANGULAR;
-    break;
-    case 'o': case 'O':
+      break;
+    case 'o':
+    case 'O':
       eGeometricModelToCompute = ESSENTIAL_MATRIX_ORTHO;
-    break;
+      break;
     default:
       std::cerr << "Unknown geometric model" << std::endl;
       return EXIT_FAILURE;
@@ -192,9 +199,10 @@ int main(int argc, char **argv)
   // Read SfM Scene (image view & intrinsics data)
   //---------------------------------------
   SfM_Data sfm_data;
-  if (!Load(sfm_data, sSfM_Data_Filename, ESfM_Data(VIEWS|INTRINSICS))) {
+  if ( !Load( sfm_data, sSfM_Data_Filename, ESfM_Data( VIEWS | INTRINSICS ) ) )
+  {
     std::cerr << std::endl
-      << "The input SfM_Data file \""<< sSfM_Data_Filename << "\" cannot be read." << std::endl;
+              << "The input SfM_Data file \"" << sSfM_Data_Filename << "\" cannot be read." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -204,12 +212,12 @@ int main(int argc, char **argv)
   // Init the regions_type from the image describer file (used for image regions extraction)
   using namespace openMVG::features;
   // Consider that the image_describer.json is inside the matches directory (which is bellow the sfm_data.bin)
-  const std::string sImage_describer = stlplus::create_filespec( sMatchesDirectory , "image_describer.json" ) ;
-  std::unique_ptr<Regions> regions_type = Init_region_type_from_file(sImage_describer);
-  if (!regions_type)
+  const std::string        sImage_describer = stlplus::create_filespec( sMatchesDirectory, "image_describer.json" );
+  std::unique_ptr<Regions> regions_type     = Init_region_type_from_file( sImage_describer );
+  if ( !regions_type )
   {
     std::cerr << "Invalid: "
-      << sImage_describer << " regions type file." << std::endl;
+              << sImage_describer << " regions type file." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -221,7 +229,7 @@ int main(int argc, char **argv)
 
   // Load the corresponding view regions
   std::shared_ptr<Regions_Provider> regions_provider;
-  if (ui_max_cache_size == 0)
+  if ( ui_max_cache_size == 0 )
   {
     // Default regions provider (load & store all regions in memory)
     regions_provider = std::make_shared<Regions_Provider>();
@@ -229,40 +237,40 @@ int main(int argc, char **argv)
   else
   {
     // Cached regions provider (load & store regions on demand)
-    regions_provider = std::make_shared<Regions_Provider_Cache>(ui_max_cache_size);
+    regions_provider = std::make_shared<Regions_Provider_Cache>( ui_max_cache_size );
   }
 
   // Show the progress on the command line:
   C_Progress_display progress;
 
-  if (!regions_provider->load(sfm_data, sMatchesDirectory, regions_type, &progress)) 
+  if ( !regions_provider->load( sfm_data, sMatchesDirectory, regions_type, &progress ) )
   {
-    std::cerr << std::endl << "Invalid regions." << std::endl;
+    std::cerr << std::endl
+              << "Invalid regions." << std::endl;
     return EXIT_FAILURE;
   }
 
   PairWiseMatches map_PutativesMatches;
   //---------------------------------------
-  // A. Load initial matches 
+  // A. Load initial matches
   //---------------------------------------
-  if( ! Load( map_PutativesMatches, sPutativeMatchesFilename) ) 
+  if ( !Load( map_PutativesMatches, sPutativeMatchesFilename ) )
   {
-    std::cerr << "Failed to load the initial matches file." ;
+    std::cerr << "Failed to load the initial matches file.";
     return EXIT_FAILURE;
   }
 
-  if( ! sInputPairsFilename.empty() )
+  if ( !sInputPairsFilename.empty() )
   {
-    // Load input pairs 
-    std::cout << "Loading input pairs ..." << std::endl; 
+    // Load input pairs
+    std::cout << "Loading input pairs ..." << std::endl;
     Pair_Set input_pairs;
-    loadPairs( sfm_data.GetViews().size(), sInputPairsFilename , input_pairs );
+    loadPairs( sfm_data.GetViews().size(), sInputPairsFilename, input_pairs );
 
-    // Filter matches with the given pairs 
+    // Filter matches with the given pairs
     std::cout << "Filtering matches with the given pairs." << std::endl;
-    map_PutativesMatches = getPairs( map_PutativesMatches , input_pairs );
+    map_PutativesMatches = getPairs( map_PutativesMatches, input_pairs );
   }
-
 
   //---------------------------------------
   // b. Geometric filtering of putative matches
@@ -271,73 +279,86 @@ int main(int argc, char **argv)
   //---------------------------------------
 
   std::unique_ptr<ImageCollectionGeometricFilter> filter_ptr(
-    new ImageCollectionGeometricFilter(&sfm_data, regions_provider));
+      new ImageCollectionGeometricFilter( &sfm_data, regions_provider ) );
 
-  if (filter_ptr)
+  if ( filter_ptr )
   {
     system::Timer timer;
-    const double d_distance_ratio = 0.6;
+    const double  d_distance_ratio = 0.6;
 
     PairWiseMatches map_GeometricMatches;
-    switch (eGeometricModelToCompute)
+    switch ( eGeometricModelToCompute )
     {
       case HOMOGRAPHY_MATRIX:
       {
         const bool bGeometric_only_guided_matching = true;
         filter_ptr->Robust_model_estimation(
-          GeometricFilter_HMatrix_AC(4.0, imax_iteration),
-          map_PutativesMatches, bGuided_matching,
-          bGeometric_only_guided_matching ? -1.0 : d_distance_ratio, &progress);
+            GeometricFilter_HMatrix_AC( 4.0, imax_iteration ),
+            map_PutativesMatches,
+            bGuided_matching,
+            bGeometric_only_guided_matching ? -1.0 : d_distance_ratio,
+            &progress );
         map_GeometricMatches = filter_ptr->Get_geometric_matches();
       }
       break;
       case FUNDAMENTAL_MATRIX:
       {
         filter_ptr->Robust_model_estimation(
-          GeometricFilter_FMatrix_AC(4.0, imax_iteration),
-          map_PutativesMatches, bGuided_matching, d_distance_ratio, &progress);
+            GeometricFilter_FMatrix_AC( 4.0, imax_iteration ),
+            map_PutativesMatches,
+            bGuided_matching,
+            d_distance_ratio,
+            &progress );
         map_GeometricMatches = filter_ptr->Get_geometric_matches();
       }
       break;
       case ESSENTIAL_MATRIX:
       {
         filter_ptr->Robust_model_estimation(
-          GeometricFilter_EMatrix_AC(4.0, imax_iteration),
-          map_PutativesMatches, bGuided_matching, d_distance_ratio, &progress);
+            GeometricFilter_EMatrix_AC( 4.0, imax_iteration ),
+            map_PutativesMatches,
+            bGuided_matching,
+            d_distance_ratio,
+            &progress );
         map_GeometricMatches = filter_ptr->Get_geometric_matches();
 
         //-- Perform an additional check to remove pairs with poor overlap
         std::vector<PairWiseMatches::key_type> vec_toRemove;
-        for (const auto & pairwisematches_it : map_GeometricMatches)
+        for ( const auto& pairwisematches_it : map_GeometricMatches )
         {
-          const size_t putativePhotometricCount = map_PutativesMatches.find(pairwisematches_it.first)->second.size();
-          const size_t putativeGeometricCount = pairwisematches_it.second.size();
-          const float ratio = putativeGeometricCount / static_cast<float>(putativePhotometricCount);
-          if (putativeGeometricCount < 50 || ratio < .3f)  {
+          const size_t putativePhotometricCount = map_PutativesMatches.find( pairwisematches_it.first )->second.size();
+          const size_t putativeGeometricCount   = pairwisematches_it.second.size();
+          const float  ratio                    = putativeGeometricCount / static_cast<float>( putativePhotometricCount );
+          if ( putativeGeometricCount < 50 || ratio < .3f )
+          {
             // the pair will be removed
-            vec_toRemove.push_back(pairwisematches_it.first);
+            vec_toRemove.push_back( pairwisematches_it.first );
           }
         }
         //-- remove discarded pairs
-        for (const auto & pair_to_remove_it : vec_toRemove)
+        for ( const auto& pair_to_remove_it : vec_toRemove )
         {
-          map_GeometricMatches.erase(pair_to_remove_it);
+          map_GeometricMatches.erase( pair_to_remove_it );
         }
       }
       break;
       case ESSENTIAL_MATRIX_ANGULAR:
       {
         filter_ptr->Robust_model_estimation(
-          GeometricFilter_ESphericalMatrix_AC_Angular(4.0, imax_iteration),
-          map_PutativesMatches, bGuided_matching);
+            GeometricFilter_ESphericalMatrix_AC_Angular( 4.0, imax_iteration ),
+            map_PutativesMatches,
+            bGuided_matching );
         map_GeometricMatches = filter_ptr->Get_geometric_matches();
       }
       break;
       case ESSENTIAL_MATRIX_ORTHO:
       {
         filter_ptr->Robust_model_estimation(
-          GeometricFilter_EOMatrix_RA(2.0, imax_iteration),
-          map_PutativesMatches, bGuided_matching, d_distance_ratio, &progress);
+            GeometricFilter_EOMatrix_RA( 2.0, imax_iteration ),
+            map_PutativesMatches,
+            bGuided_matching,
+            d_distance_ratio,
+            &progress );
         map_GeometricMatches = filter_ptr->Get_geometric_matches();
       }
       break;
@@ -346,11 +367,11 @@ int main(int argc, char **argv)
     //---------------------------------------
     //-- Export geometric filtered matches
     //---------------------------------------
-    if (!Save(map_GeometricMatches, sFilteredMatchesFilename) )
+    if ( !Save( map_GeometricMatches, sFilteredMatchesFilename ) )
     {
       std::cerr
-          << "Cannot save filtered matches in: " 
-          << sFilteredMatchesFilename ;
+          << "Cannot save filtered matches in: "
+          << sFilteredMatchesFilename;
       return EXIT_FAILURE;
     }
 
@@ -358,35 +379,33 @@ int main(int argc, char **argv)
 
     //-- export Adjacency matrix
     std::cout << "\n Export Adjacency Matrix of the pairwise's geometric matches"
-      << std::endl;
-    PairWiseMatchingToAdjacencyMatrixSVG(sfm_data.GetViews().size(),
-      map_GeometricMatches,
-      stlplus::create_filespec(sMatchesDirectory, "GeometricAdjacencyMatrix", "svg"));
+              << std::endl;
+    PairWiseMatchingToAdjacencyMatrixSVG( sfm_data.GetViews().size(),
+                                          map_GeometricMatches,
+                                          stlplus::create_filespec( sMatchesDirectory, "GeometricAdjacencyMatrix", "svg" ) );
 
-    const Pair_Set outputPairs = getPairs(map_GeometricMatches);
+    const Pair_Set outputPairs = getPairs( map_GeometricMatches );
 
     //-- export view pair graph once geometric filter have been done
     {
       std::set<IndexT> set_ViewIds;
-      std::transform(sfm_data.GetViews().begin(), sfm_data.GetViews().end(),
-        std::inserter(set_ViewIds, set_ViewIds.begin()), stl::RetrieveKey());
-      graph::indexedGraph putativeGraph(set_ViewIds, outputPairs );
+      std::transform( sfm_data.GetViews().begin(), sfm_data.GetViews().end(), std::inserter( set_ViewIds, set_ViewIds.begin() ), stl::RetrieveKey() );
+      graph::indexedGraph putativeGraph( set_ViewIds, outputPairs );
       graph::exportToGraphvizData(
-        stlplus::create_filespec(sMatchesDirectory, "geometric_matches"),
-        putativeGraph);
+          stlplus::create_filespec( sMatchesDirectory, "geometric_matches" ),
+          putativeGraph );
     }
-    
-    // Write pairs 
-    if( !sOutputPairsFilename.empty() )
+
+    // Write pairs
+    if ( !sOutputPairsFilename.empty() )
     {
-      std::cout << "Saving pairs to: " << sOutputPairsFilename << std::endl; 
-      if( ! savePairs( sOutputPairsFilename , outputPairs ) )
+      std::cout << "Saving pairs to: " << sOutputPairsFilename << std::endl;
+      if ( !savePairs( sOutputPairsFilename, outputPairs ) )
       {
-        std::cerr << "Failed to write pairs file" << std::endl; 
+        std::cerr << "Failed to write pairs file" << std::endl;
         return EXIT_FAILURE;
       }
     }
-
   }
   return EXIT_SUCCESS;
 }

--- a/src/software/SfM/main_GeometricFilter.cpp
+++ b/src/software/SfM/main_GeometricFilter.cpp
@@ -1,0 +1,352 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2012, 2019 Pierre MOULON, Romuald PERROT
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/graph/graph.hpp"
+#include "openMVG/features/akaze/image_describer_akaze.hpp"
+#include "openMVG/features/descriptor.hpp"
+#include "openMVG/features/feature.hpp"
+#include "openMVG/matching/indMatch.hpp"
+#include "openMVG/matching/indMatch_utils.hpp"
+#include "openMVG/matching_image_collection/Matcher_Regions.hpp"
+#include "openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions.hpp"
+#include "openMVG/matching_image_collection/GeometricFilter.hpp"
+#include "openMVG/sfm/pipelines/sfm_features_provider.hpp"
+#include "openMVG/sfm/pipelines/sfm_regions_provider.hpp"
+#include "openMVG/sfm/pipelines/sfm_regions_provider_cache.hpp"
+#include "openMVG/matching_image_collection/F_ACRobust.hpp"
+#include "openMVG/matching_image_collection/E_ACRobust.hpp"
+#include "openMVG/matching_image_collection/E_ACRobust_Angular.hpp"
+#include "openMVG/matching_image_collection/Eo_Robust.hpp"
+#include "openMVG/matching_image_collection/H_ACRobust.hpp"
+#include "openMVG/matching_image_collection/Pair_Builder.hpp"
+#include "openMVG/matching/pairwiseAdjacencyDisplay.hpp"
+#include "openMVG/sfm/sfm_data.hpp"
+#include "openMVG/sfm/sfm_data_io.hpp"
+#include "openMVG/stl/stl.hpp"
+#include "openMVG/system/timer.hpp"
+
+#include "third_party/cmdLine/cmdLine.h"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace openMVG;
+using namespace openMVG::matching;
+using namespace openMVG::robust;
+using namespace openMVG::sfm;
+using namespace openMVG::matching_image_collection;
+using namespace std;
+
+enum EGeometricModel
+{
+  FUNDAMENTAL_MATRIX = 0,
+  ESSENTIAL_MATRIX   = 1,
+  HOMOGRAPHY_MATRIX  = 2,
+  ESSENTIAL_MATRIX_ANGULAR = 3,
+  ESSENTIAL_MATRIX_ORTHO = 4
+};
+
+/// Compute corresponding features between a series of views:
+/// - Load view images description (regions: features & descriptors)
+/// - Compute putative local feature matches (descriptors matching)
+/// - Compute geometric coherent feature matches (robust model estimation from putative matches)
+/// - Export computed data
+int main(int argc, char **argv)
+{
+  CmdLine cmd;
+
+  std::string sSfM_Data_Filename;
+  std::string sPutativePairsFilename;
+  std::string sFilteredPairsFilename;
+  std::string sGeometricModel = "f";
+  bool bForce = false;
+  bool bGuided_matching = false;
+  int imax_iteration = 2048;
+  unsigned int ui_max_cache_size = 0;
+
+  //required
+  cmd.add( make_option('i', sSfM_Data_Filename, "input_file") );
+  cmd.add( make_option('o', sFilteredPairsFilename, "output_file") );
+  cmd.add( make_option('p', sPutativePairsFilename, "pairs") );
+  // Options
+  cmd.add( make_option('g', sGeometricModel, "geometric_model") );
+  cmd.add( make_option('f', bForce, "force") );
+  cmd.add( make_option('m', bGuided_matching, "guided_matching") );
+  cmd.add( make_option('I', imax_iteration, "max_iteration") );
+  cmd.add( make_option('c', ui_max_cache_size, "cache_size") );
+
+
+  try {
+      if (argc == 1) throw std::string("Invalid command line parameter.");
+      cmd.process(argc, argv);
+  } catch (const std::string& s) {
+      std::cerr << "Usage: " << argv[0] << '\n'
+      << "[-i|--input_file] a SfM_Data file\n"
+      << "[-p|--pairs] initial pairs filename to use\n"
+      << "[-o|--output_file] output filtered pairs filename\n"
+      << "\n[Optional]\n"
+      << "[-f|--force] Force to recompute data]\n"
+      << "[-g|--geometric_model]\n"
+      << "  (pairwise correspondences filtering thanks to robust model estimation):\n"
+      << "   f: (default) fundamental matrix,\n"
+      << "   e: essential matrix,\n"
+      << "   h: homography matrix.\n"
+      << "   a: essential matrix with an angular parametrization,\n"
+      << "   o: orthographic essential matrix.\n"
+      << "[-m|--guided_matching]\n"
+      << "  use the found model to improve the pairwise correspondences.\n"
+      << "[-c|--cache_size]\n"
+      << "  Use a regions cache (only cache_size regions will be stored in memory)\n"
+      << "  If not used, all regions will be load in memory."
+      << std::endl;
+
+      std::cerr << s << std::endl;
+      return EXIT_FAILURE;
+  }
+
+  std::cout << " You called : " << "\n"
+            << argv[0] << "\n"
+            << "--input_file: " << sSfM_Data_Filename << "\n"
+            << "--pairs: " << sPutativePairsFilename << "\n"
+            << "--output_file: " << sFilteredPairsFilename << "\n"
+            << "Optional parameters:" << "\n"
+            << "--force " << bForce << "\n"
+            << "--geometric_model " << sGeometricModel << "\n"
+            << "--guided_matching " << bGuided_matching << "\n"
+            << "--cache_size " << ((ui_max_cache_size == 0) ? "unlimited" : std::to_string(ui_max_cache_size)) << std::endl;
+
+
+
+  if (sFilteredPairsFilename.empty() )  
+  {
+    std::cerr << "\nIt is an invalid output file" << std::endl;
+    return EXIT_FAILURE;
+  }
+  if( sSfM_Data_Filename.empty() )
+  {
+    std::cerr << "\nIt is an invalid SfM file" << std::endl; 
+    return EXIT_FAILURE;
+  }
+  if( sPutativePairsFilename.empty() )
+  {
+    std::cerr << "\nIt is an invalid putative pairs file" << std::endl; 
+    return EXIT_FAILURE;
+  }
+
+  const std::string sMatchesDirectory = stlplus::folder_part( sSfM_Data_Filename ) + "/../matches/" ;
+
+
+  EGeometricModel eGeometricModelToCompute = FUNDAMENTAL_MATRIX;
+  switch (sGeometricModel[0])
+  {
+    case 'f': case 'F':
+      eGeometricModelToCompute = FUNDAMENTAL_MATRIX;
+    break;
+    case 'e': case 'E':
+      eGeometricModelToCompute = ESSENTIAL_MATRIX;
+    break;
+    case 'h': case 'H':
+      eGeometricModelToCompute = HOMOGRAPHY_MATRIX;
+    break;
+    case 'a': case 'A':
+      eGeometricModelToCompute = ESSENTIAL_MATRIX_ANGULAR;
+    break;
+    case 'o': case 'O':
+      eGeometricModelToCompute = ESSENTIAL_MATRIX_ORTHO;
+    break;
+    default:
+      std::cerr << "Unknown geometric model" << std::endl;
+      return EXIT_FAILURE;
+  }
+
+  // -----------------------------
+  // - Load SfM_Data Views & intrinsics data
+  // a. Load putative descriptor matches
+  // b. Geometric filtering of putative matches
+  // + Export some statistics
+  // -----------------------------
+
+  //---------------------------------------
+  // Read SfM Scene (image view & intrinsics data)
+  //---------------------------------------
+  SfM_Data sfm_data;
+  if (!Load(sfm_data, sSfM_Data_Filename, ESfM_Data(VIEWS|INTRINSICS))) {
+    std::cerr << std::endl
+      << "The input SfM_Data file \""<< sSfM_Data_Filename << "\" cannot be read." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  //---------------------------------------
+  // Load SfM Scene regions
+  //---------------------------------------
+  // Init the regions_type from the image describer file (used for image regions extraction)
+  using namespace openMVG::features;
+  // Consider that the image_describer.json is inside the matches directory (which is bellow the sfm_data.bin)
+  const std::string sImage_describer = stlplus::create_filespec( sMatchesDirectory , "image_describer.json" ) ;
+  std::unique_ptr<Regions> regions_type = Init_region_type_from_file(sImage_describer);
+  if (!regions_type)
+  {
+    std::cerr << "Invalid: "
+      << sImage_describer << " regions type file." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  //---------------------------------------
+  // a. Compute putative descriptor matches
+  //    - Descriptor matching (according user method choice)
+  //    - Keep correspondences only if NearestNeighbor ratio is ok
+  //---------------------------------------
+
+  // Load the corresponding view regions
+  std::shared_ptr<Regions_Provider> regions_provider;
+  if (ui_max_cache_size == 0)
+  {
+    // Default regions provider (load & store all regions in memory)
+    regions_provider = std::make_shared<Regions_Provider>();
+  }
+  else
+  {
+    // Cached regions provider (load & store regions on demand)
+    regions_provider = std::make_shared<Regions_Provider_Cache>(ui_max_cache_size);
+  }
+
+  // Show the progress on the command line:
+  C_Progress_display progress;
+
+  if (!regions_provider->load(sfm_data, sMatchesDirectory, regions_type, &progress)) 
+  {
+    std::cerr << std::endl << "Invalid regions." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  PairWiseMatches map_PutativesMatches;
+  //---------------------------------------
+  // A. Load initial matches 
+  //---------------------------------------
+  if( ! Load( map_PutativesMatches, sPutativePairsFilename) ) 
+  {
+    std::cerr << "Filed to load the initial pairs" ;
+    return EXIT_FAILURE;
+  }
+
+
+  //---------------------------------------
+  // b. Geometric filtering of putative matches
+  //    - AContrario Estimation of the desired geometric model
+  //    - Use an upper bound for the a contrario estimated threshold
+  //---------------------------------------
+
+  std::unique_ptr<ImageCollectionGeometricFilter> filter_ptr(
+    new ImageCollectionGeometricFilter(&sfm_data, regions_provider));
+
+  if (filter_ptr)
+  {
+    system::Timer timer;
+    const double d_distance_ratio = 0.6;
+
+    PairWiseMatches map_GeometricMatches;
+    switch (eGeometricModelToCompute)
+    {
+      case HOMOGRAPHY_MATRIX:
+      {
+        const bool bGeometric_only_guided_matching = true;
+        filter_ptr->Robust_model_estimation(
+          GeometricFilter_HMatrix_AC(4.0, imax_iteration),
+          map_PutativesMatches, bGuided_matching,
+          bGeometric_only_guided_matching ? -1.0 : d_distance_ratio, &progress);
+        map_GeometricMatches = filter_ptr->Get_geometric_matches();
+      }
+      break;
+      case FUNDAMENTAL_MATRIX:
+      {
+        filter_ptr->Robust_model_estimation(
+          GeometricFilter_FMatrix_AC(4.0, imax_iteration),
+          map_PutativesMatches, bGuided_matching, d_distance_ratio, &progress);
+        map_GeometricMatches = filter_ptr->Get_geometric_matches();
+      }
+      break;
+      case ESSENTIAL_MATRIX:
+      {
+        filter_ptr->Robust_model_estimation(
+          GeometricFilter_EMatrix_AC(4.0, imax_iteration),
+          map_PutativesMatches, bGuided_matching, d_distance_ratio, &progress);
+        map_GeometricMatches = filter_ptr->Get_geometric_matches();
+
+        //-- Perform an additional check to remove pairs with poor overlap
+        std::vector<PairWiseMatches::key_type> vec_toRemove;
+        for (const auto & pairwisematches_it : map_GeometricMatches)
+        {
+          const size_t putativePhotometricCount = map_PutativesMatches.find(pairwisematches_it.first)->second.size();
+          const size_t putativeGeometricCount = pairwisematches_it.second.size();
+          const float ratio = putativeGeometricCount / static_cast<float>(putativePhotometricCount);
+          if (putativeGeometricCount < 50 || ratio < .3f)  {
+            // the pair will be removed
+            vec_toRemove.push_back(pairwisematches_it.first);
+          }
+        }
+        //-- remove discarded pairs
+        for (const auto & pair_to_remove_it : vec_toRemove)
+        {
+          map_GeometricMatches.erase(pair_to_remove_it);
+        }
+      }
+      break;
+      case ESSENTIAL_MATRIX_ANGULAR:
+      {
+        filter_ptr->Robust_model_estimation(
+          GeometricFilter_ESphericalMatrix_AC_Angular(4.0, imax_iteration),
+          map_PutativesMatches, bGuided_matching);
+        map_GeometricMatches = filter_ptr->Get_geometric_matches();
+      }
+      break;
+      case ESSENTIAL_MATRIX_ORTHO:
+      {
+        filter_ptr->Robust_model_estimation(
+          GeometricFilter_EOMatrix_RA(2.0, imax_iteration),
+          map_PutativesMatches, bGuided_matching, d_distance_ratio, &progress);
+        map_GeometricMatches = filter_ptr->Get_geometric_matches();
+      }
+      break;
+    }
+
+    //---------------------------------------
+    //-- Export geometric filtered matches
+    //---------------------------------------
+    if (!Save(map_GeometricMatches, sFilteredPairsFilename) )
+    {
+      std::cerr
+          << "Cannot save filtered matches in: " 
+          << sFilteredPairsFilename ;
+      return EXIT_FAILURE;
+    }
+
+    std::cout << "Task done in (s): " << timer.elapsed() << std::endl;
+
+    //-- export Adjacency matrix
+    std::cout << "\n Export Adjacency Matrix of the pairwise's geometric matches"
+      << std::endl;
+    PairWiseMatchingToAdjacencyMatrixSVG(sfm_data.GetViews().size(),
+      map_GeometricMatches,
+      stlplus::create_filespec(sMatchesDirectory, "GeometricAdjacencyMatrix", "svg"));
+
+    //-- export view pair graph once geometric filter have been done
+    {
+      std::set<IndexT> set_ViewIds;
+      std::transform(sfm_data.GetViews().begin(), sfm_data.GetViews().end(),
+        std::inserter(set_ViewIds, set_ViewIds.begin()), stl::RetrieveKey());
+      graph::indexedGraph putativeGraph(set_ViewIds, getPairs(map_GeometricMatches));
+      graph::exportToGraphvizData(
+        stlplus::create_filespec(sMatchesDirectory, "geometric_matches"),
+        putativeGraph);
+    }
+  }
+  return EXIT_SUCCESS;
+}

--- a/src/software/SfM/main_GeometricFilter.cpp
+++ b/src/software/SfM/main_GeometricFilter.cpp
@@ -379,7 +379,7 @@ int main(int argc, char **argv)
     // Write pairs 
     if( !sOutputPairsFilename.empty() )
     {
-      std::cout << "Saving pairs to :" << sOutputPairsFilename << std::endl; 
+      std::cout << "Saving pairs to: " << sOutputPairsFilename << std::endl; 
       if( ! savePairs( sOutputPairsFilename , outputPairs ) )
       {
         std::cerr << "Failed to write pairs file" << std::endl; 

--- a/src/software/SfM/main_PairGenerator.cpp
+++ b/src/software/SfM/main_PairGenerator.cpp
@@ -16,7 +16,7 @@
 #include <iostream>
 
 /**
- * @brief Current list of pair mode available
+ * @brief Current list of available pair mode
  * 
  */
 enum EPairMode
@@ -127,29 +127,29 @@ int main( int argc, char** argv )
   const size_t NImage = sfm_data.GetViews().size();
 
   // 2. Compute pairs
-  std::cout << "Computing pairs.";
+  std::cout << "Computing pairs." << std::endl;
   Pair_Set pairs;
   switch ( pairMode )
   {
-  case PAIR_EXHAUSTIVE:
-  {
-    pairs = exhaustivePairs( NImage );
-    break;
-  }
-  case PAIR_CONTIGUOUS:
-  {
-    pairs = contiguousWithOverlap( NImage, iContiguousCount );
-    break;
-  }
-  default:
-  {
-    std::cerr << "Unknown pair mode";
-    exit( EXIT_FAILURE );
-  }
+    case PAIR_EXHAUSTIVE:
+    {
+      pairs = exhaustivePairs( NImage );
+      break;
+    }
+    case PAIR_CONTIGUOUS:
+    {
+      pairs = contiguousWithOverlap( NImage, iContiguousCount );
+      break;
+    }
+    default:
+    {
+      std::cerr << "Unknown pair mode" << std::endl;
+      exit( EXIT_FAILURE );
+    }
   }
 
   // 3. Save pairs
-  std::cout << "Saving pairs.";
+  std::cout << "Saving pairs." << std::endl;
   if ( !savePairs( sOutputPairsFilename, pairs ) )
   {
     std::cerr << "Failed to save pairs to file: \"" << sOutputPairsFilename << "\"" << std::endl;

--- a/src/software/SfM/main_PairsGenerator.cpp
+++ b/src/software/SfM/main_PairsGenerator.cpp
@@ -1,0 +1,160 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2019 Romuald PERROT
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "openMVG/matching_image_collection/Pair_Builder.hpp"
+#include "openMVG/sfm/sfm_data.hpp"
+#include "openMVG/sfm/sfm_data_io.hpp"
+
+#include "third_party/cmdLine/cmdLine.h"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+#include <iostream>
+
+/**
+ * @brief Current list of pair mode available
+ * 
+ */
+enum EPairMode
+{
+  PAIR_EXHAUSTIVE = 0, // Build every combination of image pairs
+  PAIR_CONTIGUOUS = 1  // Only consecutive image pairs (useful for video mode)
+};
+
+using namespace openMVG;
+using namespace openMVG::sfm;
+
+void usage( const char* argv0 )
+{
+  std::cerr << "Usage: " << argv0 << '\n'
+            << "[-i|--input_file]         A SfM_Data file\n"
+            << "[-o|--output_file]        Output file where pairs are stored\n"
+            << "\n[Optional]\n"
+            << "[-m|--pair_mode] mode     Pair generation mode\n"
+            << "       EXHAUSTIVE:        Build all possible pairs. [default]\n"
+            << "       CONTIGUOUS:        Build pairs for contiguous images (use it with --contiguous_count parameter)\n"
+            << "[-c|--contiguous_count] X Number of contiguous links\n"
+            << "       X: with match 0 with (1->X), ...]\n"
+            << "       2: will match 0 with (1,2), 1 with (2,3), ...\n"
+            << "       3: will match 0 with (1,2,3), 1 with (2,3,4), ...\n"
+            << std::endl;
+}
+
+// This executable computes pairs of images to be matched
+int main( int argc, char** argv )
+{
+  CmdLine cmd;
+
+  std::string sSfMDataFilename;
+  std::string sOutputPairsFilename;
+  std::string sPairMode        = "EXHAUSTIVE";
+  int         iContiguousCount = -1;
+
+  // Mandatory elements:
+  cmd.add( make_option( 'i', sSfMDataFilename, "input_file" ) );
+  cmd.add( make_option( 'o', sOutputPairsFilename, "output_file" ) );
+  // Optionnal elements:
+  cmd.add( make_option( 'm', sPairMode, "pair_mode" ) );
+  cmd.add( make_option( 'c', iContiguousCount, "contiguous_count" ) );
+
+  try
+  {
+    if ( argc == 1 )
+      throw std::string( "Invalid command line parameter." );
+    cmd.process( argc, argv );
+  }
+  catch ( const std::string& s )
+  {
+    usage( argv[ 0 ] );
+    std::cerr << "[Error] " << s << std::endl;
+
+    return EXIT_FAILURE;
+  }
+
+  // 0. Parse parameters
+  std::cout << " You called:\n"
+            << argv[ 0 ] << "\n"
+            << "--input_file       : " << sSfMDataFilename << "\n"
+            << "--output_file      : " << sOutputPairsFilename << "\n"
+            << "Optional parameters\n"
+            << "--pair_mode        : " << sPairMode << "\n"
+            << "--contiguous_count : " << iContiguousCount << "\n"
+            << std::endl;
+
+  if ( sSfMDataFilename.empty() )
+  {
+    usage( argv[ 0 ] );
+    std::cerr << "[Error] Input file not set." << std::endl;
+    exit( EXIT_FAILURE );
+  }
+  if ( sOutputPairsFilename.empty() )
+  {
+    usage( argv[ 0 ] );
+    std::cerr << "[Error] Output file not set." << std::endl;
+    exit( EXIT_FAILURE );
+  }
+
+  EPairMode pairMode;
+  if ( sPairMode == "EXHAUSTIVE" )
+  {
+    pairMode = PAIR_EXHAUSTIVE;
+  }
+  else if ( sPairMode == "CONTIGUOUS" )
+  {
+    if ( iContiguousCount == -1 )
+    {
+      usage( argv[ 0 ] );
+      std::cerr << "[Error] Contiguous pair mode selected but contiguous_count not set." << std::endl;
+      exit( EXIT_FAILURE );
+    }
+
+    pairMode = PAIR_CONTIGUOUS;
+  }
+
+  // 1. Load SfM data scene
+  std::cout << "Loading scene.";
+  SfM_Data sfm_data;
+  if ( !Load( sfm_data, sSfMDataFilename, ESfM_Data( VIEWS | INTRINSICS ) ) )
+  {
+    std::cerr << std::endl
+              << "The input SfM_Data file \"" << sSfMDataFilename << "\" cannot be read." << std::endl;
+    exit( EXIT_FAILURE );
+  }
+  const size_t NImage = sfm_data.GetViews().size();
+
+  // 2. Compute pairs
+  std::cout << "Computing pairs.";
+  Pair_Set pairs;
+  switch ( pairMode )
+  {
+  case PAIR_EXHAUSTIVE:
+  {
+    pairs = exhaustivePairs( NImage );
+    break;
+  }
+  case PAIR_CONTIGUOUS:
+  {
+    pairs = contiguousWithOverlap( NImage, iContiguousCount );
+    break;
+  }
+  default:
+  {
+    std::cerr << "Unknown pair mode";
+    exit( EXIT_FAILURE );
+  }
+  }
+
+  // 3. Save pairs
+  std::cout << "Saving pairs.";
+  if ( !savePairs( sOutputPairsFilename, pairs ) )
+  {
+    std::cerr << "Failed to save pairs to file: \"" << sOutputPairsFilename << "\"" << std::endl;
+    exit( EXIT_FAILURE );
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Hi, 

this PR aims at splitting the openMVG_main_ComputeMatches executable into three executables: 
- openMVG_main_PairGenerator : given an sfm_data, it computes the set of image pairs to be matched. It comes from the original openMVG_main_ComputeMatches executable where two modes are available: exhaustif pair (ie: all possible combination of image pairs) and contiguous (ex: video mode)
- openMVG_main_ComputeMatches : it now does only matching.
- openMVG_main_GeometricFilter : it does geometric only filtering, it accepts as input a matches file. It comes from the original openMVG_main_ComputeMatches file. 

The standard pipelines have been updated to take into account this new division. 

The new executables may provide more flexibility for hybrid pipelines because it allows multiple pass.

Hope it helps !