### PR TITLE
[C++] Remove a redundant copying in saveDescsToBinFile

### DIFF
--- a/src/openMVG/features/descriptor.hpp
+++ b/src/openMVG/features/descriptor.hpp
@@ -206,7 +206,7 @@ inline bool loadDescsFromBinFile(
 template<typename DescriptorsT >
 inline bool saveDescsToBinFile(
   const std::string & sfileNameDescs,
-  DescriptorsT & vec_desc)
+  const DescriptorsT & vec_desc)
 {
   using VALUE = typename DescriptorsT::value_type;
 
@@ -217,8 +217,8 @@ inline bool saveDescsToBinFile(
   const std::size_t cardDesc = vec_desc.size();
   file.write((const char*) &cardDesc,  sizeof(std::size_t));
   //Write descriptor content
-  for (const auto iter : vec_desc) {
-    file.write((const char*) iter.data(),
+  for (const auto & desc : vec_desc) {
+    file.write((const char*) desc.data(),
       VALUE::static_size*sizeof(typename VALUE::bin_type));
   }
   const bool bOk = file.good();

--- a/src/openMVG/features/feature.hpp
+++ b/src/openMVG/features/feature.hpp
@@ -167,7 +167,7 @@ static bool loadFeatsFromFile(
 template<typename FeaturesT >
 static bool saveFeatsToFile(
   const std::string & sfileNameFeats,
-  FeaturesT & vec_feat)
+  const FeaturesT & vec_feat)
 {
   std::ofstream file(sfileNameFeats.c_str());
   if (!file.is_open())


### PR DESCRIPTION
* Change the copy to reference.
* Rename the variable from iter to desc, since it's not iterator and the name can be confusing.
* Use const to pass the vectors to saveFeatsToFile and saveDescsToBinFile.