### PR TITLE
Fix inconsistency in spherical Intrinsic_Spherical projection functor

### DIFF
--- a/src/openMVG/sfm/sfm_data_BA_ceres_camera_functor.hpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres_camera_functor.hpp
@@ -708,8 +708,8 @@ struct ResidualErrorFunctor_Intrinsic_Spherical
     const T coord[] = {lon / (2 * M_PI), - lat / (2 * M_PI)}; // normalization
 
     const T size ( std::max(m_imageSize[0], m_imageSize[1]) );
-    const T projected_x = coord[0] * size - 0.5 + m_imageSize[0] / 2.0;
-    const T projected_y = coord[1] * size - 0.5 + m_imageSize[1] / 2.0;
+    const T projected_x = coord[0] * size + m_imageSize[0] / 2.0;
+    const T projected_y = coord[1] * size + m_imageSize[1] / 2.0;
 
     out_residuals[0] = projected_x - m_pos_2dpoint[0];
     out_residuals[1] = projected_y - m_pos_2dpoint[1];


### PR DESCRIPTION
There is an inconsistency between the way spherical projection is computed in the ceres cost functor and the way it's defined in Camera_Spherical.hpp. In the ceres functor the coordinates are shifted by -0.5 (top left is (0,0)) and in the Camera_Spherical.hpp file they are not (top left is (-0.5,-0.5)). Apparently there are some other [inconsistencies](https://github.com/openMVG/openMVG/issues/1271) of this kind in the lib that might need to be addressed.