### PR TITLE
Fix #2407 & #2401: Bad argument in SfM tutorial_demo.py: 'AUTO' vs 'ANNL2'

### DIFF
--- a/src/software/SfM/tutorial_demo.py.in
+++ b/src/software/SfM/tutorial_demo.py.in
@@ -54,7 +54,7 @@ pFeatures = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_Compu
 pFeatures.wait()
 
 print ("2. Compute matches")
-pMatches = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeMatches"),  "-i", matches_dir+"/sfm_data.json", "-o", matches_dir+"/matches.putative.bin", "-f", "1", "-n", "ANNL2"] )
+pMatches = subprocess.Popen( [os.path.join(OPENMVG_SFM_BIN, "openMVG_main_ComputeMatches"),  "-i", matches_dir+"/sfm_data.json", "-o", matches_dir+"/matches.putative.bin", "-f", "1", "-n", "AUTO"] )
 pMatches.wait()
 
 print ("2. Filter matches" )


### PR DESCRIPTION
As said in the title, the variable `sNearestMatchingMethod` called by the SfM function `main_ComputeMatches` was filled in by `ANNL2` in the file "tutorial_demo.py" ("tutorial_demo.py.in" in the sources). So the argument `AUTO` replaced it. That fixed the problem. Maybe some documentation has to be updated.