### PR TITLE
Enable multithreading when numThreads == 0.

### DIFF
--- a/src/software/SfM/main_ComputeFeatures.cpp
+++ b/src/software/SfM/main_ComputeFeatures.cpp
@@ -261,7 +261,7 @@ int main(int argc, char **argv)
         omp_set_num_threads(iNumThreads);
     } else {
         iNumThreads = nb_max_thread - 1;
-        omp_set_num_threads(nb_max_thread - 1);
+        omp_set_num_threads(iNumThreads);
     }
 
     #pragma omp parallel for schedule(dynamic) if (iNumThreads > 0) private(imageGray)

--- a/src/software/SfM/main_ComputeFeatures.cpp
+++ b/src/software/SfM/main_ComputeFeatures.cpp
@@ -260,7 +260,8 @@ int main(int argc, char **argv)
     if (iNumThreads > 0) {
         omp_set_num_threads(iNumThreads);
     } else {
-        omp_set_num_threads(nb_max_thread);
+        iNumThreads = nb_max_thread - 1;
+        omp_set_num_threads(nb_max_thread - 1);
     }
 
     #pragma omp parallel for schedule(dynamic) if (iNumThreads > 0) private(imageGray)


### PR DESCRIPTION
It seems like multiple people have encountered this bug where the CPU is only 100% on the compute features stage. 
 https://github.com/openMVG/openMVG/issues/2198  https://github.com/openMVG/openMVG/issues/1730

After applying the change from https://github.com/openMVG/openMVG/issues/1730#issuecomment-678771888 it worked for me as well.