### PR TITLE
Remove usage of unordered_map for clang

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,12 +102,6 @@ else (OpenMVG_BUILD_SHARED)
   set(BUILD_SHARED_LIBS OFF)
 endif()
 
-# For both regular Clang and AppleClang
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  message("clang detected: using std::unordered_map for Hash_Map")
-  register_definitions(-DOPENMVG_STD_UNORDERED_MAP)
-endif()
-
 # ==============================================================================
 # Check that submodule have been initialized and updated
 # ==============================================================================

--- a/src/openMVG/types.hpp
+++ b/src/openMVG/types.hpp
@@ -9,44 +9,13 @@
 #ifndef OPENMVG_TYPES_HPP
 #define OPENMVG_TYPES_HPP
 
-#ifndef OPENMVG_STD_UNORDERED_MAP
-
 #include <Eigen/Core>
-
-#endif
-
 #include <cstdint>
 #include <functional>
 #include <limits>
 #include <map>
 #include <set>
 #include <vector>
-
-#ifdef OPENMVG_STD_UNORDERED_MAP
-
-#include <algorithm>
-#include <unordered_map>
-#include <utility>
-
-#include "openMVG/stl/hash.hpp"
-namespace std {
-  template<typename T1, typename T2>
-  struct hash<std::pair<T1, T2>> {
-    std::size_t operator()(std::pair<T1, T2> const &p) const {
-      std::size_t seed1(0);
-      stl::hash_combine(seed1, p.first);
-      stl::hash_combine(seed1, p.second);
-
-      std::size_t seed2(0);
-      stl::hash_combine(seed2, p.second);
-      stl::hash_combine(seed2, p.first);
-
-      return std::min(seed1, seed2);
-    }
-  };
-}
-
-#endif // OPENMVG_STD_UNORDERED_MAP
 
 /**
 * @brief Main namespace of openMVG API
@@ -69,18 +38,6 @@ using Pair_Set = std::set<Pair>;
 /// Vector of Pair
 using Pair_Vec = std::vector<Pair>;
 
-#if defined OPENMVG_STD_UNORDERED_MAP
-
-/**
-* @brief Standard Hash_Map class
-* @tparam K type of the keys
-* @tparam V type of the values
-*/
-template<typename Key, typename Value>
-using Hash_Map = std::unordered_map<Key, Value>;
-
-#else
-
 /**
 * @brief Standard Hash_Map class
 * @tparam K type of the keys
@@ -89,8 +46,6 @@ using Hash_Map = std::unordered_map<Key, Value>;
 template<typename Key, typename Value>
 using Hash_Map = std::map<Key, Value, std::less<Key>,
   Eigen::aligned_allocator<std::pair<const Key, Value>>>;
-
-#endif // OPENMVG_STD_UNORDERED_MAP
 
 } // namespace openMVG
 


### PR DESCRIPTION
I'm not sure what the original intention behind it is, but it doesn't seem worth the headache it causes. This resolves the crashes I've been seeing when using openmvg as a library on macOS with clang.

Fixes https://github.com/openMVG/openMVG/issues/1474
Fixes https://github.com/openMVG/openMVG/issues/1417