### PR TITLE
[Exif][Sensor DB] Add Samsung Galaxy S23+ main camera

### DIFF
--- a/src/openMVG/exif/sensor_width_database/sensor_width_camera_database.txt
+++ b/src/openMVG/exif/sensor_width_database/sensor_width_camera_database.txt
@@ -5303,6 +5303,7 @@ Samsung Galaxy S7 Edge Exynos;3.2
 Samsung Galaxy S7 Edge SD820;3.2
 Samsung Galaxy S7 Exynos;3.2
 Samsung Galaxy S7 SD820;3.2
+Samsung Galaxy S23+;8.19
 Samsung Galaxy Tab S 10.5 LTE;3.6
 Samsung Galaxy Tab S 10.5 Wi-Fi;3.6
 Samsung Galaxy Tab S 8.4 LTE;3.6


### PR DESCRIPTION
First, I go through this https://www.gsmarena.com/samsung_galaxy_s23+-12083.php to find the main camera is 1/1.56". Then it's this page https://designreviews.com/digital-camera-sensor-size-chart/ to see 1/1.56'' is ~8.19 x 6.14 mm. Hopefully it's the correct way to get the sensor size.