### PR TITLE
(filters_frustum) Add colors to exported ply

### DIFF
--- a/src/openMVG/image/pixel_types.hpp
+++ b/src/openMVG/image/pixel_types.hpp
@@ -378,6 +378,7 @@ std::ostream& operator<<( std::ostream& os, const Rgba<T>& col )
 using RGBAColor = Rgba<unsigned char>;
 
 const RGBColor WHITE( 255, 255, 255 );
+const RGBColor GRAY( 127, 127, 127);
 const RGBColor BLACK( 0, 0, 0 );
 const RGBColor BLUE( 0, 0, 255 );
 const RGBColor RED( 255, 0, 0 );

--- a/src/openMVG/sfm/sfm_data_filters_frustum.cpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.cpp
@@ -10,6 +10,7 @@
 
 #include "openMVG/cameras/Camera_Pinhole.hpp"
 #include "openMVG/geometry/pose3.hpp"
+#include "openMVG/image/pixel_types.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/stl/stl.hpp"
 
@@ -19,19 +20,14 @@
 #include <iomanip>
 #include <iterator>
 
-static const std::string COLOR_BOTTOM = "107 118 178";
-static const std::string COLOR_LEFT = "112 178 107";
-static const std::string COLOR_TOP = "178 107 124";
-static const std::string COLOR_RIGHT = "178 175 107";
-static const std::string COLOR_FAR = "164 107 178";
-static const std::string COLOR_NEAR = "223 196 230";
-
 namespace openMVG {
 namespace sfm {
 
 using namespace openMVG::cameras;
 using namespace openMVG::geometry;
 using namespace openMVG::geometry::halfPlane;
+
+std::string RgbPLYString(const image::RGBColor& color);
 
 // Constructor
 Frustum_Filter::Frustum_Filter
@@ -191,26 +187,28 @@ const
 
   // Export frustums faces
   IndexT count = 0;
+  std::string color_top_face{RgbPLYString(image::RED)};
+  std::string color_other_face{RgbPLYString(image::GRAY)};
   for (FrustumsT::const_iterator it = frustum_perView.begin();
     it != frustum_perView.end(); ++it)
   {
     if (it->second.isInfinite()) // infinite frustum: drawn normalized cone: 4 faces
     {
-      of << "3 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << COLOR_BOTTOM << '\n'
-        << "3 " << count + 0 << ' ' << count + 2 << ' ' << count + 3 << ' ' << COLOR_LEFT << '\n'
-        << "3 " << count + 0 << ' ' << count + 3 << ' ' << count + 4 << ' ' << COLOR_TOP << '\n'
-        << "3 " << count + 0 << ' ' << count + 4 << ' ' << count + 1 << ' ' << COLOR_RIGHT << '\n'
-        << "4 " << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << count + 4 << ' ' << COLOR_FAR << '\n';
+      of << "3 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << color_other_face << '\n'
+        << "3 " << count + 0 << ' ' << count + 2 << ' ' << count + 3 << ' ' << color_other_face << '\n'
+        << "3 " << count + 0 << ' ' << count + 3 << ' ' << count + 4 << ' ' << color_top_face << '\n'
+        << "3 " << count + 0 << ' ' << count + 4 << ' ' << count + 1 << ' ' << color_other_face << '\n'
+        << "4 " << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << count + 4 << ' ' << color_other_face << '\n';
       count += 5;
     }
     else // truncated frustum: 6 faces
     {
-      of << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << COLOR_BOTTOM << '\n'
-        << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 5 << ' ' << count + 4 << ' ' << COLOR_LEFT << '\n'
-        << "4 " << count + 1 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 2 << ' ' << COLOR_TOP << '\n'
-        << "4 " << count + 3 << ' ' << count + 7 << ' ' << count + 6 << ' ' << count + 2 << ' ' << COLOR_RIGHT << '\n'
-        << "4 " << count + 0 << ' ' << count + 4 << ' ' << count + 7 << ' ' << count + 3 << ' ' << COLOR_NEAR << '\n'
-        << "4 " << count + 4 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 7 << ' ' << COLOR_FAR << '\n';
+      of << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << color_other_face << '\n'
+        << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 5 << ' ' << count + 4 << ' ' << color_other_face << '\n'
+        << "4 " << count + 1 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 2 << ' ' << color_top_face << '\n'
+        << "4 " << count + 3 << ' ' << count + 7 << ' ' << count + 6 << ' ' << count + 2 << ' ' << color_other_face << '\n'
+        << "4 " << count + 0 << ' ' << count + 4 << ' ' << count + 7 << ' ' << count + 3 << ' ' << color_other_face << '\n'
+        << "4 " << count + 4 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 7 << ' ' << color_other_face << '\n';
       count += 8;
     }
   }
@@ -274,6 +272,11 @@ void Frustum_Filter::init_z_near_z_far_depth
         z_near_z_far_perView[view->id_view] = {zNear, zFar};
     }
   }
+}
+
+std::string RgbPLYString(const image::RGBColor& color)
+{
+  return std::to_string(color.r()) + ' ' + std::to_string(color.g()) + ' ' + std::to_string(color.b());
 }
 
 } // namespace sfm

--- a/src/openMVG/sfm/sfm_data_filters_frustum.cpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.cpp
@@ -19,6 +19,13 @@
 #include <iomanip>
 #include <iterator>
 
+static const std::string COLOR_BOTTOM = "107 118 178";
+static const std::string COLOR_LEFT = "112 178 107";
+static const std::string COLOR_TOP = "178 107 124";
+static const std::string COLOR_RIGHT = "178 175 107";
+static const std::string COLOR_FAR = "164 107 178";
+static const std::string COLOR_NEAR = "223 196 230";
+
 namespace openMVG {
 namespace sfm {
 
@@ -168,6 +175,9 @@ const
     << "property double z" << '\n'
     << "element face " << face_count << '\n'
     << "property list uchar int vertex_index" << '\n'
+    << "property uchar red" << "\n"
+    << "property uchar green" << "\n"
+    << "property uchar blue" << "\n"
     << "end_header" << '\n';
 
   // Export frustums points
@@ -186,21 +196,21 @@ const
   {
     if (it->second.isInfinite()) // infinite frustum: drawn normalized cone: 4 faces
     {
-      of << "3 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << '\n'
-        << "3 " << count + 0 << ' ' << count + 2 << ' ' << count + 3 << '\n'
-        << "3 " << count + 0 << ' ' << count + 3 << ' ' << count + 4 << '\n'
-        << "3 " << count + 0 << ' ' << count + 4 << ' ' << count + 1 << '\n'
-        << "4 " << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << count + 4 << '\n';
+      of << "3 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << COLOR_BOTTOM << '\n'
+        << "3 " << count + 0 << ' ' << count + 2 << ' ' << count + 3 << ' ' << COLOR_LEFT << '\n'
+        << "3 " << count + 0 << ' ' << count + 3 << ' ' << count + 4 << ' ' << COLOR_TOP << '\n'
+        << "3 " << count + 0 << ' ' << count + 4 << ' ' << count + 1 << ' ' << COLOR_RIGHT << '\n'
+        << "4 " << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << count + 4 << ' ' << COLOR_FAR << '\n';
       count += 5;
     }
     else // truncated frustum: 6 faces
     {
-      of << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << count + 3 << '\n'
-        << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 5 << ' ' << count + 4 << '\n'
-        << "4 " << count + 1 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 2 << '\n'
-        << "4 " << count + 3 << ' ' << count + 7 << ' ' << count + 6 << ' ' << count + 2 << '\n'
-        << "4 " << count + 0 << ' ' << count + 4 << ' ' << count + 7 << ' ' << count + 3 << '\n'
-        << "4 " << count + 4 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 7 << '\n';
+      of << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << COLOR_BOTTOM << '\n'
+        << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 5 << ' ' << count + 4 << ' ' << COLOR_LEFT << '\n'
+        << "4 " << count + 1 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 2 << ' ' << COLOR_TOP << '\n'
+        << "4 " << count + 3 << ' ' << count + 7 << ' ' << count + 6 << ' ' << count + 2 << ' ' << COLOR_RIGHT << '\n'
+        << "4 " << count + 0 << ' ' << count + 4 << ' ' << count + 7 << ' ' << count + 3 << ' ' << COLOR_NEAR << '\n'
+        << "4 " << count + 4 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 7 << ' ' << COLOR_FAR << '\n';
       count += 8;
     }
   }

--- a/src/openMVG/sfm/sfm_data_filters_frustum.cpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.cpp
@@ -135,7 +135,8 @@ const
 // Export defined frustum in PLY file for viewing
 bool Frustum_Filter::export_Ply
 (
-  const std::string & filename
+  const std::string & filename,
+  bool colorize
 )
 const
 {
@@ -170,11 +171,15 @@ const
     << "property double y" << '\n'
     << "property double z" << '\n'
     << "element face " << face_count << '\n'
-    << "property list uchar int vertex_index" << '\n'
-    << "property uchar red" << "\n"
+    << "property list uchar int vertex_index" << '\n';
+
+  if (colorize) {
+    of << "property uchar red" << "\n"
     << "property uchar green" << "\n"
-    << "property uchar blue" << "\n"
-    << "end_header" << '\n';
+    << "property uchar blue" << "\n";
+  }
+
+  of << "end_header" << '\n';
 
   // Export frustums points
   for (FrustumsT::const_iterator it = frustum_perView.begin();
@@ -187,28 +192,28 @@ const
 
   // Export frustums faces
   IndexT count = 0;
-  std::string color_top_face{RgbPLYString(image::RED)};
-  std::string color_other_face{RgbPLYString(image::GRAY)};
+  std::string color_top_face = colorize ? RgbPLYString(image::RED) : "";
+  std::string color_other_face = colorize ? RgbPLYString(image::GRAY) : "";
   for (FrustumsT::const_iterator it = frustum_perView.begin();
     it != frustum_perView.end(); ++it)
   {
     if (it->second.isInfinite()) // infinite frustum: drawn normalized cone: 4 faces
     {
-      of << "3 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << color_other_face << '\n'
-        << "3 " << count + 0 << ' ' << count + 2 << ' ' << count + 3 << ' ' << color_other_face << '\n'
-        << "3 " << count + 0 << ' ' << count + 3 << ' ' << count + 4 << ' ' << color_top_face << '\n'
-        << "3 " << count + 0 << ' ' << count + 4 << ' ' << count + 1 << ' ' << color_other_face << '\n'
-        << "4 " << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << count + 4 << ' ' << color_other_face << '\n';
+      of << "3 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << color_other_face << '\n'
+        << "3 " << count + 0 << ' ' << count + 2 << ' ' << count + 3 << color_other_face << '\n'
+        << "3 " << count + 0 << ' ' << count + 3 << ' ' << count + 4 << color_top_face << '\n'
+        << "3 " << count + 0 << ' ' << count + 4 << ' ' << count + 1 << color_other_face << '\n'
+        << "4 " << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << count + 4 << color_other_face << '\n';
       count += 5;
     }
     else // truncated frustum: 6 faces
     {
-      of << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << color_other_face << '\n'
-        << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 5 << ' ' << count + 4 << ' ' << color_other_face << '\n'
-        << "4 " << count + 1 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 2 << ' ' << color_top_face << '\n'
-        << "4 " << count + 3 << ' ' << count + 7 << ' ' << count + 6 << ' ' << count + 2 << ' ' << color_other_face << '\n'
-        << "4 " << count + 0 << ' ' << count + 4 << ' ' << count + 7 << ' ' << count + 3 << ' ' << color_other_face << '\n'
-        << "4 " << count + 4 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 7 << ' ' << color_other_face << '\n';
+      of << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << count + 3 << color_other_face << '\n'
+        << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 5 << ' ' << count + 4 << color_other_face << '\n'
+        << "4 " << count + 1 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 2 << color_top_face << '\n'
+        << "4 " << count + 3 << ' ' << count + 7 << ' ' << count + 6 << ' ' << count + 2 << color_other_face << '\n'
+        << "4 " << count + 0 << ' ' << count + 4 << ' ' << count + 7 << ' ' << count + 3 << color_other_face << '\n'
+        << "4 " << count + 4 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 7 << color_other_face << '\n';
       count += 8;
     }
   }
@@ -276,7 +281,7 @@ void Frustum_Filter::init_z_near_z_far_depth
 
 std::string RgbPLYString(const image::RGBColor& color)
 {
-  return std::to_string(color.r()) + ' ' + std::to_string(color.g()) + ' ' + std::to_string(color.b());
+  return ' ' + std::to_string(color.r()) + ' ' + std::to_string(color.g()) + ' ' + std::to_string(color.b());
 }
 
 } // namespace sfm

--- a/src/openMVG/sfm/sfm_data_filters_frustum.hpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.hpp
@@ -50,7 +50,7 @@ public:
   ) const;
 
   // Export defined frustum in PLY file for viewing
-  bool export_Ply(const std::string & filename) const;
+  bool export_Ply(const std::string & filename, bool colorize = false) const;
 
 private:
 

--- a/src/software/SfM/export/main_ExportCameraFrustums.cpp
+++ b/src/software/SfM/export/main_ExportCameraFrustums.cpp
@@ -34,6 +34,7 @@ int main(int argc, char **argv)
 
   cmd.add( make_option('i', sSfM_Data_Filename, "input_file") );
   cmd.add( make_option('o', sOutFile, "output_file") );
+  cmd.add( make_switch('c', "colorize") );
 
   try {
     if (argc == 1) throw std::string("Invalid command line parameter.");
@@ -42,6 +43,7 @@ int main(int argc, char **argv)
     std::cerr << "Usage: " << argv[0] << '\n'
     << "[-i|--input_file] path to a SfM_Data scene\n"
     << "[-o|--output_file] PLY file to store the camera frustums as triangle meshes.\n"
+    << "[-c|--colorize] Colorize the camera frustums.\n"
     << std::endl;
 
     std::cerr << s << std::endl;
@@ -61,11 +63,14 @@ int main(int argc, char **argv)
     if (!stlplus::folder_create( stlplus::folder_part(sOutFile) ))
       return EXIT_FAILURE;
 
+  // Detect if colorization is requested
+  const bool colorize = cmd.used('c');
+
   // If sfm_data have not structure, cameras are displayed as tiny normalized cones
   const Frustum_Filter frustum_filter(sfm_data);
   if (!sOutFile.empty())
   {
-    if (frustum_filter.export_Ply(sOutFile))
+    if (frustum_filter.export_Ply(sOutFile, colorize))
       return EXIT_SUCCESS;
   }
   return EXIT_FAILURE;


### PR DESCRIPTION
This colors the faces of the frustums exported by `ExportCameraFrustums`. This is meant to be an aid to help with orientating poses visually. 

This PR is currently just basic implementation in order to begin discussing details.

Questions/Thoughts:

1.  Should colors be optional?
2. Is there a better/preferred way to define color constants? I haven't really looked into the other colorization features in openMVG yet. Is `image::RGBColor` a good const class? Does it have an `ostream` operator?
3. I used colors generated by MeshLab. Do we want to tweak these?
4. What will it take to [add axis lines](https://github.com/openMVG/openMVG/issues/1700#issuecomment-602950501)? By this, I think you mean the camera's axes of rotation, centered on the pinhole.