### PR TITLE
(filters_frustum) Fix top face not being colored correctly

### DIFF
--- a/src/openMVG/sfm/sfm_data_filters_frustum.cpp
+++ b/src/openMVG/sfm/sfm_data_filters_frustum.cpp
@@ -199,9 +199,9 @@ const
   {
     if (it->second.isInfinite()) // infinite frustum: drawn normalized cone: 4 faces
     {
-      of << "3 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << color_other_face << '\n'
+      of << "3 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << color_top_face << '\n'
         << "3 " << count + 0 << ' ' << count + 2 << ' ' << count + 3 << color_other_face << '\n'
-        << "3 " << count + 0 << ' ' << count + 3 << ' ' << count + 4 << color_top_face << '\n'
+        << "3 " << count + 0 << ' ' << count + 3 << ' ' << count + 4 << color_other_face << '\n'
         << "3 " << count + 0 << ' ' << count + 4 << ' ' << count + 1 << color_other_face << '\n'
         << "4 " << count + 1 << ' ' << count + 2 << ' ' << count + 3 << ' ' << count + 4 << color_other_face << '\n';
       count += 5;
@@ -209,8 +209,8 @@ const
     else // truncated frustum: 6 faces
     {
       of << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 2 << ' ' << count + 3 << color_other_face << '\n'
-        << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 5 << ' ' << count + 4 << color_other_face << '\n'
-        << "4 " << count + 1 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 2 << color_top_face << '\n'
+        << "4 " << count + 0 << ' ' << count + 1 << ' ' << count + 5 << ' ' << count + 4 << color_top_face << '\n'
+        << "4 " << count + 1 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 2 << color_other_face << '\n'
         << "4 " << count + 3 << ' ' << count + 7 << ' ' << count + 6 << ' ' << count + 2 << color_other_face << '\n'
         << "4 " << count + 0 << ' ' << count + 4 << ' ' << count + 7 << ' ' << count + 3 << color_other_face << '\n'
         << "4 " << count + 4 << ' ' << count + 5 << ' ' << count + 6 << ' ' << count + 7 << color_other_face << '\n';


### PR DESCRIPTION
This fixes a bug introduced in #1702 in the frustum PLY exporter where the wrong face was being colored as the top face. This patch correctly colors the top face of both the infinite and truncated frustums.

Using the Sceaux Castle dataset + global SfM, this is the new output of `openMVG_main_ExportCameraFrustums`:

![frustum-color-fixed-01](https://user-images.githubusercontent.com/1434526/88234559-19740680-cc47-11ea-9712-1814260adf4b.png)

And this is the same for a truncated frustum:

![frustum-color-fixed-00](https://user-images.githubusercontent.com/1434526/88234574-2133ab00-cc47-11ea-96ee-595d900997c1.png)
