### PR TITLE
[BUILD] Fix compilation on GCC + Mac OS #1580

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
             - libqt5opengl5-dev
       env:
         - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
+          
     # works on Precise and Trusty
     - os: linux
       addons:
@@ -215,7 +216,6 @@ before_script:
       -DOpenMVG_BUILD_EXAMPLES=ON \
       -DOpenMVG_BUILD_SOFTWARES=ON \
       -DSCHUR_SPECIALIZATIONS=OFF \
-      -DCXXFLAGS=-w \
       . $OPENMVG_SOURCE
 
 script:
@@ -227,5 +227,4 @@ script:
     else
       time make all -j 2
     fi
-    
   - ctest -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,63 +9,63 @@ language: cpp
 
 matrix:
   include:
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - ubuntu-sdk-team/ppa
-          packages:
-            - g++-4.8
-            - qtbase5-dev
-            - libqt5svg5-dev
-            - libqt5opengl5-dev
-      env:
-        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      env:
-        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-
-    # works on macOS 10.13
-    - os: osx
-      osx_image: xcode9.4
-    
-    # works on macOS 10.14
-    - os: osx
-      osx_image: xcode10.2
-       
-    - os: osx
-      osx_image: xcode11
-
+  #    - os: linux
+  #      addons:
+  #        apt:
+  #          sources:
+  #            - ubuntu-toolchain-r-test
+  #            - ubuntu-sdk-team/ppa
+  #          packages:
+  #            - g++-4.8
+  #            - qtbase5-dev
+  #            - libqt5svg5-dev
+  #            - libqt5opengl5-dev
+  #      env:
+  #        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
+  #    # works on Precise and Trusty
+  #    - os: linux
+  #      addons:
+  #        apt:
+  #          sources:
+  #            - ubuntu-toolchain-r-test
+  #          packages:
+  #            - g++-5
+  #      env:
+  #         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+  #
+  #    # works on Precise and Trusty
+  #    - os: linux
+  #      addons:
+  #        apt:
+  #          sources:
+  #            - ubuntu-toolchain-r-test
+  #          packages:
+  #            - g++-6
+  #      env:
+  #        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+  #
+  #    # works on Precise and Trusty
+  #    - os: linux
+  #      addons:
+  #        apt:
+  #          sources:
+  #            - ubuntu-toolchain-r-test
+  #          packages:
+  #            - g++-7
+  #      env:
+  #        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+  #
+  #    # works on macOS 10.13
+  #    - os: osx
+  #      osx_image: xcode9.4
+  #    
+  #    # works on macOS 10.14
+  #    - os: osx
+  #      osx_image: xcode10.2
+  #       
+     - os: osx
+       osx_image: xcode11
+ 
     # allowed to fail: an exact topy is below in allow_failures
     # watching for Apple updates.
     # there are problems with GCC including new but nonstandard Apple .h
@@ -91,64 +91,64 @@ matrix:
           - gcc@5
       env:
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
-          packages:
-            - clang-3.6
-      env:
-        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - clang-3.7
-      env:
-        - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
-          packages:
-            - clang-3.8
-      env:
-        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
-
-    # works on Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-3.9
-          packages:
-            - clang-3.9
-      env:
-        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
-
-    # works on Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-4.0
-          packages:
-            - clang-4.0
-      env:
-        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+  #
+  #    # works on Precise and Trusty
+  #    - os: linux
+  #      addons:
+  #        apt:
+  #          sources:
+  #            - ubuntu-toolchain-r-test
+  #            - llvm-toolchain-precise-3.6
+  #          packages:
+  #            - clang-3.6
+  #      env:
+  #        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
+  #
+  #    # works on Precise and Trusty
+  #    - os: linux
+  #      addons:
+  #        apt:
+  #          sources:
+  #            - ubuntu-toolchain-r-test
+  #            - llvm-toolchain-precise-3.7
+  #          packages:
+  #            - clang-3.7
+  #      env:
+  #        - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
+  #
+  #    # works on Precise and Trusty
+  #    - os: linux
+  #      addons:
+  #        apt:
+  #          sources:
+  #            - ubuntu-toolchain-r-test
+  #            - llvm-toolchain-precise-3.8
+  #          packages:
+  #            - clang-3.8
+  #      env:
+  #        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+  #
+  #    # works on Trusty
+  #    - os: linux
+  #      addons:
+  #        apt:
+  #          sources:
+  #            - llvm-toolchain-trusty-3.9
+  #          packages:
+  #            - clang-3.9
+  #      env:
+  #        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+  #
+  #    # works on Trusty
+  #    - os: linux
+  #      addons:
+  #        apt:
+  #          sources:
+  #            - llvm-toolchain-trusty-4.0
+  #          packages:
+  #            - clang-4.0
+  #      env:
+  #        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
 
     # works on Trusty
     - os: linux
@@ -162,16 +162,6 @@ matrix:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
           
   allow_failures:
-    - os: osx
-      osx_image: xcode10.2
-      addons:
-        homebrew:
-          packages:
-          - gcc@5
-      env:
-        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-      
-          
     - os: osx
       osx_image: xcode11
       addons:
@@ -231,7 +221,7 @@ script:
     if [ "$TRAVIS_OS_NAME" = "osx" -a `echo $CC | grep -o gcc-`="gcc-" ]; then 
       echo 'truncating GCC output'
       # for OSX and GCC-* we filter out linker warnings to avoid travis log size errors
-      time make all -j 2 2>&1 | grep -v -e '^/var/folders/*' -e '^[[:space:]]*\.section' -e '^[[:space:]]*\^[[:space:]]*~*'; 
+      time make all -j 2 2>&1 | grep -v -e '^/var/folders/*' -e '^[[:space:]]*\.section' -e '^[[:space:]]*\^[[:space:]]*~*' | grep --color=always -i 'warning\|error\|$'
     else
       time make all -j 2
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,10 +66,6 @@ matrix:
     - os: osx
       osx_image: xcode11
 
-    # allowed to fail: an exact topy is below in allow_failures
-    # watching for Apple updates.
-    # there are problems with GCC including new but nonstandard Apple .h
-    # https://github.com/Homebrew/homebrew-core/issues/40676
     - os: osx
       osx_image: xcode10.2
       addons:
@@ -78,6 +74,15 @@ matrix:
           - gcc@5
       env:
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+          
+    - os: osx
+      osx_image: xcode10.2
+      addons:
+        homebrew:
+          packages:
+          - gcc@7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
           
     # allowed to fail: an exact topy is below in allow_failures
     # watching for Apple updates.
@@ -218,11 +223,12 @@ script:
   - echo "$TRAVIS_OS_NAME"
   - |
     # -j2 to limit GCC builds to a reduced number of thread for the virtual machine
-    if [ "$TRAVIS_OS_NAME" = "osx" -a `echo $CC | grep -o gcc-`="gcc-" ]; then 
+    if [ "$TRAVIS_OS_NAME" = "osx" ] && (echo $CC | grep -qo gcc-) then 
       echo 'truncating GCC output'
-      # for OSX and GCC-* we filter out linker warnings to avoid travis log size errors
+      # filter out linker warnings to avoid hitting travis log size limits
       time make all -j 2 2>&1 | grep -v -e '^/var/folders/*' -e '^[[:space:]]*\.section' -e '^[[:space:]]*\^[[:space:]]*~*' | grep --color=always -i 'warning\|error\|$'
     else
       time make all -j 2
     fi
+    
   - ctest -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,10 @@ matrix:
 
     - os: osx
       osx_image: xcode10.2
-      homebrew:
-        packages:
-        - gcc@5
+      addons:
+        homebrew:
+          packages:
+          - gcc@5
       env:
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -219,13 +219,10 @@ before_script:
       . $OPENMVG_SOURCE
 
 script:
-  - echo CC:$CC
-  - echo "$TRAVIS_OS_NAME"
   - |
     # -j2 to limit GCC builds to a reduced number of thread for the virtual machine
     if [ "$TRAVIS_OS_NAME" = "osx" ] && (echo $CC | grep -qo gcc-) then 
-      echo 'truncating GCC output'
-      # filter out linker warnings to avoid hitting travis log size limits
+      echo 'filter out linker warnings to avoid travis log size limits'
       time make all -j 2 2>&1 | grep -v -e '^/var/folders/*' -e '^[[:space:]]*\.section' -e '^[[:space:]]*\^[[:space:]]*~*' | grep --color=always -i 'warning\|error\|$'
     else
       time make all -j 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,14 @@ matrix:
     - os: osx
       osx_image: xcode10.2
 
+    - os: osx
+      osx_image: xcode10.2
+      homebrew:
+        packages:
+        - gcc@5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
     # works on Precise and Trusty
     - os: linux
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
           packages:
           - gcc@5
       env:
-        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && CXXFLAGS=-w"
 
     # works on Precise and Trusty
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,8 @@ matrix:
           packages:
           - gcc@5
       env:
-        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && CXXFLAGS=-w"
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+      allow_failures: true
 
 #    # works on Precise and Trusty
 #    - os: linux
@@ -183,7 +184,7 @@ before_script:
       -DOpenMVG_BUILD_EXAMPLES=ON \
       -DOpenMVG_BUILD_SOFTWARES=ON \
       -DSCHUR_SPECIALIZATIONS=OFF \
-      CXXFLAGS=-w \
+      -DCXXFLAGS=-w \
       . $OPENMVG_SOURCE
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,16 +163,6 @@ matrix:
           
   allow_failures:
     - os: osx
-      osx_image: xcode10.2
-      addons:
-        homebrew:
-          packages:
-          - gcc@5
-      env:
-        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-      
-          
-    - os: osx
       osx_image: xcode11
       addons:
         homebrew:

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,6 +160,7 @@ matrix:
             - clang-5.0
       env:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+          
   allow_failures:
     - os: osx
       osx_image: xcode10.2
@@ -169,6 +170,7 @@ matrix:
           - gcc@5
       env:
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+      
           
     - os: osx
       osx_image: xcode11
@@ -222,6 +224,12 @@ before_script:
       . $OPENMVG_SOURCE
 
 script:
-# limit GCC builds to a reduced number of thread for the virtual machine
-  - time make all -j 2
+  - |
+    # -j2 to limit GCC builds to a reduced number of thread for the virtual machine
+    if [ "$TRAVIS_OS_NAME" = "osx" -a `echo $CC | grep -o gcc-`="gcc-" ]; then 
+      # for OSX and GCC-* we filter out linker warnings to avoid travis log size errors
+      time make all -j 2 2>&1 | grep -v -e '^/var/folders/*' -e '^[[:space:]]*\.section' -e '^[[:space:]]*\^[[:space:]]*~*'; 
+    else
+      time make all -j 2
+    fi
   - ctest -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,63 +9,63 @@ language: cpp
 
 matrix:
   include:
-  #    - os: linux
-  #      addons:
-  #        apt:
-  #          sources:
-  #            - ubuntu-toolchain-r-test
-  #            - ubuntu-sdk-team/ppa
-  #          packages:
-  #            - g++-4.8
-  #            - qtbase5-dev
-  #            - libqt5svg5-dev
-  #            - libqt5opengl5-dev
-  #      env:
-  #        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
-  #    # works on Precise and Trusty
-  #    - os: linux
-  #      addons:
-  #        apt:
-  #          sources:
-  #            - ubuntu-toolchain-r-test
-  #          packages:
-  #            - g++-5
-  #      env:
-  #         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-  #
-  #    # works on Precise and Trusty
-  #    - os: linux
-  #      addons:
-  #        apt:
-  #          sources:
-  #            - ubuntu-toolchain-r-test
-  #          packages:
-  #            - g++-6
-  #      env:
-  #        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
-  #
-  #    # works on Precise and Trusty
-  #    - os: linux
-  #      addons:
-  #        apt:
-  #          sources:
-  #            - ubuntu-toolchain-r-test
-  #          packages:
-  #            - g++-7
-  #      env:
-  #        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-  #
-  #    # works on macOS 10.13
-  #    - os: osx
-  #      osx_image: xcode9.4
-  #    
-  #    # works on macOS 10.14
-  #    - os: osx
-  #      osx_image: xcode10.2
-  #       
-     - os: osx
-       osx_image: xcode11
- 
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - ubuntu-sdk-team/ppa
+          packages:
+            - g++-4.8
+            - qtbase5-dev
+            - libqt5svg5-dev
+            - libqt5opengl5-dev
+      env:
+        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    # works on macOS 10.13
+    - os: osx
+      osx_image: xcode9.4
+    
+    # works on macOS 10.14
+    - os: osx
+      osx_image: xcode10.2
+       
+    - os: osx
+      osx_image: xcode11
+
     # allowed to fail: an exact topy is below in allow_failures
     # watching for Apple updates.
     # there are problems with GCC including new but nonstandard Apple .h
@@ -91,64 +91,64 @@ matrix:
           - gcc@5
       env:
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-  #
-  #    # works on Precise and Trusty
-  #    - os: linux
-  #      addons:
-  #        apt:
-  #          sources:
-  #            - ubuntu-toolchain-r-test
-  #            - llvm-toolchain-precise-3.6
-  #          packages:
-  #            - clang-3.6
-  #      env:
-  #        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
-  #
-  #    # works on Precise and Trusty
-  #    - os: linux
-  #      addons:
-  #        apt:
-  #          sources:
-  #            - ubuntu-toolchain-r-test
-  #            - llvm-toolchain-precise-3.7
-  #          packages:
-  #            - clang-3.7
-  #      env:
-  #        - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
-  #
-  #    # works on Precise and Trusty
-  #    - os: linux
-  #      addons:
-  #        apt:
-  #          sources:
-  #            - ubuntu-toolchain-r-test
-  #            - llvm-toolchain-precise-3.8
-  #          packages:
-  #            - clang-3.8
-  #      env:
-  #        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
-  #
-  #    # works on Trusty
-  #    - os: linux
-  #      addons:
-  #        apt:
-  #          sources:
-  #            - llvm-toolchain-trusty-3.9
-  #          packages:
-  #            - clang-3.9
-  #      env:
-  #        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
-  #
-  #    # works on Trusty
-  #    - os: linux
-  #      addons:
-  #        apt:
-  #          sources:
-  #            - llvm-toolchain-trusty-4.0
-  #          packages:
-  #            - clang-4.0
-  #      env:
-  #        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+      env:
+        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
+
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+      env:
+        - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
+
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+          packages:
+            - clang-3.8
+      env:
+        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+
+    # works on Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-3.9
+          packages:
+            - clang-3.9
+      env:
+        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+
+    # works on Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
 
     # works on Trusty
     - os: linux
@@ -162,6 +162,16 @@ matrix:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
           
   allow_failures:
+    - os: osx
+      osx_image: xcode10.2
+      addons:
+        homebrew:
+          packages:
+          - gcc@5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+      
+          
     - os: osx
       osx_image: xcode11
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,63 +9,67 @@ language: cpp
 
 matrix:
   include:
-#    - os: linux
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#            - ubuntu-sdk-team/ppa
-#          packages:
-#            - g++-4.8
-#            - qtbase5-dev
-#            - libqt5svg5-dev
-#            - libqt5opengl5-dev
-#      env:
-#        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
-#    # works on Precise and Trusty
-#    - os: linux
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#          packages:
-#            - g++-5
-#      env:
-#         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-#
-#    # works on Precise and Trusty
-#    - os: linux
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#          packages:
-#            - g++-6
-#      env:
-#        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
-#
-#    # works on Precise and Trusty
-#    - os: linux
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#          packages:
-#            - g++-7
-#      env:
-#        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - ubuntu-sdk-team/ppa
+          packages:
+            - g++-4.8
+            - qtbase5-dev
+            - libqt5svg5-dev
+            - libqt5opengl5-dev
+      env:
+        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
 
-#    # works on macOS 10.13
-#    - os: osx
-#      osx_image: xcode9.4
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    # works on macOS 10.13
+    - os: osx
+      osx_image: xcode9.4
     
     # works on macOS 10.14
     - os: osx
       osx_image: xcode10.2
-#       
-#     - os: osx
-#       osx_image: xcode11
+       
+    - os: osx
+      osx_image: xcode11
 
+    # allowed to fail: an exact topy is below in allow_failures
+    # watching for Apple updates.
+    # there are problems with GCC including new but nonstandard Apple .h
+    # https://github.com/Homebrew/homebrew-core/issues/40676
     - os: osx
       osx_image: xcode10.2
       addons:
@@ -74,77 +78,107 @@ matrix:
           - gcc@5
       env:
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-      allow_failures: true
+          
+    # allowed to fail: an exact topy is below in allow_failures
+    # watching for Apple updates.
+    # there are problems with GCC including new but nonstandard Apple .h
+    # https://github.com/Homebrew/homebrew-core/issues/40676
+    - os: osx
+      osx_image: xcode11
+      addons:
+        homebrew:
+          packages:
+          - gcc@5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
 
-#    # works on Precise and Trusty
-#    - os: linux
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#            - llvm-toolchain-precise-3.6
-#          packages:
-#            - clang-3.6
-#      env:
-#        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
-#
-#    # works on Precise and Trusty
-#    - os: linux
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#            - llvm-toolchain-precise-3.7
-#          packages:
-#            - clang-3.7
-#      env:
-#        - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
-#
-#    # works on Precise and Trusty
-#    - os: linux
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#            - llvm-toolchain-precise-3.8
-#          packages:
-#            - clang-3.8
-#      env:
-#        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
-#
-#    # works on Trusty
-#    - os: linux
-#      addons:
-#        apt:
-#          sources:
-#            - llvm-toolchain-trusty-3.9
-#          packages:
-#            - clang-3.9
-#      env:
-#        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
-#
-#    # works on Trusty
-#    - os: linux
-#      addons:
-#        apt:
-#          sources:
-#            - llvm-toolchain-trusty-4.0
-#          packages:
-#            - clang-4.0
-#      env:
-#        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
-#
-#    # works on Trusty
-#    - os: linux
-#      addons:
-#        apt:
-#          sources:
-#            - llvm-toolchain-trusty-5.0
-#          packages:
-#            - clang-5.0
-#      env:
-#        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+      env:
+        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
 
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+      env:
+        - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
+
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+          packages:
+            - clang-3.8
+      env:
+        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+
+    # works on Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-3.9
+          packages:
+            - clang-3.9
+      env:
+        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+
+    # works on Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+
+    # works on Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+  allow_failures:
+    - os: osx
+      osx_image: xcode10.2
+      addons:
+        homebrew:
+          packages:
+          - gcc@5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+          
+    - os: osx
+      osx_image: xcode11
+      addons:
+        homebrew:
+          packages:
+          - gcc@5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+  
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,62 +9,62 @@ language: cpp
 
 matrix:
   include:
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - ubuntu-sdk-team/ppa
-          packages:
-            - g++-4.8
-            - qtbase5-dev
-            - libqt5svg5-dev
-            - libqt5opengl5-dev
-      env:
-        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+#    - os: linux
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#            - ubuntu-sdk-team/ppa
+#          packages:
+#            - g++-4.8
+#            - qtbase5-dev
+#            - libqt5svg5-dev
+#            - libqt5opengl5-dev
+#      env:
+#        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
+#    # works on Precise and Trusty
+#    - os: linux
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#          packages:
+#            - g++-5
+#      env:
+#         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+#
+#    # works on Precise and Trusty
+#    - os: linux
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#          packages:
+#            - g++-6
+#      env:
+#        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+#
+#    # works on Precise and Trusty
+#    - os: linux
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#          packages:
+#            - g++-7
+#      env:
+#        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      env:
-        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-
-    # works on macOS 10.13
-    - os: osx
-      osx_image: xcode9.4
+#    # works on macOS 10.13
+#    - os: osx
+#      osx_image: xcode9.4
     
     # works on macOS 10.14
     - os: osx
       osx_image: xcode10.2
-      
-    - os: osx
-      osx_image: xcode11
+#       
+#     - os: osx
+#       osx_image: xcode11
 
     - os: osx
       osx_image: xcode10.2
@@ -75,74 +75,74 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && CXXFLAGS=-w"
 
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
-          packages:
-            - clang-3.6
-      env:
-        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - clang-3.7
-      env:
-        - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
-          packages:
-            - clang-3.8
-      env:
-        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
-
-    # works on Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-3.9
-          packages:
-            - clang-3.9
-      env:
-        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
-
-    # works on Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-4.0
-          packages:
-            - clang-4.0
-      env:
-        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
-
-    # works on Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
-      env:
-        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+#    # works on Precise and Trusty
+#    - os: linux
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#            - llvm-toolchain-precise-3.6
+#          packages:
+#            - clang-3.6
+#      env:
+#        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
+#
+#    # works on Precise and Trusty
+#    - os: linux
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#            - llvm-toolchain-precise-3.7
+#          packages:
+#            - clang-3.7
+#      env:
+#        - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
+#
+#    # works on Precise and Trusty
+#    - os: linux
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#            - llvm-toolchain-precise-3.8
+#          packages:
+#            - clang-3.8
+#      env:
+#        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+#
+#    # works on Trusty
+#    - os: linux
+#      addons:
+#        apt:
+#          sources:
+#            - llvm-toolchain-trusty-3.9
+#          packages:
+#            - clang-3.9
+#      env:
+#        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+#
+#    # works on Trusty
+#    - os: linux
+#      addons:
+#        apt:
+#          sources:
+#            - llvm-toolchain-trusty-4.0
+#          packages:
+#            - clang-4.0
+#      env:
+#        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+#
+#    # works on Trusty
+#    - os: linux
+#      addons:
+#        apt:
+#          sources:
+#            - llvm-toolchain-trusty-5.0
+#          packages:
+#            - clang-5.0
+#      env:
+#        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
 
 addons:
   apt:
@@ -183,6 +183,7 @@ before_script:
       -DOpenMVG_BUILD_EXAMPLES=ON \
       -DOpenMVG_BUILD_SOFTWARES=ON \
       -DSCHUR_SPECIALIZATIONS=OFF \
+      CXXFLAGS=-w \
       . $OPENMVG_SOURCE
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -224,9 +224,12 @@ before_script:
       . $OPENMVG_SOURCE
 
 script:
+  - echo CC:$CC
+  - echo "$TRAVIS_OS_NAME"
   - |
     # -j2 to limit GCC builds to a reduced number of thread for the virtual machine
     if [ "$TRAVIS_OS_NAME" = "osx" -a `echo $CC | grep -o gcc-`="gcc-" ]; then 
+      echo 'truncating GCC output'
       # for OSX and GCC-* we filter out linker warnings to avoid travis log size errors
       time make all -j 2 2>&1 | grep -v -e '^/var/folders/*' -e '^[[:space:]]*\.section' -e '^[[:space:]]*\^[[:space:]]*~*'; 
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,9 @@ matrix:
     # works on macOS 10.14
     - os: osx
       osx_image: xcode10.2
+      
+    - os: osx
+      osx_image: xcode11
 
     - os: osx
       osx_image: xcode10.2

--- a/src/software/SfM/export/InterfaceMVS.h
+++ b/src/software/SfM/export/InterfaceMVS.h
@@ -219,9 +219,7 @@ ARCHIVE_DEFINE_TYPE(uint64_t)
 ARCHIVE_DEFINE_TYPE(float)
 ARCHIVE_DEFINE_TYPE(double)
 #ifdef __APPLE__
-  #ifdef __clang__
-    ARCHIVE_DEFINE_TYPE(unsigned long)
-  #endif
+  ARCHIVE_DEFINE_TYPE(unsigned long)
 #endif
 
 // Serialization support for cv::Matx


### PR DESCRIPTION
There was a compile error with GCC 5 under Mac, due to a lacking
explicit instantiation for size_t.
This commit proposes a fix to #1580. GCC + Mac is not on Travis.