### PR TITLE
Fix missing ceres libaries

### DIFF
--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -161,6 +161,7 @@ target_link_libraries(openMVG_main_ComputeStructureFromKnownPoses
     openMVG_features
     openMVG_sfm
     ${STLPLUS_LIBRARY}
+    ${CERES_LIBRARIES}
 )
 
 add_executable(openMVG_main_ComputeSfM_DataColor main_ComputeSfM_DataColor.cpp)


### PR DESCRIPTION
Had same problem as in #1529 linking target `openMVG_main_ComputeStructureFromKnownPoses` misses `ceres` in linker call.
```
[ 90%] Linking CXX executable ../../Linux-x86_64-RELEASE/openMVG_main_ComputeStructureFromKnownPoses
/usr/bin/ld: CMakeFiles/openMVG_main_ComputeStructureFromKnownPoses.dir/main_ComputeStructureFromKnownPoses.cpp.o: undefined reference to symbol '_ZN5ceres41IsSparseLinearAlgebraLibraryTypeAvailableENS_30SparseLinearAlgebraLibraryTypeE'
/usr/bin/ld: /usr/lib/libceres.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [software/SfM/CMakeFiles/openMVG_main_ComputeStructureFromKnownPoses.dir/build.make:112: Linux-x86_64-RELEASE/openMVG_main_ComputeStructureFromKnownPoses] Error 1
```
Looks like `STLPLUS_LIBRARY` requires `CERES_LIBRARIES`  when linked with shared `libceres`.