### PR TITLE
Optimize geometric filtering performance from O(n^2) to O(n)

### DIFF
--- a/src/openMVG/matching_image_collection/GeometricFilter.hpp
+++ b/src/openMVG/matching_image_collection/GeometricFilter.hpp
@@ -77,12 +77,8 @@ void ImageCollectionGeometricFilter::Robust_model_estimation
   my_progress_bar->Restart( putative_matches.size(), "- Geometric filtering -" );
 
   // Cache iterators to avoid O(n^2) std::map traversal with advance().
-  std::vector<PairWiseMatches::const_iterator> match_iters;
-  match_iters.reserve(putative_matches.size());
-  for (auto it = putative_matches.cbegin(); it != putative_matches.cend(); ++it)
-  {
-    match_iters.push_back(it);
-  }
+  std::vector<PairWiseMatches::const_iterator> match_iters(
+    putative_matches.cbegin(), putative_matches.cend());
 
 #ifdef OPENMVG_USE_OPENMP
 #pragma omp parallel for schedule(dynamic)

--- a/src/openMVG/matching_image_collection/GeometricFilter.hpp
+++ b/src/openMVG/matching_image_collection/GeometricFilter.hpp
@@ -76,15 +76,22 @@ void ImageCollectionGeometricFilter::Robust_model_estimation
     my_progress_bar = &system::ProgressInterface::dummy();
   my_progress_bar->Restart( putative_matches.size(), "- Geometric filtering -" );
 
+  // Cache iterators to avoid O(n^2) std::map traversal with advance().
+  std::vector<PairWiseMatches::const_iterator> match_iters;
+  match_iters.reserve(putative_matches.size());
+  for (auto it = putative_matches.cbegin(); it != putative_matches.cend(); ++it)
+  {
+    match_iters.push_back(it);
+  }
+
 #ifdef OPENMVG_USE_OPENMP
 #pragma omp parallel for schedule(dynamic)
 #endif
-  for (int i = 0; i < (int)putative_matches.size(); ++i)
+  for (int i = 0; i < (int)match_iters.size(); ++i)
   {
     if (my_progress_bar->hasBeenCanceled())
       continue;
-    auto iter = putative_matches.begin();
-    advance(iter,i);
+    auto iter = match_iters[static_cast<size_t>(i)];
 
     Pair current_pair = iter->first;
     const std::vector<IndMatch> & vec_PutativeMatches = iter->second;

--- a/src/openMVG/matching_image_collection/GeometricFilter.hpp
+++ b/src/openMVG/matching_image_collection/GeometricFilter.hpp
@@ -77,8 +77,12 @@ void ImageCollectionGeometricFilter::Robust_model_estimation
   my_progress_bar->Restart( putative_matches.size(), "- Geometric filtering -" );
 
   // Cache iterators to avoid O(n^2) std::map traversal with advance().
-  std::vector<PairWiseMatches::const_iterator> match_iters(
-    putative_matches.cbegin(), putative_matches.cend());
+  std::vector<PairWiseMatches::const_iterator> match_iters;
+  match_iters.reserve(putative_matches.size());
+  for (auto it = putative_matches.cbegin(); it != putative_matches.cend(); ++it)
+  {
+    match_iters.push_back(it);
+  }
 
 #ifdef OPENMVG_USE_OPENMP
 #pragma omp parallel for schedule(dynamic)


### PR DESCRIPTION
Improve the efficiency of geometric filtering by caching iterators, reducing the traversal complexity from O(n^2) to O(n) for each pair of matches.

I've been running into a wall where as I increase the number of pictures, the processing time increased exponentially and it just didn't make any sense.

<img width="1064" height="796" alt="image" src="https://github.com/user-attachments/assets/29c09fb4-6e81-448f-94af-afca2ebaa86e" />

As the number of pictures and features increased, most of the time was spent on geometric filtering, which should have been a simple and fast process.  Eventually traced it down to this bug and and the fix completely eliminated the bottleneck and made the processing tractable.

Hope this helps everyone else who couldn't process a large number of photos.

@pmoulon please take a look at this.  It's pretty significant.

