### PR TITLE
Add near/far bounds to frustums visualization binary

### DIFF
--- a/src/software/SfM/export/main_ExportCameraFrustums.cpp
+++ b/src/software/SfM/export/main_ExportCameraFrustums.cpp
@@ -31,9 +31,13 @@ int main(int argc, char **argv)
 
   std::string sSfM_Data_Filename;
   std::string sOutFile = "";
+  double z_near = -1.;
+  double z_far = -1.;
 
   cmd.add( make_option('i', sSfM_Data_Filename, "input_file") );
   cmd.add( make_option('o', sOutFile, "output_file") );
+  cmd.add( make_option('n', z_near, "z_near") );
+  cmd.add( make_option('f', z_far, "z_far") );
   cmd.add( make_switch('c', "colorize") );
 
   try {
@@ -43,7 +47,9 @@ int main(int argc, char **argv)
     std::cerr << "Usage: " << argv[0] << '\n'
     << "[-i|--input_file] path to a SfM_Data scene\n"
     << "[-o|--output_file] PLY file to store the camera frustums as triangle meshes.\n"
-    << "[-c|--colorize] Colorize the camera frustums.\n"
+    << "[-n|--z_near] 'optional' distance of the near camera plane\n"
+    << "[-f|--z_far] 'optional' distance of the far camera plane\n"
+    << "[-c|--colorize] 'optional' colorize the camera frustums.\n"
     << std::endl;
 
     std::cerr << s << std::endl;
@@ -67,7 +73,7 @@ int main(int argc, char **argv)
   const bool colorize = cmd.used('c');
 
   // If sfm_data have not structure, cameras are displayed as tiny normalized cones
-  const Frustum_Filter frustum_filter(sfm_data);
+  const Frustum_Filter frustum_filter(sfm_data, z_near, z_far);
   if (!sOutFile.empty())
   {
     if (frustum_filter.export_Ply(sOutFile, colorize))


### PR DESCRIPTION
**Change:**
Add flags to `openMVG_main_ExportCameraFrustums` binary to allow the user to set near/far bounds of frustums. This makes it easier to visualize and debug frustums related functionalities such as frustums intersection. The functionality was already there, it just needed to be exposed from the cli.

Cli:
```sh
openMVG_main_ExportCameraFrustums -i sfm_data.bin -o frustums.ply -n NEAR_PLANE -f FAR_PLANE
```

**Examples:**
Before:
![default](https://user-images.githubusercontent.com/3511664/136833914-74143960-4202-4c6c-b918-0bff997e3794.jpg)

Custom near & far planes:
![custom](https://user-images.githubusercontent.com/3511664/136833950-4fef49cb-1fc7-4522-8aff-45b147ff7888.jpg)

Thanks @pmoulon for the great library 😊!!