### PR TITLE
Parameters update rule in BA

### DIFF
--- a/src/openMVG/sfm/sfm_data_BA_ceres.cpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.cpp
@@ -515,7 +515,22 @@ bool Bundle_Adjustment_Ceres::Adjust
         Vec3 t_refined(map_poses.at(indexPose)[3], map_poses.at(indexPose)[4], map_poses.at(indexPose)[5]);
         // Update the pose
         Pose3 & pose = pose_it.second;
-        pose = Pose3(R_refined, -R_refined.transpose() * t_refined);
+        if (options.extrinsics_opt == Extrinsic_Parameter_Type::ADJUST_ROTATION)
+        {
+            // Update only rotation
+            pose.rotation() = R_refined;
+        }
+        else if (options.extrinsics_opt == Extrinsic_Parameter_Type::ADJUST_TRANSLATION)
+        {
+            // Update only translation
+            Vec3 C_refined = -R_refined.transpose() * t_refined;
+            pose.center() = C_refined;
+        }
+        else
+        {
+            // Update rotation + translation
+            pose = Pose3(R_refined, -R_refined.transpose() * t_refined);
+        }
       }
     }
 


### PR DESCRIPTION
Hi @pmoulon 
Please check this pull request.
I did some test on the ImageDataset_SceauxCastle, by running BA with 3 different mode (rotation only, translation only, translation rotation) after first reconstruction by Global_SfM. Everything same to well working. 
Check image below for the comparision of delta_X/Y/Z (translation) and delta_O/P/K (rotation) when using 3 different BA mode. Seem to be correct behavior for me. 
Let me know if there is problem. 

![TestOpenMVG_BA_case](https://user-images.githubusercontent.com/18443054/76201483-a025cb00-61f3-11ea-988c-4e182ca8b030.png)
 
