### PR TITLE
(trivial) Remove using namespace std and add std:: qualifications in few places where needed

### DIFF
--- a/src/openMVG/exif/exif_IO_test.cpp
+++ b/src/openMVG/exif/exif_IO_test.cpp
@@ -14,7 +14,6 @@
 #include <iostream>
 #include <memory>
 
-using namespace std;
 using namespace openMVG;
 using namespace openMVG::exif;
 

--- a/src/openMVG/features/features_test.cpp
+++ b/src/openMVG/features/features_test.cpp
@@ -18,9 +18,6 @@
 
 using namespace openMVG;
 using namespace openMVG::features;
-using namespace std;
-
-using std::string;
 
 // Define a feature and a container of features
 using Feature_T = SIOPointFeature;

--- a/src/openMVG/features/image_describer_test.cpp
+++ b/src/openMVG/features/image_describer_test.cpp
@@ -21,9 +21,6 @@
 
 using namespace openMVG;
 using namespace openMVG::features;
-using namespace std;
-
-using std::string;
 
 bool SaveAndLoad
 (

--- a/src/openMVG/geometry/frustum_box_intersection_test.cpp
+++ b/src/openMVG/geometry/frustum_box_intersection_test.cpp
@@ -22,7 +22,6 @@
 using namespace openMVG;
 using namespace openMVG::geometry;
 using namespace openMVG::geometry::halfPlane;
-using namespace std;
 
 //--
 // Box/Camera frustum intersection unit test

--- a/src/openMVG/geometry/frustum_intersection_test.cpp
+++ b/src/openMVG/geometry/frustum_intersection_test.cpp
@@ -21,7 +21,6 @@
 using namespace openMVG;
 using namespace openMVG::geometry;
 using namespace openMVG::geometry::halfPlane;
-using namespace std;
 
 //--
 // Camera frustum intersection unit test

--- a/src/openMVG/geometry/half_space_intersection_test.cpp
+++ b/src/openMVG/geometry/half_space_intersection_test.cpp
@@ -17,7 +17,6 @@
 
 using namespace openMVG;
 using namespace openMVG::geometry::halfPlane;
-using namespace std;
 
 TEST(HALF_PLANE, ExistingSubspace) {
 

--- a/src/openMVG/geometry/rigid_transformation3D_srt_test.cpp
+++ b/src/openMVG/geometry/rigid_transformation3D_srt_test.cpp
@@ -13,7 +13,6 @@
 
 using namespace openMVG;
 using namespace openMVG::geometry;
-using namespace std;
 
 TEST(SRT_precision, Experiment_ScaleOnly) {
 

--- a/src/openMVG/image/image_filtering_test.cpp
+++ b/src/openMVG/image/image_filtering_test.cpp
@@ -15,7 +15,6 @@
 
 using namespace openMVG;
 using namespace openMVG::image;
-using namespace std;
 
 TEST(Image, Convolution)
 {

--- a/src/openMVG/image/image_test.cpp
+++ b/src/openMVG/image/image_test.cpp
@@ -14,7 +14,6 @@
 
 #include <iostream>
 
-using namespace std;
 using namespace openMVG;
 using namespace openMVG::image;
 
@@ -26,12 +25,12 @@ TEST(Image, Basis)
   imaGray(2,2) = 2;
   imaGray(5,0) = 2;
 
-  cout << imaGray << endl << endl;
+  std::cout << imaGray << std::endl << std::endl;
   //-- Get raw ptr to image data :
   const unsigned char * ptr = imaGray.data();
   ((unsigned char*)ptr)[0] = 2;
-  fill(((unsigned char*)ptr+9*10),((unsigned char*)ptr+10*10),2);
-  cout << "After" << endl << imaGray;
+  std::fill(((unsigned char*)ptr+9*10),((unsigned char*)ptr+10*10),2);
+  std::cout << "After" << std::endl << imaGray;
 
   // Construction by re-copy
   Image<unsigned char> imageGray2(imaGray);

--- a/src/openMVG/linearProgramming/lInfinityCV/global_translations_fromTij_test.cpp
+++ b/src/openMVG/linearProgramming/lInfinityCV/global_translations_fromTij_test.cpp
@@ -16,7 +16,6 @@
 using namespace openMVG;
 using namespace openMVG::linearProgramming;
 using namespace lInfinityCV;
-using namespace std;
 
 TEST(translation_averaging, globalTi_from_tijs) {
 

--- a/src/openMVG/linearProgramming/lInfinityCV/global_translations_fromTriplets_test.cpp
+++ b/src/openMVG/linearProgramming/lInfinityCV/global_translations_fromTriplets_test.cpp
@@ -16,7 +16,6 @@
 using namespace openMVG;
 using namespace openMVG::linearProgramming;
 using namespace lInfinityCV;
-using namespace std;
 
 TEST(translation_averaging, globalTi_from_tijs_Triplets) {
 

--- a/src/openMVG/matching/matching_filters_test.cpp
+++ b/src/openMVG/matching/matching_filters_test.cpp
@@ -14,18 +14,17 @@
 
 using namespace openMVG;
 using namespace openMVG::matching;
-using namespace std;
 
 /// Sorted vector intersection (increasing order)
 TEST( matching, setIntersection)
 {
   const int tab0[] = {0, 1, 2, 3, 4, 5, 6, 7};
   const int tab1[] = {0, 1, 8, 3, 4, 9, 6, 7};
-  const set<int> vec_0(tab0, tab0+8);
-  const set<int> vec_1(tab1, tab1+8);
+  const std::set<int> vec_0(tab0, tab0+8);
+  const std::set<int> vec_1(tab1, tab1+8);
   /// Array must be sorted
 
-  vector<int> vec_intersect;
+  std::vector<int> vec_intersect;
   IntersectMatches(vec_0.begin(), vec_0.end(),
     vec_1.begin(), vec_1.end(),
     vec_intersect);

--- a/src/openMVG/matching/matching_test.cpp
+++ b/src/openMVG/matching/matching_test.cpp
@@ -19,7 +19,6 @@
 #include "testing/testing.h"
 
 #include <iostream>
-using namespace std;
 
 using namespace openMVG;
 using namespace matching;
@@ -48,7 +47,7 @@ TEST(Matching, ArrayMatcherBruteForce_NN)
 
   const float query[] = {2};
   IndMatches vec_nIndice;
-  vector<float> vec_fDistance;
+  std::vector<float> vec_fDistance;
   EXPECT_TRUE( matcher.SearchNeighbours(query,1, &vec_nIndice, &vec_fDistance, 5) );
 
   EXPECT_EQ( 5, vec_nIndice.size());
@@ -97,7 +96,7 @@ TEST(Matching, ArrayMatcher_Kdtree_Flann_Simple__NN)
 
   const float query[] = {2};
   IndMatches vec_nIndice;
-  vector<float> vec_fDistance;
+  std::vector<float> vec_fDistance;
   const int NN = 5;
   EXPECT_TRUE( matcher.SearchNeighbours(query, 1, &vec_nIndice, &vec_fDistance, NN) );
 
@@ -129,7 +128,7 @@ TEST(Matching, ArrayMatcher_Hnsw_Simple__NN)
 
   const float query[] = {2};
   IndMatches vec_nIndice;
-  vector<float> vec_fDistance;
+  std::vector<float> vec_fDistance;
   const int NN = 5;
   EXPECT_TRUE( matcher.SearchNeighbours(query, 1, &vec_nIndice, &vec_fDistance, NN) );
 

--- a/src/openMVG/matching/metric_test.cpp
+++ b/src/openMVG/matching/metric_test.cpp
@@ -14,8 +14,6 @@
 
 #include <iostream>
 
-using namespace std;
-
 using namespace openMVG;
 using namespace matching;
 

--- a/src/openMVG/matching_image_collection/Pair_Builder_test.cpp
+++ b/src/openMVG/matching_image_collection/Pair_Builder_test.cpp
@@ -13,7 +13,6 @@
 #include <iostream>
 
 using namespace openMVG;
-using namespace std;
 
 // Check pairs follow a weak ordering pair.first < pair.second
 template<typename IterablePairs>

--- a/src/openMVG/multiview/rotation_averaging_test.cpp
+++ b/src/openMVG/multiview/rotation_averaging_test.cpp
@@ -61,8 +61,6 @@ TEST ( rotation_averaging, ClosestSVDRotationMatrixNoisy )
 //     1
 TEST ( rotation_averaging, RotationLeastSquare_3_Camera)
 {
-  using namespace std;
-
   //--
   // Setup 3 camera that have a relative orientation of 120 degree
   // Set Z axis as UP Vector for the rotation
@@ -162,8 +160,6 @@ TEST ( rotation_averaging, RefineRotationsL2_CompleteGraph)
 
 TEST ( rotation_averaging, RefineRotationsAvgL1IRLS_SimpleTriplet)
 {
-  using namespace std;
-
   //--
   // Setup 3 camera that have a relative orientation of 120 degree
   // Set Z axis as UP Vector for the rotation

--- a/src/openMVG/multiview/solver_fundamental_kernel_test.cpp
+++ b/src/openMVG/multiview/solver_fundamental_kernel_test.cpp
@@ -37,7 +37,6 @@
 #include <numeric>
 
 using namespace openMVG;
-using namespace std;
 
 // Check that sin(angle(a, b)) < tolerance.
 template<typename A, typename B>
@@ -86,9 +85,9 @@ bool ExpectKernelProperties(const Mat &x1,
                             Mat3 *F_expected = nullptr) {
   bool bOk = true;
   Kernel kernel(x1, x2);
-  vector<uint32_t> samples(x1.cols());
+  std::vector<uint32_t> samples(x1.cols());
   std::iota(samples.begin(), samples.end(), 0);
-  vector<Mat3> Fs;
+  std::vector<Mat3> Fs;
   kernel.Fit(samples, &Fs);
 
   bOk &= (!Fs.empty());

--- a/src/openMVG/multiview/solver_homography_kernel_test.cpp
+++ b/src/openMVG/multiview/solver_homography_kernel_test.cpp
@@ -33,12 +33,11 @@
 
 #include <vector>
 
-using namespace std;
 using namespace openMVG;
 
 TEST(HomographyKernelTest, Fitting_Unnormalized) {
   // Define 3 knows homographies (Use as GT).
-  vector<Mat3> H_gt(3);
+  std::vector<Mat3> H_gt(3);
 
   H_gt[0] = Mat3::Identity();
   H_gt[1] << 1,  0, -4, // Affine homography motion
@@ -60,13 +59,13 @@ TEST(HomographyKernelTest, Fitting_Unnormalized) {
 
     homography::kernel::UnnormalizedKernel kernel(x, y);
 
-    vector<uint32_t> samples = {0,1,2,3,4};
+    std::vector<uint32_t> samples = {0,1,2,3,4};
     for (
       Mat::Index j = 4;
       static_cast<Mat::Index>(samples.size()) < x.cols();
       samples.push_back(j++))
     {
-      vector<Mat3> Hs;
+      std::vector<Mat3> Hs;
       kernel.Fit(samples, &Hs);
       CHECK_EQUAL(1, Hs.size());
       // Check that found matrix is equal to the GT
@@ -77,7 +76,7 @@ TEST(HomographyKernelTest, Fitting_Unnormalized) {
 
 TEST(HomographyKernelTest, Fitting_Normalized) {
   // Define 3 knows homographies (Use as GT).
-  vector<Mat3> H_gt(3);
+  std::vector<Mat3> H_gt(3);
 
   H_gt[0] = Mat3::Identity();
   H_gt[1] << 1,  0, -4, // Affine homography motion
@@ -99,13 +98,13 @@ TEST(HomographyKernelTest, Fitting_Normalized) {
 
     homography::kernel::Kernel kernel(x, y);
 
-    vector<uint32_t> samples = {0,1,2,3,4};
+    std::vector<uint32_t> samples = {0,1,2,3,4};
     for (
       Mat::Index j = 4;
       static_cast<Mat::Index>(samples.size()) < x.cols();
       samples.push_back(j++))
     {
-      vector<Mat3> Hs;
+      std::vector<Mat3> Hs;
       kernel.Fit(samples, &Hs);
       CHECK_EQUAL(1, Hs.size());
       // Check that found matrix is equal to the GT

--- a/src/openMVG/multiview/solver_resection_kernel.cpp
+++ b/src/openMVG/multiview/solver_resection_kernel.cpp
@@ -15,8 +15,6 @@ namespace openMVG {
 namespace resection {
 namespace kernel {
 
-using namespace std;
-
 void translate
 (
   const Mat3X & X,
@@ -71,7 +69,7 @@ void SixPointResectionSolver::Solve
 (
   const Mat &pt2D,
   const Mat &pt3d,
-  vector<Mat34> *Ps,
+  std::vector<Mat34> *Ps,
   bool bcheck
 )
 {

--- a/src/openMVG/multiview/translation_averaging_test.cpp
+++ b/src/openMVG/multiview/translation_averaging_test.cpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 using namespace openMVG;
-using namespace std;
 
 TEST(translation_averaging, globalTi_from_tijs_Triplets_softL1_Ceres) {
 

--- a/src/openMVG/multiview/triangulation_test.cpp
+++ b/src/openMVG/multiview/triangulation_test.cpp
@@ -14,7 +14,6 @@
 #include "testing/testing.h"
 
 using namespace openMVG;
-using namespace std;
 
 TEST(Triangulation, TriangulateDLT) {
 

--- a/src/openMVG/numeric/l1_solver_test.cpp
+++ b/src/openMVG/numeric/l1_solver_test.cpp
@@ -16,7 +16,6 @@
 #include <random>
 
 using namespace openMVG;
-using namespace std;
 
 TEST(L1Solver_ADMM, Decoding)
 {

--- a/src/openMVG/numeric/lm_test.cpp
+++ b/src/openMVG/numeric/lm_test.cpp
@@ -21,7 +21,6 @@
 
 using namespace openMVG;
 using namespace svg;
-using namespace std;
 
 // Implementation of the problem found here:
 // digilander.libero.it/foxes/optimiz/Optimiz1.htm

--- a/src/openMVG/numeric/numeric_test.cpp
+++ b/src/openMVG/numeric/numeric_test.cpp
@@ -36,7 +36,6 @@
 #include <set>
 
 using namespace openMVG;
-using namespace std;
 
 //-- Assert that stream interface is available
 TEST ( TinyMatrix, print )

--- a/src/openMVG/robust_estimation/gms_filter_test.cpp
+++ b/src/openMVG/robust_estimation/gms_filter_test.cpp
@@ -13,7 +13,6 @@
 
 using namespace openMVG;
 using namespace openMVG::robust;
-using namespace std;
 
 TEST(GMSFilter, borderCases)
 {

--- a/src/openMVG/robust_estimation/robust_estimator_ACRansac_test.cpp
+++ b/src/openMVG/robust_estimation/robust_estimator_ACRansac_test.cpp
@@ -20,7 +20,6 @@
 
 using namespace openMVG;
 using namespace openMVG::robust;
-using namespace std;
 using namespace svg;
 
 /// ACRansac Kernel for line estimation
@@ -182,7 +181,7 @@ TEST(RansacLineFitter, RealisticCase) {
 
   //-- Simulate outliers (for the asked percentage amount of the datum)
   constexpr auto nbPtToNoise = static_cast<uint32_t>(NbPoints*inlierRatio);
-  vector<uint32_t> vec_samples; // Fit with unique random index
+  std::vector<uint32_t> vec_samples; // Fit with unique random index
   UniformSample(nbPtToNoise, NbPoints, random_generator, &vec_samples);
   for (size_t i = 0; i <vec_samples.size(); ++i)
   {
@@ -316,9 +315,9 @@ TEST(RansacLineFitter, ACRANSACSimu) {
       svgTest.drawCircle(x,y, 1, svgStyle().fill("red").noStroke());
     }
 
-    ostringstream osSvg;
+    std::ostringstream osSvg;
     osSvg << gaussianNoiseLevel << "_line_.svg";
-    ofstream svgFile( osSvg.str() );
+    std::ofstream svgFile( osSvg.str() );
     svgFile << svgTest.closeSvgFile().str();
 
     // robust line estimation
@@ -332,16 +331,16 @@ TEST(RansacLineFitter, ACRANSACSimu) {
     std::vector<uint32_t> vec_inliers;
     const std::pair<double,double> ret = ACRANSAC(lineKernel, vec_inliers, 1000, &line);
     const double errorMax = ret.first;
-    EXPECT_TRUE(sqrt(errorMax) < noise*2+.5);
+    EXPECT_TRUE(std::sqrt(errorMax) < noise*2+.5);
 
-    ostringstream os;
-    os << gaussianNoiseLevel << "_line_" << sqrt(errorMax) << ".png";
+    std::ostringstream os;
+    os << gaussianNoiseLevel << "_line_" << std::sqrt(errorMax) << ".png";
 
     // Svg drawing
     {
       svgDrawer svgTest(W,H);
       for (size_t i = 0; i < nbPoints; ++i) {
-        string sCol = "red";
+        std::string sCol = "red";
         const float x = points.col(i)[0];
         const float y = points.col(i)[1];
         if (find(vec_inliers.begin(), vec_inliers.end(), i) != vec_inliers.end())
@@ -356,9 +355,9 @@ TEST(RansacLineFitter, ACRANSACSimu) {
       const float yb = line[1] * xb + line[0];
       svgTest.drawLine(xa, ya, xb, yb, svgStyle().stroke("blue", 0.5));
 
-      ostringstream osSvg;
-      osSvg << gaussianNoiseLevel << "_line_" << sqrt(errorMax) << ".svg";
-      ofstream svgFile( osSvg.str() );
+      std::ostringstream osSvg;
+      osSvg << gaussianNoiseLevel << "_line_" << std::sqrt(errorMax) << ".svg";
+      std::ofstream svgFile( osSvg.str() );
       svgFile << svgTest.closeSvgFile().str();
     }
   }

--- a/src/openMVG_Samples/cameras_undisto_Brown/undistoBrown.cpp
+++ b/src/openMVG_Samples/cameras_undisto_Brown/undistoBrown.cpp
@@ -20,7 +20,6 @@
 using namespace openMVG;
 using namespace openMVG::cameras;
 using namespace openMVG::image;
-using namespace std;
 
 int main(int argc, char **argv)
 {
@@ -88,10 +87,11 @@ int main(int argc, char **argv)
   {
     //read the depth
     int w,h,depth;
-    vector<unsigned char> tmp_vec;
-    const string sOutFileName =
+    std::vector<unsigned char> tmp_vec;
+    const std::string sOutFileName =
       stlplus::create_filespec(sOutPath, stlplus::basename_part(vec_fileNames[j]), "png");
-    const string sInFileName = stlplus::create_filespec(sPath, stlplus::filename_part(vec_fileNames[j]));
+    const std::string sInFileName =
+      stlplus::create_filespec(sPath, stlplus::filename_part(vec_fileNames[j]));
     const int res = ReadImage(sInFileName.c_str(), &tmp_vec, &w, &h, &depth);
 
     const Pinhole_Intrinsic_Radial_K3 cam(w, h, f, c(0), c(1), k(0), k(1), k(2));

--- a/src/openMVG_Samples/features_affine_demo/features_affine_demo.cpp
+++ b/src/openMVG_Samples/features_affine_demo/features_affine_demo.cpp
@@ -27,7 +27,6 @@
 using namespace openMVG;
 using namespace openMVG::image;
 using namespace openMVG::features;
-using namespace std;
 
 /**
  ** Normalize a patch to a specified size, given an ellipse
@@ -157,7 +156,7 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
   }
   const std::string sInputDir =
-    stlplus::folder_up(string(THIS_SOURCE_DIR)) + "/imageData/SceauxCastle/";
+    stlplus::folder_up(std::string(THIS_SOURCE_DIR)) + "/imageData/SceauxCastle/";
   const std::string jpg_filename = sInputDir + "100_7101.jpg";
 
   Image<unsigned char> image;

--- a/src/openMVG_Samples/features_image_matching/describe_and_match.cpp
+++ b/src/openMVG_Samples/features_image_matching/describe_and_match.cpp
@@ -21,7 +21,6 @@
 
 using namespace openMVG;
 using namespace openMVG::image;
-using namespace std;
 
 int main(int argc, char **argv) {
 
@@ -47,9 +46,9 @@ int main(int argc, char **argv) {
       return EXIT_FAILURE;
   }
 
-  const string jpg_filenameL = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string jpg_filenameL = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
-  const string jpg_filenameR = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string jpg_filenameR = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
 
   Image<unsigned char> imageL, imageR;
@@ -90,7 +89,7 @@ int main(int argc, char **argv) {
     //- Show images side by side
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    const string out_filename = "00_images.jpg";
+    const std::string out_filename = "00_images.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 

--- a/src/openMVG_Samples/features_image_matching_gmsfilter/describe_and_match_gmsfilter.cpp
+++ b/src/openMVG_Samples/features_image_matching_gmsfilter/describe_and_match_gmsfilter.cpp
@@ -24,7 +24,6 @@
 using namespace openMVG;
 using namespace openMVG::image;
 using namespace openMVG::robust;
-using namespace std;
 
 int main(int argc, char **argv) {
 
@@ -53,9 +52,9 @@ int main(int argc, char **argv) {
       return EXIT_FAILURE;
   }
 
-  const string jpg_filenameL = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string jpg_filenameL = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
-  const string jpg_filenameR = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string jpg_filenameR = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
 
   Image<unsigned char> imageL, imageR;
@@ -99,7 +98,7 @@ int main(int argc, char **argv) {
     //- Show images side by side
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    const string out_filename = "00_images.jpg";
+    const std::string out_filename = "00_images.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 

--- a/src/openMVG_Samples/features_kvld_filter/kvld_filter.cpp
+++ b/src/openMVG_Samples/features_kvld_filter/kvld_filter.cpp
@@ -27,14 +27,13 @@ using namespace openMVG;
 using namespace openMVG::image;
 using namespace openMVG::matching;
 using namespace svg;
-using namespace std;
 
 int main(int argc, char **argv) {
   CmdLine cmd;
 
-  std::string sImg1 = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  std::string sImg1 = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
-  std::string sImg2 = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  std::string sImg2 = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
   std::string sOutDir = "./kvldOut";
   std::cout << sImg1 << std::endl << sImg2 << std::endl;
@@ -83,8 +82,8 @@ int main(int argc, char **argv) {
   if (!stlplus::folder_exists(sOutDir))
     stlplus::folder_create( sOutDir );
 
-  const string jpg_filenameL = sImg1;
-  const string jpg_filenameR = sImg2;
+  const std::string jpg_filenameL = sImg1;
+  const std::string jpg_filenameR = sImg2;
 
   Image<unsigned char> imageL, imageR;
   ReadImage(jpg_filenameL.c_str(), &imageL);
@@ -111,7 +110,7 @@ int main(int argc, char **argv) {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "00_images.jpg";
+    std::string out_filename = "00_images.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 
@@ -194,7 +193,8 @@ int main(int argc, char **argv) {
 
   //Print K-VLD consistent matches
   {
-    svgDrawer svgStream(imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(),
+                        std::max(imageL.Height(), imageR.Height()));
 
     // ".svg"
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
@@ -222,15 +222,16 @@ int main(int argc, char **argv) {
         }
       }
     }
-    const string out_filename = stlplus::create_filespec(sOutDir, "03_KVLD_Matches.svg");
-    ofstream svgFile( out_filename.c_str() );
+    const std::string out_filename = stlplus::create_filespec(sOutDir, "03_KVLD_Matches.svg");
+    std::ofstream svgFile( out_filename.c_str() );
     svgFile << svgStream.closeSvgFile().str();
     svgFile.close();
   }
 
   {
     //Print keypoints kept by K-VLD
-    svgDrawer svgStream(imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(),
+                        std::max(imageL.Height(), imageR.Height()));
 
     // ".svg"
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
@@ -247,8 +248,8 @@ int main(int argc, char **argv) {
         svgStream.drawCircle(r.x() + imageL.Width(), r.y(), 10, svgStyle().stroke("yellow", 2.0));
       }
     }
-    const string out_filename = stlplus::create_filespec(sOutDir, "04_KVLD_Keypoints.svg");
-    ofstream svgFile( out_filename.c_str() );
+    const std::string out_filename = stlplus::create_filespec(sOutDir, "04_KVLD_Keypoints.svg");
+    std::ofstream svgFile( out_filename.c_str() );
     svgFile << svgStream.closeSvgFile().str();
     svgFile.close();
   }
@@ -264,11 +265,11 @@ int main(int argc, char **argv) {
     E);
 
   {
-    const string out_filename = stlplus::create_filespec(sOutDir, "05_Left-K-VLD-MASK.jpg");
+    const std::string out_filename = stlplus::create_filespec(sOutDir, "05_Left-K-VLD-MASK.jpg");
     WriteImage(out_filename.c_str(), imageOutL);
   }
   {
-    const string out_filename = stlplus::create_filespec(sOutDir, "06_Right-K-VLD-MASK.jpg");
+    const std::string out_filename = stlplus::create_filespec(sOutDir, "06_Right-K-VLD-MASK.jpg");
     WriteImage(out_filename.c_str(), imageOutR);
   }
 

--- a/src/openMVG_Samples/features_repeatability/main_repeatability_dataset.cpp
+++ b/src/openMVG_Samples/features_repeatability/main_repeatability_dataset.cpp
@@ -22,7 +22,6 @@
 using namespace openMVG;
 using namespace openMVG::image;
 using namespace openMVG::matching;
-using namespace std;
 
 #include "openMVG/features/sift/SIFT_Anatomy_Image_Describer.hpp"
 #include "nonFree/sift/SIFT_describer.hpp"

--- a/src/openMVG_Samples/features_siftPutativeMatches/siftmatch.cpp
+++ b/src/openMVG_Samples/features_siftPutativeMatches/siftmatch.cpp
@@ -23,14 +23,13 @@
 using namespace openMVG;
 using namespace openMVG::image;
 using namespace openMVG::matching;
-using namespace std;
 
 int main() {
 
   Image<RGBColor> image;
-  string jpg_filenameL = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  std::string jpg_filenameL = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
-  string jpg_filenameR = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  std::string jpg_filenameR = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
 
   Image<unsigned char> imageL, imageR;
@@ -54,7 +53,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatV(imageL, imageR, concat);
-    string out_filename = "00_images.jpg";
+    std::string out_filename = "00_images.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 

--- a/src/openMVG_Samples/geodesy_show_exif_gps_position/show_exif_gps_position_demo.cpp
+++ b/src/openMVG_Samples/geodesy_show_exif_gps_position/show_exif_gps_position_demo.cpp
@@ -21,7 +21,6 @@
 using namespace openMVG;
 using namespace openMVG::exif;
 using namespace openMVG::geodesy;
-using namespace std;
 
 int main(int argc, char **argv)
 {

--- a/src/openMVG_Samples/image_spherical_to_pinholes/main_pano_converter.cpp
+++ b/src/openMVG_Samples/image_spherical_to_pinholes/main_pano_converter.cpp
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 using namespace svg;
 
 // Convert spherical panorama to rectilinear images

--- a/src/openMVG_Samples/multiview_robust_essential/robust_essential.cpp
+++ b/src/openMVG_Samples/multiview_robust_essential/robust_essential.cpp
@@ -31,7 +31,6 @@ using namespace openMVG::matching;
 using namespace openMVG::image;
 using namespace openMVG::cameras;
 using namespace openMVG::geometry;
-using namespace std;
 
 /// Read intrinsic K matrix from a file (ASCII)
 /// F 0 ppx
@@ -46,10 +45,10 @@ bool exportToPly(const std::vector<Vec3> & vec_points,
 
 int main() {
 
-  const std::string sInputDir = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string sInputDir = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/SceauxCastle/";
-  const string jpg_filenameL = sInputDir + "100_7101.jpg";
-  const string jpg_filenameR = sInputDir + "100_7102.jpg";
+  const std::string jpg_filenameL = sInputDir + "100_7101.jpg";
+  const std::string jpg_filenameR = sInputDir + "100_7102.jpg";
 
   Image<unsigned char> imageL, imageR;
   ReadImage(jpg_filenameL.c_str(), &imageL);
@@ -75,7 +74,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 
@@ -246,8 +245,8 @@ int main() {
 bool readIntrinsic(const std::string & fileName, Mat3 & K)
 {
   // Load the K matrix
-  ifstream in;
-  in.open( fileName.c_str(), ifstream::in);
+  std::ifstream in;
+  in.open( fileName.c_str(), std::ifstream::in);
   if (in)  {
     for (int j=0; j < 3; ++j)
       for (int i=0; i < 3; ++i)

--- a/src/openMVG_Samples/multiview_robust_essential_ba/robust_essential_ba.cpp
+++ b/src/openMVG_Samples/multiview_robust_essential_ba/robust_essential_ba.cpp
@@ -37,7 +37,6 @@ using namespace openMVG::matching;
 using namespace openMVG::cameras;
 using namespace openMVG::geometry;
 using namespace openMVG::sfm;
-using namespace std;
 
 /// Read intrinsic K matrix from a file (ASCII)
 /// F 0 ppx
@@ -52,11 +51,11 @@ bool readIntrinsic(const std::string & fileName, Mat3 & K);
 ///   way 2: independent cameras motion [R|t], shared focal [f] and structure
 int main() {
 
-  const std::string sInputDir = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string sInputDir = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/SceauxCastle/";
   Image<RGBColor> image;
-  const string jpg_filenameL = sInputDir + "100_7101.jpg";
-  const string jpg_filenameR = sInputDir + "100_7102.jpg";
+  const std::string jpg_filenameL = sInputDir + "100_7101.jpg";
+  const std::string jpg_filenameR = sInputDir + "100_7102.jpg";
 
   Image<unsigned char> imageL, imageR;
   ReadImage(jpg_filenameL.c_str(), &imageL);
@@ -82,7 +81,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 
@@ -278,8 +277,8 @@ int main() {
 bool readIntrinsic(const std::string & fileName, Mat3 & K)
 {
   // Load the K matrix
-  ifstream in;
-  in.open( fileName.c_str(), ifstream::in);
+  std::ifstream in;
+  in.open(fileName.c_str(), std::ifstream::in);
   if (in)  {
     for (int j=0; j < 3; ++j)
       for (int i=0; i < 3; ++i)

--- a/src/openMVG_Samples/multiview_robust_essential_spherical/robust_essential_spherical.cpp
+++ b/src/openMVG_Samples/multiview_robust_essential_spherical/robust_essential_spherical.cpp
@@ -41,13 +41,12 @@ using namespace openMVG::image;
 using namespace openMVG::matching;
 using namespace openMVG::robust;
 using namespace openMVG::sfm;
-using namespace std;
 
 int main(int argc, char **argv) {
 
   CmdLine cmd;
 
-  string jpg_filenameL, jpg_filenameR;
+  std::string jpg_filenameL, jpg_filenameR;
 
   cmd.add( make_option('a', jpg_filenameL, "input_a") );
   cmd.add( make_option('b', jpg_filenameR, "input_b") );
@@ -108,7 +107,7 @@ int main(int argc, char **argv) {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 

--- a/src/openMVG_Samples/multiview_robust_estimation_tutorial/robust_estimation_tutorial_homography.cpp
+++ b/src/openMVG_Samples/multiview_robust_estimation_tutorial/robust_estimation_tutorial_homography.cpp
@@ -44,7 +44,6 @@ using namespace openMVG::features;
 using namespace openMVG::matching;
 using namespace openMVG::robust;
 using namespace svg;
-using namespace std;
 
 //- Helper function
 // Display a visual report of the inliers
@@ -65,9 +64,9 @@ void display_info
 int main() {
 
   Image<RGBColor> image;
-  const string jpg_filenameL = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string jpg_filenameL = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
-  const string jpg_filenameR = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string jpg_filenameR = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
 
   Image<unsigned char> imageL, imageR;
@@ -94,7 +93,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 
@@ -335,7 +334,7 @@ void display_info
 
   //Show homography validated point and compute residuals
   std::vector<double> vec_residuals(vec_inliers.size(), 0.0);
-  svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+  svgDrawer svgStream( imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
   svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
   svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
   for ( size_t i = 0; i < vec_inliers.size(); ++i)  {
@@ -353,7 +352,7 @@ void display_info
   }
   std::ostringstream os;
   os << sMethod << "_robust_fitting.svg";
-  ofstream svgFile( os.str().c_str() );
+  std::ofstream svgFile( os.str().c_str() );
   svgFile << svgStream.closeSvgFile().str();
   svgFile.close();
 

--- a/src/openMVG_Samples/multiview_robust_fundamental/robust_fundamental.cpp
+++ b/src/openMVG_Samples/multiview_robust_fundamental/robust_fundamental.cpp
@@ -27,15 +27,14 @@ using namespace openMVG;
 using namespace openMVG::image;
 using namespace openMVG::matching;
 using namespace openMVG::robust;
-using namespace std;
 
 int main() {
 
-  const std::string sInputDir = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string sInputDir = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/SceauxCastle/";
   Image<RGBColor> image;
-  const string jpg_filenameL = sInputDir + "100_7101.jpg";
-  const string jpg_filenameR = sInputDir + "100_7102.jpg";
+  const std::string jpg_filenameL = sInputDir + "100_7101.jpg";
+  const std::string jpg_filenameR = sInputDir + "100_7102.jpg";
 
   Image<unsigned char> imageL, imageR;
   ReadImage(jpg_filenameL.c_str(), &imageL);
@@ -61,7 +60,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 

--- a/src/openMVG_Samples/multiview_robust_fundamental_guided/robust_fundamental_guided.cpp
+++ b/src/openMVG_Samples/multiview_robust_fundamental_guided/robust_fundamental_guided.cpp
@@ -31,15 +31,14 @@ using namespace openMVG::image;
 using namespace openMVG::matching;
 using namespace openMVG::robust;
 using namespace svg;
-using namespace std;
 
 int main() {
 
-  const std::string sInputDir = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string sInputDir = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/SceauxCastle/";
   Image<RGBColor> image;
-  const string jpg_filenameL = sInputDir + "100_7101.jpg";
-  const string jpg_filenameR = sInputDir + "100_7102.jpg";
+  const std::string jpg_filenameL = sInputDir + "100_7101.jpg";
+  const std::string jpg_filenameR = sInputDir + "100_7102.jpg";
 
   Image<unsigned char> imageL, imageR;
   ReadImage(jpg_filenameL.c_str(), &imageL);
@@ -65,7 +64,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 
@@ -227,7 +226,8 @@ int main() {
       {
         const std::vector<IndMatch> & vec_corresponding_index = vec_corresponding_indexes[idx];
         //Show fundamental validated correspondences
-        svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+        svgDrawer svgStream(imageL.Width() + imageR.Width(),
+                            std::max(imageL.Height(), imageR.Height()));
         svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
         svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
         for ( size_t i = 0; i < vec_corresponding_index.size(); ++i)  {
@@ -240,10 +240,10 @@ int main() {
           svgStream.drawCircle(L.x(), L.y(), LL.scale(), svgStyle().stroke("yellow", 2.0));
           svgStream.drawCircle(R.x()+imageL.Width(), R.y(), RR.scale(),svgStyle().stroke("yellow", 2.0));
         }
-        const string out_filename =
+        const std::string out_filename =
           (idx == 0) ? "04_ACRansacFundamental_guided_geom.svg"
             : "04_ACRansacFundamental_guided_geom_distratio.svg";
-        ofstream svgFile( out_filename.c_str() );
+        std::ofstream svgFile( out_filename.c_str() );
         svgFile << svgStream.closeSvgFile().str();
         svgFile.close();
       }

--- a/src/openMVG_Samples/multiview_robust_homography/robust_homography.cpp
+++ b/src/openMVG_Samples/multiview_robust_homography/robust_homography.cpp
@@ -32,14 +32,13 @@ using namespace openMVG;
 using namespace openMVG::image;
 using namespace openMVG::matching;
 using namespace openMVG::robust;
-using namespace std;
 
 int main() {
 
   Image<RGBColor> image;
-  const string jpg_filenameL = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string jpg_filenameL = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
-  const string jpg_filenameR = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string jpg_filenameR = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
 
   Image<unsigned char> imageL, imageR;
@@ -67,7 +66,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 

--- a/src/openMVG_Samples/multiview_robust_homography_guided/robust_homography_guided.cpp
+++ b/src/openMVG_Samples/multiview_robust_homography_guided/robust_homography_guided.cpp
@@ -34,14 +34,13 @@ using namespace openMVG::image;
 using namespace openMVG::matching;
 using namespace openMVG::robust;
 using namespace svg;
-using namespace std;
 
 int main() {
 
   Image<RGBColor> image;
-  const string jpg_filenameL = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string jpg_filenameL = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
-  const string jpg_filenameR = stlplus::folder_up(string(THIS_SOURCE_DIR))
+  const std::string jpg_filenameR = stlplus::folder_up(std::string(THIS_SOURCE_DIR))
     + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
 
   Image<unsigned char> imageL, imageR;
@@ -69,7 +68,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     WriteImage(out_filename.c_str(), concat);
   }
 
@@ -230,7 +229,8 @@ int main() {
       {
         const std::vector<IndMatch> & vec_corresponding_index = vec_corresponding_indexes[idx];
         //Show homography validated correspondences
-        svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+        svgDrawer svgStream(imageL.Width() + imageR.Width(),
+                            std::max(imageL.Height(), imageR.Height()));
         svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
         svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
         for ( size_t i = 0; i < vec_corresponding_index.size(); ++i)  {
@@ -243,10 +243,10 @@ int main() {
           svgStream.drawCircle(L.x(), L.y(), LL.scale(), svgStyle().stroke("yellow", 2.0));
           svgStream.drawCircle(R.x()+imageL.Width(), R.y(), RR.scale(),svgStyle().stroke("yellow", 2.0));
         }
-        const string out_filename =
+        const std::string out_filename =
           (idx == 0) ? "04_ACRansacHomography_guided_geom.svg"
             : "04_ACRansacHomography_guided_geom_distratio.svg";
-        ofstream svgFile( out_filename.c_str() );
+        std::ofstream svgFile( out_filename.c_str() );
         svgFile << svgStream.closeSvgFile().str();
         svgFile.close();
       }

--- a/src/software/Geodesy/registration_to_exif_gps_position.cpp
+++ b/src/software/Geodesy/registration_to_exif_gps_position.cpp
@@ -32,8 +32,6 @@ using namespace openMVG::exif;
 using namespace openMVG::geodesy;
 using namespace openMVG::sfm;
 
-using namespace std;
-
 int main(int argc, char **argv)
 {
   enum ERegistrationType

--- a/src/software/Localization/main_SfM_Localization.cpp
+++ b/src/software/Localization/main_SfM_Localization.cpp
@@ -49,7 +49,6 @@ std::string FindCommonRootDir(const std::string & dir1, const std::string & dir2
 // ----------------------------------------------------
 int main(int argc, char **argv)
 {
-  using namespace std;
   std::cout << std::endl
     << "-----------------------------------------------------------\n"
     << "  Images localization in an existing SfM reconstruction:\n"
@@ -486,7 +485,7 @@ int main(int argc, char **argv)
 
   GroupSharedIntrinsics(sfm_data);
 
-  std::cout << " Total poses found : " << vec_found_poses.size() << "/" << total_num_images << endl;
+  std::cout << " Total poses found : " << vec_found_poses.size() << "/" << total_num_images << std::endl;
 
   // Export the found camera position in a ply.
   const std::string out_file_name = stlplus::create_filespec(sOutDir, "found_pose_centers", "ply");

--- a/src/software/SfM/clustering/main_ComputeClusters.cpp
+++ b/src/software/SfM/clustering/main_ComputeClusters.cpp
@@ -152,7 +152,6 @@ bool exportData( const SfM_Data &sfm_data,
 
 int main( int argc, char **argv )
 {
-  using namespace std;
   OPENMVG_LOG_INFO << "Dominant Set Clustering";
 
   CmdLine cmd;

--- a/src/software/SfM/export/main_ExportCameraFrustums.cpp
+++ b/src/software/SfM/export/main_ExportCameraFrustums.cpp
@@ -25,7 +25,6 @@ using namespace openMVG::sfm;
 /// Export camera frustrums as a triangle PLY file
 int main(int argc, char **argv)
 {
-  using namespace std;
   OPENMVG_LOG_INFO << "Export camera frustums";
 
   CmdLine cmd;

--- a/src/software/SfM/main_ComputeFeatures.cpp
+++ b/src/software/SfM/main_ComputeFeatures.cpp
@@ -40,7 +40,6 @@ using namespace openMVG;
 using namespace openMVG::image;
 using namespace openMVG::features;
 using namespace openMVG::sfm;
-using namespace std;
 
 features::EDESCRIBER_PRESET stringToEnum(const std::string & sPreset)
 {

--- a/src/software/SfM/main_ComputeFeatures_OpenCV.cpp
+++ b/src/software/SfM/main_ComputeFeatures_OpenCV.cpp
@@ -32,7 +32,6 @@ using namespace openMVG;
 using namespace openMVG::image;
 using namespace openMVG::features;
 using namespace openMVG::sfm;
-using namespace std;
 
 enum eGeometricModel
 {

--- a/src/software/SfM/main_ComputeMatches.cpp
+++ b/src/software/SfM/main_ComputeMatches.cpp
@@ -35,7 +35,6 @@ using namespace openMVG;
 using namespace openMVG::matching;
 using namespace openMVG::sfm;
 using namespace openMVG::matching_image_collection;
-using namespace std;
 
 /// Compute corresponding features between a series of views:
 /// - Load view images description (regions: features & descriptors)

--- a/src/software/SfM/main_ComputeStructureFromKnownPoses.cpp
+++ b/src/software/SfM/main_ComputeStructureFromKnownPoses.cpp
@@ -53,7 +53,6 @@ Pair_Set BuildPairsFromFrustumsIntersections(
 /// Compute the structure of a scene according existing camera poses.
 int main(int argc, char **argv)
 {
-  using namespace std;
   OPENMVG_LOG_INFO << "Compute Structure from the provided poses";
 
   static const int min_track_length = 2;

--- a/src/software/SfM/main_ComputeVLAD.cpp
+++ b/src/software/SfM/main_ComputeVLAD.cpp
@@ -39,14 +39,13 @@ using namespace openMVG::matching;
 using namespace openMVG::sfm;
 using namespace openMVG::retrieval;
 
-using namespace std;
 using namespace svg;
 
 // TODO: these two output function could be factored and put somewhere else
 // Display the image retrieval matrix
 template <typename Order>
 void saveRetrievalMatrix(
-    const string &filename, const SfM_Data &sfm_data,
+    const std::string &filename, const SfM_Data &sfm_data,
     const IndexedPairwiseSimilarity<Order> &result_ordered_by_similarity) {
   const size_t num_neighbors =
       result_ordered_by_similarity.begin()->second.size();
@@ -82,7 +81,7 @@ void saveRetrievalMatrix(
     ++y_offset;
   }
 
-  ofstream svg_file(filename.c_str());
+  std::ofstream svg_file(filename.c_str());
   svg_file << svg_stream.closeSvgFile().str();
   svg_file.close();
 }

--- a/src/software/SfM/main_FrustumFiltering.cpp
+++ b/src/software/SfM/main_FrustumFiltering.cpp
@@ -60,7 +60,6 @@ Pair_Set BuildPairsFromFrustumsIntersections(
 
 int main(int argc, char **argv)
 {
-  using namespace std;
   OPENMVG_LOG_INFO
     << "\n-----------------------------------------------------------"
     << "\nFrustum filtering:"

--- a/src/software/SfM/main_GeometricFilter.cpp
+++ b/src/software/SfM/main_GeometricFilter.cpp
@@ -45,7 +45,6 @@ using namespace openMVG::matching;
 using namespace openMVG::robust;
 using namespace openMVG::sfm;
 using namespace openMVG::matching_image_collection;
-using namespace std;
 
 enum EGeometricModel
 {

--- a/src/software/SfM/main_ListMatchingPairs.cpp
+++ b/src/software/SfM/main_ListMatchingPairs.cpp
@@ -83,7 +83,6 @@ void AdjacencyMatrixToSVG
 
 int main(int argc, char **argv)
 {
-  using namespace std;
   OPENMVG_LOG_INFO
     << "\n-----------------------------------------------------------"
     << "\nCompute a view pair list file for main_ComputeMatches:"

--- a/src/software/SfM/main_PointsFiltering.cpp
+++ b/src/software/SfM/main_PointsFiltering.cpp
@@ -24,7 +24,6 @@ using namespace openMVG::sfm;
 
 int main(int argc, char **argv)
 {
-  using namespace std;
   OPENMVG_LOG_INFO
     << "\n-----------------------------------------------------------"
     << "\nFilter Structure based on statistics computed per view    :"

--- a/src/software/SfM/main_SfM.cpp
+++ b/src/software/SfM/main_SfM.cpp
@@ -132,7 +132,6 @@ bool computeIndexFromImageNames(
 
 int main(int argc, char **argv)
 {
-  using namespace std;
   OPENMVG_LOG_INFO
       << "\n-----------------------------------------------------------"
       << "\n Structure from Motion:"

--- a/src/software/SfM/main_SplitMatchFileIntoMatchFiles.cpp
+++ b/src/software/SfM/main_SplitMatchFileIntoMatchFiles.cpp
@@ -23,8 +23,6 @@ using namespace openMVG::sfm;
 
 int main(int argc, char **argv)
 {
-  using namespace std;
-
   CmdLine cmd;
 
   std::string sfm_data_filename;

--- a/src/software/SfM/main_evalQuality.cpp
+++ b/src/software/SfM/main_evalQuality.cpp
@@ -30,8 +30,6 @@ using namespace openMVG::cameras;
 
 int main(int argc, char **argv)
 {
-  using namespace std;
-
   CmdLine cmd;
 
   std::string
@@ -175,9 +173,9 @@ int main(int argc, char **argv)
 
   // Visual output of the camera location
   plyHelper::exportToPly(camera_pos_gt,
-    string(stlplus::folder_append_separator(sOutDir) + "camGT.ply").c_str());
+    (stlplus::folder_append_separator(sOutDir) + "camGT.ply").c_str());
   plyHelper::exportToPly(camera_pos_to_compare,
-    string(stlplus::folder_append_separator(sOutDir) + "camComputed.ply").c_str());
+    (stlplus::folder_append_separator(sOutDir) + "camComputed.ply").c_str());
 
   // Evaluation
   htmlDocument::htmlDocumentStream _htmlDocStream("openMVG Quality evaluation.");
@@ -186,7 +184,7 @@ int main(int argc, char **argv)
     camera_rot_gt, camera_rot_to_compare,
     sOutDir, &_htmlDocStream, vec_distance_residuals, vec_rotation_angular_residuals);
 
-  ofstream htmlFileStream( string(stlplus::folder_append_separator(sOutDir) +
+  std::ofstream htmlFileStream((stlplus::folder_append_separator(sOutDir) +
     "ExternalCalib_Report.html").c_str());
   htmlFileStream << _htmlDocStream.getDoc();
 

--- a/src/software/VO/main_VO.cpp
+++ b/src/software/VO/main_VO.cpp
@@ -31,7 +31,6 @@ using namespace openMVG;
 
 int main(int argc, char **argv)
 {
-  using namespace std;
   std::cout << "VISUAL ODOMETRY -- Tracking demo --" << std::endl;
 
   CmdLine cmd;

--- a/src/software/colorHarmonize/main_ColHarmonize.cpp
+++ b/src/software/colorHarmonize/main_ColHarmonize.cpp
@@ -19,7 +19,6 @@ using namespace openMVG;
 
 int main( int argc, char **argv )
 {
-  using namespace std;
   std::cout << "Global Color Harmonization" << std::endl
             << std::endl;
 

--- a/src/software/ui/SfM/control_points_registration/GraphicsView.cpp
+++ b/src/software/ui/SfM/control_points_registration/GraphicsView.cpp
@@ -29,7 +29,6 @@
 
 namespace control_point_GUI
 {
-  using namespace std;
   using namespace openMVG;
   using namespace openMVG::sfm;
 


### PR DESCRIPTION
`using namespace std;` is generally an antipattern as it imports a huge number of common names into the global namespace. We already qualify names with std:: in majority of cases and `using namespace std` is not actually needed most of the time. This commit addresses a small number of remaining cases where std:: is missing and removes all `using namespace std`.