### PR TITLE
[Camera] Change the way Brown and Fisheye models are serialized

### DIFF
--- a/src/openMVG/cameras/Camera_Pinhole_Brown_io.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Brown_io.hpp
@@ -17,14 +17,14 @@
 template <class Archive>
 inline void openMVG::cameras::Pinhole_Intrinsic_Brown_T2::save( Archive & ar ) const
 {
-    ar(cereal::base_class<Pinhole_Intrinsic>(this));
+    Pinhole_Intrinsic::save( ar );
     ar( cereal::make_nvp( "disto_t2", params_ ) );
 }
 
 template <class Archive>
 inline void openMVG::cameras::Pinhole_Intrinsic_Brown_T2::load( Archive & ar )
 {
-    ar(cereal::base_class<Pinhole_Intrinsic>(this));
+    Pinhole_Intrinsic::load( ar );
     ar( cereal::make_nvp( "disto_t2", params_ ) );
 }
 

--- a/src/openMVG/cameras/Camera_Pinhole_Fisheye_io.hpp
+++ b/src/openMVG/cameras/Camera_Pinhole_Fisheye_io.hpp
@@ -15,14 +15,14 @@
 template <class Archive>
 inline void openMVG::cameras::Pinhole_Intrinsic_Fisheye::save( Archive & ar ) const
 {
-    ar(cereal::base_class<Pinhole_Intrinsic>(this));
+    Pinhole_Intrinsic::save( ar );
     ar( cereal::make_nvp( "fisheye", params_ ) );
 }
 
 template <class Archive>
 inline void openMVG::cameras::Pinhole_Intrinsic_Fisheye::load( Archive & ar )
 {
-    ar(cereal::base_class<Pinhole_Intrinsic>(this));
+    Pinhole_Intrinsic::load( ar );
     ar( cereal::make_nvp( "fisheye", params_ ) );
 }
 


### PR DESCRIPTION
Currently used method add an additional "value0" field to Brown and Fisheye models that add aditional complexity to the parsing of json/xml by external process/libs.

it should be integrated into a future 2.0 release as it break compatibility