### PR TITLE
Fix compilation error with eigen 3.4.0

### DIFF
--- a/src/openMVG/multiview/solver_fundamental_kernel.cpp
+++ b/src/openMVG/multiview/solver_fundamental_kernel.cpp
@@ -134,7 +134,7 @@ void EightPointSolver::Solve
     MatX9 epipolar_constraint(x1.cols(), 9);
     epipolar_constraint.fill(0.0);
     EncodeEpipolarEquation(x1, x2, &epipolar_constraint);
-    Eigen::SelfAdjointEigenSolver<MatX9> solver
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, 9, 9>> solver
       (epipolar_constraint.transpose() * epipolar_constraint);
     f = solver.eigenvectors().leftCols<1>();
   }


### PR DESCRIPTION
Although I have been said that this issue is going to be eventually fixed in eigen 3.4.1, if I'm not mistaken the size of that AᵀA matrix is going to be always 9×9, so it's better being explicit.