### PR TITLE
fix: compilation for ubuntu22.04 arm64

### DIFF
--- a/src/openMVG/system/cpu_instruction_set.hpp
+++ b/src/openMVG/system/cpu_instruction_set.hpp
@@ -15,7 +15,9 @@
 #if defined _MSC_VER
   #include <intrin.h>
 #else
+#if not defined __aarch64__
   #include <cpuid.h>
+#endif
 #endif
 
 namespace openMVG
@@ -117,6 +119,9 @@ class CpuInstructionSet
 private:
   static bool internal_cpuid(int32_t out[4], int32_t x)
   {
+    #if defined  __aarch64__
+    return false;
+    #endif
     #if defined __GNUC__
     __cpuid_count(x, 0, out[0], out[1], out[2], out[3]);
     return true;


### PR DESCRIPTION
error: On machines not built on x86-64 architecture, the `cpuid.h` file does not exist

```bash
/home/jujimeizuo/Workspace/openMVG/src/openMVG/system/cpu_instruction_set.hpp:18:12: fatal error: cpuid.h: No such file or directory
   18 |   #include <cpuid.h>
      |            ^~~~~~~~~
compilation terminated.
```

fixed: https://github.com/openMVG/openMVG/issues/1881#issuecomment-886149844, `#if defined __aarch64__` check architecture