### PR TITLE
[SfM/export] Fix bug when exporting sfm_data with unknown intrinsics …

### DIFF
--- a/src/software/SfM/export/main_openMVG2openMVS.cpp
+++ b/src/software/SfM/export/main_openMVG2openMVS.cpp
@@ -86,20 +86,25 @@ bool exportToOpenMVS(
   scene.images.reserve(nViews);
   for (const auto& view : sfm_data.GetViews())
   {
-    map_view[view.first] = scene.images.size();
-    MVS::Interface::Image image;
+    ++my_progress_bar;
+
     const std::string srcImage = stlplus::create_filespec(sfm_data.s_root_path, view.second->s_Img_path);
-    image.name = stlplus::create_filespec(sOutDir, view.second->s_Img_path);
-    image.platformID = map_intrinsic.at(view.second->id_intrinsic);
-    MVS::Interface::Platform& platform = scene.platforms[image.platformID];
-    image.cameraID = 0;
     if (!stlplus::is_file(srcImage))
     {
-      std::cout << "Cannot read the corresponding image: " << srcImage << std::endl;
-      return EXIT_FAILURE;
+      std::cerr << "Cannot read the corresponding image: " << srcImage << std::endl;
+      return false;
     }
-    if (sfm_data.IsPoseAndIntrinsicDefined(view.second.get()))
+
+    if (sfm_data.IsPoseAndIntrinsicDefined(view.second.get())) 
     {
+      map_view[view.first] = scene.images.size();
+
+      MVS::Interface::Image image;
+      image.name = stlplus::create_filespec(sOutDir, view.second->s_Img_path);
+      image.platformID = map_intrinsic.at(view.second->id_intrinsic);
+      MVS::Interface::Platform& platform = scene.platforms[image.platformID];
+      image.cameraID = 0;
+
       MVS::Interface::Platform::Pose pose;
       image.poseID = platform.poses.size();
       const openMVG::geometry::Pose3 poseMVG(sfm_data.GetPoseOrDie(view.second.get()));
@@ -107,16 +112,13 @@ bool exportToOpenMVS(
       pose.C = poseMVG.center();
       platform.poses.push_back(pose);
       ++nPoses;
+
+      scene.images.emplace_back(image);
     }
     else
     {
-      // image have not valid pose, so set an undefined pose
-      image.poseID = NO_ID;
-      // just copy the image
-      //stlplus::file_copy(srcImage, image.name);
+      std::cout << "Cannot read the corresponding pose or intrinsic of view " << view.first << std::endl;
     }
-    scene.images.emplace_back(image);
-    ++my_progress_bar;
   }
 
   // Export undistorted images
@@ -143,12 +145,6 @@ bool exportToOpenMVS(
     const std::string srcImage = stlplus::create_filespec(sfm_data.s_root_path, view->s_Img_path);
     const std::string imageName = stlplus::create_filespec(sOutDir, view->s_Img_path);
 
-    if (!stlplus::is_file(srcImage))
-    {
-      std::cerr << "Cannot read the corresponding image: " << srcImage << std::endl;
-      bOk = false;
-      continue;
-    }
     if (sfm_data.IsPoseAndIntrinsicDefined(view))
     {
       // export undistorted images
@@ -191,7 +187,7 @@ bool exportToOpenMVS(
   {
     std::cerr << "Catched a memory error in the image conversion."
      << " Please consider to use less threads ([-n|--numThreads])." << std::endl;
-    return EXIT_FAILURE;
+    return false;
   }
 
   // define structure


### PR DESCRIPTION
Fix bug when executing `openMVG_main_openMVG2openMVS` using a `sfm_data.json` which contains some views with unknown intrinsic parameters (i.e, `"id_intrinsic": 4294967295`). 

Tested dataset: [Photo Tourism](http://phototour.cs.washington.edu/datasets/)