### PR TITLE
[continuous integration] added support for gcc 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,16 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+      env:
+        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
+
     # works on macOS 10.13
     - os: osx
       osx_image: xcode9.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
     # works on Precise and Trusty
+
     - os: linux
       addons:
         apt:
@@ -54,6 +55,16 @@ matrix:
             - g++-7
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
     - os: linux
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+<<<<<<< HEAD
             - g++-8
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
@@ -72,6 +73,8 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+=======
+>>>>>>> 57c40a9c34625572df21f4380be0ad8e895cf62f
             - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ matrix:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
     # works on Precise and Trusty
-
     - os: linux
       addons:
         apt:


### PR DESCRIPTION
Needed for any Ubuntu that have gcc 8 compiler as native (e.g. Ubuntu 19.04)
