### PR TITLE
Seg fault fix -- thread pool could be resize / read race condition

### DIFF
--- a/src/openMVG/sfm/pipelines/global/GlobalSfM_translation_averaging.cpp
+++ b/src/openMVG/sfm/pipelines/global/GlobalSfM_translation_averaging.cpp
@@ -458,10 +458,18 @@ void GlobalSfM_Translation_AveragingSolver::ComputePutativeTranslation_EdgesCove
     system::LoggerProgress my_progress_bar(vec_edges.size(),
       "Relative translations computation (edge coverage algorithm)");
 
+    // Initialize vector inside parallel region to get actual thread count
+    std::vector<std::vector<RelativeInfo_Vec>> initial_estimates;
 #  ifdef OPENMVG_USE_OPENMP
-    std::vector<std::vector<RelativeInfo_Vec>> initial_estimates(omp_get_max_threads());
+    #pragma omp parallel
+    {
+      #pragma omp single
+      {
+        initial_estimates.resize(omp_get_num_threads());
+      }
+    }
 #  else
-    std::vector<std::vector<RelativeInfo_Vec>> initial_estimates(1);
+    initial_estimates.resize(1);
 #  endif
 
     #ifdef OPENMVG_USE_OPENMP
@@ -569,6 +577,14 @@ void GlobalSfM_Translation_AveragingSolver::ComputePutativeTranslation_EdgesCove
               #else
                 const int thread_id = 0;
               #endif
+
+              // Safety check to prevent out-of-bounds access
+              if (thread_id >= static_cast<int>(initial_estimates.size()))
+              {
+                OPENMVG_LOG_ERROR << "Thread ID " << thread_id
+                                  << " exceeds initial_estimates size " << initial_estimates.size();
+                continue;
+              }
 
               RelativeInfo_Vec triplet_relative_motion;
               triplet_relative_motion.push_back(


### PR DESCRIPTION
The code was calling omp_get_max_threads() before the parallel region to size the initial_estimates vector, but using omp_get_thread_num() inside the parallel region to index it. If the thread pool resizes between those two calls (which happens after long-running operations like rotation averaging), the thread ID can exceed the vector size, causing a segmentation fault.