### PR TITLE
[SfM/triangulation] the whole track was checked against predicates (not only the hypothesis)

### DIFF
--- a/src/openMVG/sfm/sfm_data_triangulation.cpp
+++ b/src/openMVG/sfm/sfm_data_triangulation.cpp
@@ -359,13 +359,15 @@ const
     std::vector<uint32_t> samples;
     robust::UniformSample(min_sample_index_, obs.size(), random_generator, &samples);
 
-    // Hypothesis generation
     Vec3 X;
-    if (!track_triangulation(sfm_data, ObservationsSampler(obs, samples), X))
+    // Hypothesis generation
+    const auto minimal_sample = ObservationsSampler(obs, samples);
+    
+    if (!track_triangulation(sfm_data, minimal_sample, X))
       continue;
 
     // Test validity of the hypothesis
-    if (!track_check_predicate(obs, sfm_data, X, predicate_binding))
+    if (!track_check_predicate(minimal_sample, sfm_data, X, predicate_binding))
       continue;
 
     std::deque<IndexT> inlier_set;


### PR DESCRIPTION
In the `SfM_Data_Structure_Computation_Robust` class: 
Since the inception of the function `track_check_predicate`, the full track was passed to the function (instead of checking *only* the hypothesis). As a result some valid hypothesis are discarded and the robust triangulation create less "valid" tracks than it should.
My bad for not having spotted this before the merge :-1:  
