### PR TITLE
Removed xfeatures2d and made it efficient with declaration

### DIFF
--- a/src/software/SfM/main_ComputeFeatures_OpenCV.cpp
+++ b/src/software/SfM/main_ComputeFeatures_OpenCV.cpp
@@ -23,7 +23,7 @@
 #include <opencv2/opencv.hpp>
 #include "opencv2/core/eigen.hpp"
 #ifdef USE_OCVSIFT
-#include "opencv2/xfeatures2d.hpp"
+#include "opencv2/features2d.hpp"
 #endif
 
 #include <cstdlib>
@@ -159,8 +159,13 @@ class SIFT_OPENCV_Image_describer : public Image_describer
 {
 public:
   using Regions_type = SIFT_Regions;
+  // Declare a SIFT detector
+  cv::Ptr<cv::Feature2D> siftdetector;
 
-  SIFT_OPENCV_Image_describer() : Image_describer() {}
+  SIFT_OPENCV_Image_describer() : Image_describer() {
+    // Create a SIFT detector
+    siftdetector = cv::SIFT::create();
+  }
 
   ~SIFT_OPENCV_Image_describer() {}
 
@@ -205,10 +210,9 @@ public:
       cv::eigen2cv(mask->GetMat(), m_mask);
     }
 
-    // Create a SIFT detector
+    // Create a Keypoints & Descriptors container
     std::vector< cv::KeyPoint > v_keypoints;
     cv::Mat m_desc;
-    cv::Ptr<cv::Feature2D> siftdetector = cv::xfeatures2d::SIFT::create();
 
     // Process SIFT computation
     siftdetector->detectAndCompute(img, m_mask, v_keypoints, m_desc);


### PR DESCRIPTION
Hi,

I was working with the OpenCV version of `main_ComputeFeatures_OpenCV` and found that it still uses the SIFT implementation from xfeatures2d(OpenCV contrib).

So I changed the code to use the SIFT Implementation from features2d. and removed the inclusion of xfeatures2d.hpp

Also, I found that the code was creating the SIFT Object every time when Describing the Features. So I changed the code to create the SIFT Descriptor in a constructor and use the created SIFT Descriptor object while describing the feature

Plz take a look if it looks fine to you, and comments are very welcomed.

Thank you for your contribution to this great OpenSource.