### PR TITLE
[Build] Use PROJECT_SOURCE_DIR to replace CMAKE_SOURCE_DIR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 include(GNUInstallDirs)
 
 # guard against in-source builds
-if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if (${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "In-source builds not allowed.")
 endif()
 
@@ -239,7 +239,7 @@ MACRO(UNIT_TEST NAMESPACE NAME EXTRA_LIBS)
     set_property(TARGET ${NAMESPACE}_test_${NAME} PROPERTY FOLDER OpenMVG/test)
     target_include_directories(${NAMESPACE}_test_${NAME}
                                PRIVATE
-                               ${CMAKE_SOURCE_DIR}/third_party)
+                               ${PROJECT_SOURCE_DIR}/third_party)
     target_link_libraries(${NAMESPACE}_test_${NAME}
                           ${EXTRA_LIBS} # Extra libs MUST be first.
                           CppUnitLite)
@@ -614,7 +614,7 @@ endforeach()
 # Create a OpenMVGConfig.cmake file. <name>Config.cmake files are searched by
 # find_package() automatically. We configure that file so that we can put any
 # information we want in it, e.g. version numbers, include directories, etc.
-configure_file("${CMAKE_SOURCE_DIR}/cmakeFindModules/OpenMVGConfig.cmake.in"
+configure_file("${PROJECT_SOURCE_DIR}/cmakeFindModules/OpenMVGConfig.cmake.in"
                "${CMAKE_CURRENT_BINARY_DIR}/OpenMVGConfig.cmake" @ONLY)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/OpenMVGConfig.cmake"

--- a/src/openMVG/exif/CMakeLists.txt
+++ b/src/openMVG/exif/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_library(openMVG_exif exif_IO_EasyExif.cpp)
 target_compile_features(openMVG_exif INTERFACE ${CXX11_FEATURES})
 target_link_libraries(openMVG_exif LINK_PRIVATE openMVG_easyexif)
-target_include_directories(openMVG_exif PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/third_party/include/easyexif)
+target_include_directories(openMVG_exif PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/third_party/include/easyexif)
 set_target_properties(openMVG_exif PROPERTIES SOVERSION ${OPENMVG_VERSION_MAJOR} VERSION "${OPENMVG_VERSION_MAJOR}.${OPENMVG_VERSION_MINOR}")
 set_property(TARGET openMVG_exif PROPERTY FOLDER OpenMVG/OpenMVG)
 install(TARGETS openMVG_exif DESTINATION ${CMAKE_INSTALL_LIBDIR} EXPORT openMVG-targets)

--- a/src/openMVG/features/CMakeLists.txt
+++ b/src/openMVG/features/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 target_include_directories(openMVG_features
   PUBLIC
     $<BUILD_INTERFACE:${EIGEN_INCLUDE_DIRS}>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
     $<INSTALL_INTERFACE:include/openMVG>
 )

--- a/src/openMVG/numeric/CMakeLists.txt
+++ b/src/openMVG/numeric/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 target_include_directories(openMVG_numeric
   PUBLIC
     $<BUILD_INTERFACE:${EIGEN_INCLUDE_DIRS}>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 if (DEFINED OpenMVG_USE_INTERNAL_EIGEN)

--- a/src/openMVG/system/CMakeLists.txt
+++ b/src/openMVG/system/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_library(openMVG_system
   timer.hpp
   timer.cpp)
-target_include_directories(openMVG_system PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
+target_include_directories(openMVG_system PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 target_compile_features(openMVG_system INTERFACE ${CXX11_FEATURES})
 set_target_properties(openMVG_system PROPERTIES SOVERSION ${OPENMVG_VERSION_MAJOR} VERSION "${OPENMVG_VERSION_MAJOR}.${OPENMVG_VERSION_MINOR}")
 set_property(TARGET openMVG_system PROPERTY FOLDER OpenMVG/OpenMVG)

--- a/src/openMVG_Samples/exif_Parsing/CMakeLists.txt
+++ b/src/openMVG_Samples/exif_Parsing/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 add_executable(openMVG_main_exif_Parsing exifParsing.cpp)
-target_include_directories(openMVG_main_exif_Parsing PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(openMVG_main_exif_Parsing PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(openMVG_main_exif_Parsing PRIVATE openMVG_exif)
 set_property(TARGET openMVG_main_exif_Parsing PROPERTY FOLDER OpenMVG/Samples)

--- a/src/testing/CMakeLists.txt
+++ b/src/testing/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(openMVG_testing INTERFACE)
-target_include_directories(openMVG_testing INTERFACE ${CMAKE_SOURCE_DIR};${EIGEN_INCLUDE_DIRS})
+target_include_directories(openMVG_testing INTERFACE ${PROJECT_SOURCE_DIR};${EIGEN_INCLUDE_DIRS})
 target_link_libraries(openMVG_testing INTERFACE openMVG_numeric)


### PR DESCRIPTION
CMAKE_SOURCE_DIR is the root CMakeLists, PROJECT_SOURCE_DIR is the closest project() in the tree. When building alone, they are same. But when include openMVG into a superproject by add_subdirectory(), the CMAKE_SOURCE_DIR will find the parent project's root CMakeLists, but PROJECT_SOURCE_DIR still finds the root CMakeLists of openMVG.

Note: I do notice there are 2 previous PRs using CMAKE_CURRENT_SOURCE_DIR to replace CMAKE_SOURCE_DIR. But with CMAKE_CURRENT_SOURCE_DIR, you need to change paths to all in relative to that CMakeLists. Meanwhile PROJECT_SOURCE_DIR is fixed at the root CMakeLists of openMVG.

Also note: in the BUILD.md, there are instructions of using find_package. But that requires build and install openMVG first. By using PROJECT_SOURCE_DIR, the original workflow stays, and add_subdirectory() also works to put openMVG and parent project together in one project.