### PR TITLE
[robust_estimation] Add openmp parallelism in other guided matching

### DIFF
--- a/src/openMVG/robust_estimation/guided_matching.hpp
+++ b/src/openMVG/robust_estimation/guided_matching.hpp
@@ -41,7 +41,7 @@ void GuidedMatching(
   //  the smallest distance (smaller than the provided Threshold)
 
   #pragma omp parallel for
-  for (int i = 0; i < xLeft.cols(); ++i) {
+  for (size_t i = 0; i < xLeft.cols(); ++i) {
 
     double min = std::numeric_limits<double>::max();
     matching::IndMatch match;
@@ -135,13 +135,13 @@ void GuidedMatching(
   assert(xLeft.cols() == lDescriptors.size());
   assert(xRight.cols() == rDescriptors.size());
 
-  MetricT metric;
 
   // Looking for the corresponding points that have to satisfy:
   //   1. a geometric distance below the provided Threshold
   //   2. a distance ratio between descriptors of valid geometric correspondencess
-
+  #pragma omp parallel for
   for (size_t i = 0; i < xLeft.cols(); ++i) {
+    MetricT metric;
 
     distanceRatio<typename MetricT::ResultType > dR;
     for (size_t j = 0; j < xRight.cols(); ++j) {
@@ -159,6 +159,7 @@ void GuidedMatching(
     // Add correspondence only iff the distance ratio is valid
     if (dR.isValid(distRatio))  {
       // save the best corresponding index
+      #pragma omp critical
       vec_corresponding_index.push_back(matching::IndMatch(i,dR.idx));
     }
   }
@@ -200,6 +201,7 @@ void GuidedMatching(
     rRegionsPos[i] = camR ? camR->get_ud_pixel(rRegions.GetRegionPosition(i)) : rRegions.GetRegionPosition(i);
   }
 
+  #pragma omp parallel for
   for (size_t i = 0; i < lRegions.RegionCount(); ++i) {
 
     distanceRatio<double> dR;
@@ -218,6 +220,7 @@ void GuidedMatching(
     // Add correspondence only iff the distance ratio is valid
     if (dR.isValid(distRatio))  {
       // save the best corresponding index
+      #pragma omp critical
       vec_corresponding_index.push_back(matching::IndMatch(i,dR.idx));
     }
   }

--- a/src/openMVG/robust_estimation/guided_matching.hpp
+++ b/src/openMVG/robust_estimation/guided_matching.hpp
@@ -41,7 +41,7 @@ void GuidedMatching(
   //  the smallest distance (smaller than the provided Threshold)
 
   #pragma omp parallel for
-  for (size_t i = 0; i < xLeft.cols(); ++i) {
+  for (int i = 0; i < xLeft.cols(); ++i) {
 
     double min = std::numeric_limits<double>::max();
     matching::IndMatch match;
@@ -140,7 +140,7 @@ void GuidedMatching(
   //   1. a geometric distance below the provided Threshold
   //   2. a distance ratio between descriptors of valid geometric correspondencess
   #pragma omp parallel for
-  for (size_t i = 0; i < xLeft.cols(); ++i) {
+  for (int i = 0; i < xLeft.cols(); ++i) {
     MetricT metric;
 
     distanceRatio<typename MetricT::ResultType > dR;
@@ -202,7 +202,7 @@ void GuidedMatching(
   }
 
   #pragma omp parallel for
-  for (size_t i = 0; i < lRegions.RegionCount(); ++i) {
+  for (int i = 0; i < lRegions.RegionCount(); ++i) {
 
     distanceRatio<double> dR;
     for (size_t j = 0; j < rRegions.RegionCount(); ++j) {


### PR DESCRIPTION
Openmp parallel was introduced for GuidedMatching since 2021, but other overloads have not.