### PR TITLE
[camera] use normalized bearing vector instead of homogenous coords

### DIFF
--- a/src/openMVG/cameras/Camera_Pinhole.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole.hpp
@@ -135,7 +135,7 @@ class Pinhole_Intrinsic : public IntrinsicBase
     */
     Mat3X operator () ( const Mat2X& points ) const override
     {
-      return Kinv_ * points.colwise().homogeneous();
+      return (Kinv_ * points.colwise().homogeneous()).colwise().normalized();
     }
 
     /**


### PR DESCRIPTION
Normalized bearing are needed by p3p solvers (Ke, and Kneip), currently we feed them with homogenous coordinates, it provokes drift in AC-RANSAC thresholds (see #1255).

it fixes at least #1255 