### PR TITLE
fix rotation magnitude calculation

### DIFF
--- a/src/openMVG/numeric/numeric.cpp
+++ b/src/openMVG/numeric/numeric.cpp
@@ -56,8 +56,7 @@ Mat3 RotationAroundZ(double angle) {
 }
 
 double getRotationMagnitude(const Mat3 & R2) {
-  const Mat3 R1 = Mat3::Identity();
-  double cos_theta = (R1.array() * R2.array()).sum() / 3.0;
+  double cos_theta = (R2.trace() - 1.0) / 2.0;
   cos_theta = clamp(cos_theta, -1.0, 1.0);
   return std::acos(cos_theta);
 }

--- a/src/openMVG/numeric/numeric.h
+++ b/src/openMVG/numeric/numeric.h
@@ -138,12 +138,13 @@ inline double R2D( double radian )
 }
 
 /**
-* @brief Compute mean rotation magnitude of the given rotation matrix
-* @param R2 Input rotation matrix
-* @return magnitude of the rotation (in radian)
-* @note Assuming R2 is a correct rotation matrix
-* @note Mean is computed using the matrix column dot products to an Identity matrix
-*/
+ * @brief Compute the rotation magnitute of the given rotation matrix
+ * @param R2 Input rotation matrix
+ * @return magnitude of the rotation (in radian)
+ * @note Assuming R2 is a correct rotation matrix
+ * @note Magnitude is calculated the same way as converting to angle-axis
+ * representation and taking the angle part.
+ */
 double  getRotationMagnitude( const Mat3 & R2 );
 
 /**

--- a/src/openMVG/numeric/numeric_test.cpp
+++ b/src/openMVG/numeric/numeric_test.cpp
@@ -94,6 +94,34 @@ TEST ( TinyMatrix, product )
   EXPECT_MATRIX_NEAR( expected_resBxA, resBxA, 1e-8);
 }
 
+TEST(Numeric, getRotationMagnitude) {
+
+  {
+    Mat3 R = Mat3::Identity();
+    EXPECT_NEAR(0.0, getRotationMagnitude(R), 1e-8);
+  }
+
+  {
+    Mat3 R = RotationAroundX(M_PI / 2);
+    EXPECT_NEAR(M_PI / 2, getRotationMagnitude(R), 1e-8);
+  }
+
+  {
+    Mat3 R = RotationAroundY(M_PI / 2);
+    EXPECT_NEAR(M_PI / 2, getRotationMagnitude(R), 1e-8);
+  }
+
+  {
+    Mat3 R = RotationAroundZ(M_PI);
+    EXPECT_NEAR(M_PI, getRotationMagnitude(R), 1e-8);
+  }
+
+  {
+    Mat3 R = RotationAroundZ(2 * M_PI);
+    EXPECT_NEAR(0, getRotationMagnitude(R), 1e-8);
+  }
+}
+
 TEST(TinyMatrix, LookAt) {
   // Simple orthogonality check.
   Vec3 e; e[0]= 1; e[1] = 2; e[2] = 3;


### PR DESCRIPTION
Looking at this code I expect that rotation magnitude should be the angle from identity. 
https://github.com/openMVG/openMVG/blob/c92ed1be7c25068c0cdc0927e876a9ec92e97ce8/src/openMVG/sfm/pipelines/global/GlobalSfM_rotation_averaging.cpp#L196-L199

Current implementation of `getRotationMagnitude` uses some custom logic. I think the correct magnitude should be the same as converting the rotation matrix to angle-axis representation and take the angle. Especially since this value is compare to some angular threshold. 

My implementation follows this equation: 
<img width="208" height="51" alt="image" src="https://github.com/user-attachments/assets/ef9b02ef-e31d-4803-8c19-5e0330fdfd92" />
https://en.wikipedia.org/wiki/Rotation_matrix#Determining_the_angle