### PR TITLE
Defined but Unused threshold parameter maxContrast, adding usage of threshold parameter to code,tiny fix

### DIFF
--- a/src/openMVG/matching/kvld/kvld.h
+++ b/src/openMVG/matching/kvld/kvld.h
@@ -103,7 +103,7 @@ public:
     diff[ 0 ] = 0;
     diff[ 1 ] = 0;
 
-    if (contrast > 300 || vld2.contrast > 300  || contrast <= 0 || vld2.contrast <=0 )
+    if (contrast > maxContrast || vld2.contrast > maxContrast  || contrast <= 0 || vld2.contrast <=0 )
       return 128;
 
     for (int i = 0; i < dimension; i++ )


### PR DESCRIPTION
While working on the KVLD filtering I find out that one of the parameter named maxContrast was defined but not used. I made a tiny change  in the code to put the threshold check to its right place.
Since the lines with high contrast might be unreliable, in particular along the image edges it would be better to have this threshold parameter and use it. 