### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR for cmakeFindModules, not CMAKE_SOURCE_DIR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -566,7 +566,7 @@ endforeach()
 # Create a OpenMVGConfig.cmake file. <name>Config.cmake files are searched by
 # find_package() automatically. We configure that file so that we can put any
 # information we want in it, e.g. version numbers, include directories, etc.
-configure_file("${CMAKE_SOURCE_DIR}/cmakeFindModules/OpenMVGConfig.cmake.in"
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmakeFindModules/OpenMVGConfig.cmake.in"
                "${CMAKE_CURRENT_BINARY_DIR}/OpenMVGConfig.cmake" @ONLY)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/OpenMVGConfig.cmake"


### PR DESCRIPTION
I added openMVG in my project as a library.

CMake add_subdirectory("openMVG/src") on my project root CMakeList.txt doesn't work because "cmakeFindModules/OpenMVGConfig.cmake.in" is expected on the root (my project's CMakeList) subdir.

Can you change the expected dir to OpenMVG's CMakeList?