### PR TITLE
Allow control points to be optimized

### DIFF
--- a/src/openMVG/sfm/sfm_data_BA.hpp
+++ b/src/openMVG/sfm/sfm_data_BA.hpp
@@ -55,11 +55,13 @@ struct Control_Point_Parameter
   Control_Point_Parameter
   (
     double weight_val = 20.0,
-    bool use_control_points = false
-  ): weight(weight_val), bUse_control_points(use_control_points)
+    bool use_control_points = false,
+    bool fix_control_points = true
+  ): weight(weight_val), bUse_control_points(use_control_points), bFix_control_points(fix_control_points)
   {}
   double weight;
   bool bUse_control_points;
+  bool bFix_control_points;
 };
 
 /// Structure to control which parameter will be refined during the BundleAjdustment process

--- a/src/openMVG/sfm/sfm_data_BA_ceres.cpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.cpp
@@ -442,7 +442,7 @@ bool Bundle_Adjustment_Ceres::Adjust
           << "Cannot use this GCP id: " << gcp_landmark_it.first
           << ". There is not linked image observation.";
       }
-      else
+      else if (options.control_point_opt.bFix_control_points)
       {
         // Set the 3D point as FIXED (it's a valid GCP)
         problem.SetParameterBlockConstant(gcp_landmark_it.second.X.data());


### PR DESCRIPTION
Adds an option to the `Control_Point_Parameter` struct to enable optimization of control points in BA, defaults to false so behavior is unchanged. 