### PR TITLE
fix: #1555 Export to openMVS does not support grayscale images

### DIFF
--- a/src/software/SfM/export/main_openMVG2openMVS.cpp
+++ b/src/software/SfM/export/main_openMVG2openMVS.cpp
@@ -157,12 +157,20 @@ bool exportToOpenMVS(
       {
         // undistort image and save it
         Image<openMVG::image::RGBColor> imageRGB, imageRGB_ud;
+        Image<uint8_t> image_gray, image_gray_ud;
         try
         {
           if (ReadImage(srcImage.c_str(), &imageRGB))
           {
             UndistortImage(imageRGB, cam, imageRGB_ud, BLACK);
             bOk = WriteImage(imageName.c_str(), imageRGB_ud);
+          }
+          else // If RGBColor reading fails, try to read as gray image
+          if (ReadImage(srcImage.c_str(), &image_gray))
+          {
+            UndistortImage(image_gray, cam, image_gray_ud, BLACK);
+            const bool bRes = WriteImage(imageName.c_str(), image_gray_ud);
+            bOk = bOk & bRes;
           }
           else
           {


### PR DESCRIPTION
Add some code for reading the grayscale with the openMVG Image Class.