### PR TITLE
[SFM] Using rerun logger for Incremental SfM reconstruction

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,12 @@ endif()
 
 set(CMAKE_FIND_FRAMEWORK LAST)
 
+# Download the rerun_sdk:
+include(FetchContent)
+FetchContent_Declare(rerun_sdk URL
+    https://github.com/rerun-io/rerun/releases/latest/download/rerun_cpp_sdk.zip)
+FetchContent_MakeAvailable(rerun_sdk)
+
 # ==============================================================================
 # OpenMVG build options
 # ==============================================================================
@@ -133,7 +139,7 @@ include(CXX11)
 check_for_cxx11_compiler(CXX11_COMPILER)
 # If a C++11 compiler is available, then set the appropriate flags
 if (CXX11_COMPILER)
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
 else (CXX11_COMPILER)

--- a/src/openMVG/sfm/CMakeLists.txt
+++ b/src/openMVG/sfm/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(openMVG_sfm
     openMVG_system
     ${CERES_LIBRARIES}
     ${STLPLUS_LIBRARY}
+    rerun_sdk
 )
 target_include_directories(openMVG_sfm
   PRIVATE

--- a/src/openMVG/sfm/pipelines/sfm_engine.hpp
+++ b/src/openMVG/sfm/pipelines/sfm_engine.hpp
@@ -15,6 +15,8 @@
 #include "openMVG/sfm/sfm_data.hpp"
 #include "openMVG/sfm/sfm_data_BA.hpp"
 
+#include <rerun.hpp>
+
 namespace openMVG {
 namespace sfm {
 
@@ -75,6 +77,11 @@ public:
     b_use_motion_prior_ = rhs;
   }
 
+  void Set_Rerun_Recording_Stream(std::shared_ptr<const rerun::RecordingStream> rec)
+  {
+    rerun_recording_stream_ = rec;
+  }
+
   const SfM_Data & Get_SfM_Data() const {return sfm_data_;}
 
 protected:
@@ -91,6 +98,11 @@ protected:
   cameras::Intrinsic_Parameter_Type intrinsic_refinement_options_;
   sfm::Extrinsic_Parameter_Type extrinsic_refinement_options_;
   bool b_use_motion_prior_;
+
+  //-----
+  //-- Rerun export
+  //-----
+   std::shared_ptr<const rerun::RecordingStream> rerun_recording_stream_;
 };
 
 } // namespace sfm

--- a/src/openMVG/sfm/sfm_data_io.cpp
+++ b/src/openMVG/sfm/sfm_data_io.cpp
@@ -16,6 +16,7 @@
 #include "openMVG/sfm/sfm_data_io_baf.hpp"
 #include "openMVG/sfm/sfm_data_io_cereal.hpp"
 #include "openMVG/sfm/sfm_data_io_ply.hpp"
+#include "openMVG/sfm/sfm_data_io_rerun.hpp"
 #include "openMVG/stl/stlMap.hpp"
 #include "openMVG/system/logger.hpp"
 #include "openMVG/types.hpp"
@@ -108,6 +109,8 @@ bool Save(const SfM_Data & sfm_data, const std::string & filename, ESfM_Data fla
     return Save_PLY(sfm_data, filename, flags_part);
   else if (ext == "baf") // Bundle Adjustment file
     return Save_BAF(sfm_data, filename, flags_part);
+  else if (ext == "rrd") // rerun
+    return Save_Rerun(sfm_data, filename, flags_part);
   else
   {
     OPENMVG_LOG_ERROR << "Unknown sfm_data export format: " << filename;

--- a/src/openMVG/sfm/sfm_data_io.hpp
+++ b/src/openMVG/sfm/sfm_data_io.hpp
@@ -27,7 +27,9 @@ enum ESfM_Data
   INTRINSICS      =  4,
   STRUCTURE       =  8,
   CONTROL_POINTS  = 16,
-  ALL = VIEWS | EXTRINSICS | INTRINSICS | STRUCTURE | CONTROL_POINTS
+  STRUCTURE_PER_VIEW = 32,
+  ALL = VIEWS | EXTRINSICS | INTRINSICS | STRUCTURE | CONTROL_POINTS,
+
 };
 
 ///Check that each pose have a valid intrinsic and pose id in the existing View ids

--- a/src/openMVG/sfm/sfm_data_io_rerun.hpp
+++ b/src/openMVG/sfm/sfm_data_io_rerun.hpp
@@ -1,0 +1,161 @@
+// This file is part of OpenMVG, an Open Multiple View Geometry C++ library.
+
+// Copyright (c) 2024 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef OPENMVG_SFM_SFM_DATA_IO_RERUN_HPP
+#define OPENMVG_SFM_SFM_DATA_IO_RERUN_HPP
+
+#include "openMVG/cameras/Camera_Pinhole.hpp"
+#include "openMVG/image/image_io.hpp"
+#include "openMVG/sfm/sfm_data_io.hpp"
+
+#include <rerun.hpp>
+
+namespace openMVG {
+namespace sfm {
+
+inline void Save_Rerun(
+  const rerun::RecordingStream & rec_stream,
+  const SfM_Data& sfm_data,
+  const ESfM_Data flags_part)
+{
+  const bool b_structure = (flags_part & STRUCTURE) == STRUCTURE;
+  const bool b_extrinsics = (flags_part & EXTRINSICS) == EXTRINSICS;
+  const bool b_images = (flags_part & VIEWS) == VIEWS;
+  const bool b_structure_per_image = (flags_part & STRUCTURE_PER_VIEW) == STRUCTURE_PER_VIEW;
+
+  const std::string camera_entity{"world/Camera/"};
+  const std::string points3D_entity{"world/Points3D"};
+
+  if (b_extrinsics)
+  {
+    for (const auto & view : sfm_data.GetViews())
+    {
+      if (sfm_data.GetIntrinsics().find(view.second->id_intrinsic) == sfm_data.GetIntrinsics().end())
+        continue;
+      if (sfm_data.GetPoses().find(view.second->id_pose) == sfm_data.GetPoses().end())
+        continue;
+
+      const auto view_file_name = stlplus::filename_part(view.second->s_Img_path);
+      const geometry::Pose3 pose = sfm_data.GetPoseOrDie(view.second.get());
+      const auto intrinsic = sfm_data.GetIntrinsics().find(view.second->id_intrinsic)->second;
+
+      const Vec3f camera_position = pose.translation().cast<float>();
+      const auto camera_orientation = pose.rotation().cast<float>();
+
+      const rerun::datatypes::Mat3x3 rr_rotation{
+            {camera_orientation(0, 0),
+             camera_orientation(1, 0),
+             camera_orientation(2, 0),
+             camera_orientation(0, 1),
+             camera_orientation(1, 1),
+             camera_orientation(2, 1),
+             camera_orientation(0, 2),
+             camera_orientation(1, 2),
+             camera_orientation(2, 2)}};
+
+      const rerun::datatypes::Vec3D rr_translation{
+            camera_position.x(),
+            camera_position.y(),
+            camera_position.z()};
+
+      rec_stream.log(
+            camera_entity + view_file_name,
+            rerun::archetypes::Transform3D(rr_translation, rr_rotation, true));
+
+      std::shared_ptr<openMVG::cameras::Pinhole_Intrinsic> pinhole_intrinsic(
+          dynamic_cast<openMVG::cameras::Pinhole_Intrinsic*>(intrinsic->clone()));
+      if (pinhole_intrinsic)
+      {
+        const rerun::datatypes::Vec2D resolution{
+            static_cast<float>(intrinsic->w()),
+            static_cast<float>(intrinsic->h())};
+
+        rec_stream.log(camera_entity + view_file_name,
+                rerun::archetypes::Pinhole::from_focal_length_and_resolution(
+                  pinhole_intrinsic->focal(),
+                  resolution));
+      }
+      else
+      {
+        std::cerr << "Camera type not yet supported in the sfm_data to Rerun exporter" << std::endl;
+      }
+
+      if (b_images)
+      {
+        openMVG::image::Image<openMVG::image::RGBColor> img;
+        const auto image_name = stlplus::create_filespec(sfm_data.s_root_path, view_file_name);
+        const auto is_img_loaded =
+            openMVG::image::ReadImage(image_name.c_str(), &img);
+        if (is_img_loaded) {
+          rec_stream.log(camera_entity + view_file_name,
+                  rerun::Image({static_cast<uint64_t>(img.rows()),
+                                static_cast<uint64_t>(img.cols()),
+                                static_cast<uint64_t>(img.Depth())},
+                               img.GetMat().data()->data()));
+        }
+      }
+    }
+  }
+
+  if (b_structure || b_structure_per_image)
+  {
+    std::vector<rerun::components::Position3D> points3d;
+    std::vector<rerun::components::KeypointId> track_ids;
+    const auto& landmarks = sfm_data.GetLandmarks();
+    points3d.reserve(landmarks.size());
+    track_ids.reserve(landmarks.size());
+    std::unordered_map<uint32_t, std::vector<rerun::components::Position2D>>
+        points2d_per_img;
+    for (const auto& landmark : landmarks) {
+      points3d.emplace_back(landmark.second.X(0), landmark.second.X(1), landmark.second.X(2));
+      track_ids.push_back(landmark.first);
+      if (b_structure_per_image)
+      {
+        for (const auto& obs : landmark.second.obs) {
+          points2d_per_img[obs.first].emplace_back(
+              static_cast<float>(obs.second.x(0)),
+              static_cast<float>(obs.second.x(1)));
+        }
+      }
+    }
+    if (b_structure)
+    {
+      rec_stream.log(points3D_entity,
+                     rerun::archetypes::Points3D(points3d).with_keypoint_ids(track_ids));
+    }
+    if (b_structure_per_image)
+    {
+      for (const auto& view : sfm_data.views) {
+        auto it = points2d_per_img.find(view.first);
+        if (it != points2d_per_img.end()) {
+          rec_stream.log(camera_entity + stlplus::filename_part(view.second->s_Img_path),
+                  rerun::archetypes::Points2D(points2d_per_img.at(view.first)));
+        }
+      }
+    }
+  }
+}
+
+/// Save the structure and camera positions of a SfM_Data container as a rerun rrd file.
+inline bool Save_Rerun
+(
+  const SfM_Data & sfm_data,
+  const std::string & filename,
+  ESfM_Data flags_part
+)
+{
+  auto rec_stream = rerun::RecordingStream("openMVG_to_rerun");
+  const auto error = rec_stream.save(filename.c_str());
+  Save_Rerun(rec_stream, sfm_data, flags_part);
+  return error.is_ok();
+}
+
+} // namespace sfm
+} // namespace openMVG
+
+#endif // OPENMVG_SFM_SFM_DATA_IO_RERUN_HPP

--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -172,6 +172,7 @@ target_link_libraries(openMVG_main_SfM
     openMVG_features
     openMVG_sfm
     ${STLPLUS_LIBRARY}
+    rerun_sdk
 )
 
 add_executable(openMVG_main_ConvertSfM_DataFormat main_ConvertSfM_DataFormat.cpp)

--- a/src/software/SfM/main_SfM.cpp
+++ b/src/software/SfM/main_SfM.cpp
@@ -31,6 +31,8 @@
 #include "third_party/cmdLine/cmdLine.h"
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 
+#include <rerun.hpp>
+
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -166,7 +168,8 @@ int main(int argc, char **argv)
       directory_match,
       filename_match,
       directory_output,
-      engine_name = "INCREMENTAL";
+      engine_name = "INCREMENTAL",
+      rerun_mode = "WINDOW";
 
   // Bundle adjustment options:
   std::string sIntrinsic_refinement_options = "ADJUST_ALL";
@@ -218,6 +221,9 @@ int main(int argc, char **argv)
   int graph_simplification_value = 5;
   cmd.add( make_option('G', graph_simplification, "graph_simplification") );
   cmd.add( make_option('g', graph_simplification_value, "graph_simplification_value") );
+
+  // Rerun logging options
+  cmd.add( make_option('l', rerun_mode, "rerun_logging") );
 
   try {
     if (argc == 1) throw std::string("Invalid parameter.");
@@ -319,7 +325,13 @@ int main(int argc, char **argv)
       << "\t\t -> MST_X\n"
       << "\t\t -> STAR_X\n"
       << "\t[-g|--graph_simplification_value]\n"
-      << "\t\t -> Number (default: " << graph_simplification_value << ")";
+      << "\t\t -> Number (default: " << graph_simplification_value << ")"
+      << "\n\n"
+      << "[Rerun logging]\n"
+      << "\t[-l|--rerun_logging]\n"
+      << "\t\t FILE -> rerun log to file\n"
+      << "\t\t WINDOW -> rerun log to window (default)\n"
+      << "\t\t NONE -> disblae rerun logging.\n";
 
 
     OPENMVG_LOG_ERROR << s;
@@ -497,7 +509,6 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
   }
 
-
   std::unique_ptr<ReconstructionEngine> sfm_engine;
   switch (sfm_engine_type)
   {
@@ -604,6 +615,28 @@ int main(int argc, char **argv)
   sfm_engine->Set_Intrinsics_Refinement_Type(intrinsic_refinement_options);
   sfm_engine->Set_Extrinsics_Refinement_Type(extrinsic_refinement_options);
   sfm_engine->Set_Use_Motion_Prior(b_use_motion_priors);
+
+  // rerun export
+  std::shared_ptr<const rerun::RecordingStream> rerun_recording_stream =
+    rerun_mode == "NONE"
+      ? std::shared_ptr<const rerun::RecordingStream>()
+      : std::make_shared<const rerun::RecordingStream>("rerun_openMVG");
+  if (rerun_mode == "WINDOW")
+  {
+    rerun_recording_stream->spawn().exit_on_failure();
+  } else if (rerun_mode == "FILE")
+  {
+    const auto rerun_file = stlplus::create_filespec(directory_output, "sfm_data.rrd");
+    stlplus::file_delete(rerun_file);
+    rerun_recording_stream->save(rerun_file.c_str()).exit_on_failure();
+  }
+  else if (rerun_mode != "NONE")
+  {
+    OPENMVG_LOG_ERROR << "Invalid rerun_mode option: " <<  rerun_mode;
+    return EXIT_FAILURE;
+  }
+
+  sfm_engine->Set_Rerun_Recording_Stream(rerun_recording_stream);
 
   //---------------------------------------
   // Sequential reconstruction process


### PR DESCRIPTION
Visualization of the incremental process has never been so easy. By default a rerun window will open and show the status of the reconstruction:
- Show cameras frustum
- Point Cloud (with corresponding track ids)
- Camera Resection statistics (as graph `inlier_ratio` and `a_contrario` resection threshold)
- Number of camera in the scene (see pose_count timeline)

You can use it as following:
--rerun_logging [WINDOW(default)|FILE|NONE]

- WINDOW -> will open rerun window and show the reconstruction
- FILE -> will log to a `sfm_data.rrd` file the reconstruction
- NONE -> Disable rerun logging