### PR TITLE
libtiff/tif_ojpeg.c: make OJPEGDecode() early exit in case of failure in OJPEGPreDecode()

### DIFF
--- a/src/third_party/tiff/tif_ojpeg.c
+++ b/src/third_party/tiff/tif_ojpeg.c
@@ -244,6 +244,7 @@ typedef enum {
 
 typedef struct {
 	TIFF* tif;
+	int decoder_ok;
 	#ifndef LIBJPEG_ENCAP_EXTERNAL
 	JMP_BUF exit_jmpbuf;
 	#endif
@@ -717,6 +718,7 @@ OJPEGPreDecode(TIFF* tif, uint16 s)
 		}
 		sp->write_curstrile++;
 	}
+	sp->decoder_ok = 1;
 	return(1);
 }
 
@@ -781,6 +783,11 @@ OJPEGDecode(TIFF* tif, uint8* buf, tmsize_t cc, uint16 s)
 {
 	OJPEGState* sp=(OJPEGState*)tif->tif_data;
 	(void)s;
+	if( !sp->decoder_ok )
+	{
+		TIFFErrorExt(tif->tif_clientdata,module,"Cannot decode: decoder not correctly initialized");
+		return 0;
+	}
 	if (sp->libjpeg_jpeg_query_style==0)
 	{
 		if (OJPEGDecodeRaw(tif,buf,cc)==0)


### PR DESCRIPTION
**Description**
This PR fixes a potential vulnerability in tif_ojpeg.c that was cloned from libtiff but did not receive the security patch. The original issue was reported and fixed under https://github.com/vadz/libtiff/commit/43bc256d8ae44b92d2734a3c5bc73957a4d7c1ec. This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/CVE-2016-10267
https://github.com/vadz/libtiff/commit/43bc256d8ae44b92d2734a3c5bc73957a4d7c1ec