### PR TITLE
fix triplet validation in translation averaging

### DIFF
--- a/src/openMVG/sfm/pipelines/global/GlobalSfM_translation_averaging.cpp
+++ b/src/openMVG/sfm/pipelines/global/GlobalSfM_translation_averaging.cpp
@@ -827,7 +827,7 @@ bool GlobalSfM_Translation_AveragingSolver::Estimate_T_triplet
 #endif
 
   // Keep the model iff it has a sufficient inlier count
-  const bool bTest = ( vec_inliers.size() > 30 && 0.33 * tracks.size() );
+  const bool bTest = ( vec_inliers.size() > 30 && vec_inliers.size() > 0.33 * tracks.size() );
 
 #ifdef DEBUG_TRIPLET
   {


### PR DESCRIPTION
Validation is incorrect. This fixes it. 

I was expecting big reduction of noisy triplets to be removed but there is a high probably they were already removed by rotation averaging. This fix does have a small influence on final calculation but not that much.