### PR TITLE
Small typo in documentation

### DIFF
--- a/docs/sphinx/rst/openMVG/multiview/multiview.rst
+++ b/docs/sphinx/rst/openMVG/multiview/multiview.rst
@@ -84,7 +84,7 @@ The relation :math:`x'^T_i Fx_i = 0` exists for all corresponding point belongin
    The fundamental matrix and the point to line constraint.
 
 The fundamental matrix is sometime called bifocal-tensor, it is a 3 x 3 matrix of rank 2
-with 7 degree of freedom. 8 ou 7 correspondences are sufficient to compute the :math:`F` matrix.
+with 7 degree of freedom. 8 or 7 non-coplanar correspondences are sufficient to compute the :math:`F` matrix.
 Implementation follows the DLT (Direct Linear Transform) explained in [HZ]_ book.
 
 Relative pose estimation (Essential matrix)


### PR DESCRIPTION
There was a tiny typo: ou -> or
I also added the world non-coplanar since correspondences are likely and expected to be not on the same plane, otherwise it creates degeneracy which makes it impossible to correctly calculate F matrix.
Minimum number correspondences required is 7. But since it was already 8 ou 7 , i just changed it to 8 or 7.